### PR TITLE
chore: add CODEOWNERS for deployment-automation team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @smartcontractkit/deployment-automation


### PR DESCRIPTION
This adds a new CODEOWNERS file which only allows the Deployment Automation team to approve changes.