### PR TITLE
chore: add asdf .tool-versions for easier development setup

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+golang 1.22.2
+golangci-lint 1.61.0
+task 3.39.2

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # mcms
+
 Tools/Libraries to Deploy/Manage/Interact with MCMS
+
+## Development
+
+### Getting Started
+
+Install the developments tools and dependencies to get started.
+
+#### Install `asdf`
+
+[asdf](https://asdf-vm.com/) is a tool version manager. All dependencies used for local development of this repo are managed through `asdf`. To install `asdf`:
+
+1. [Install asdf](https://asdf-vm.com/guide/getting-started.html)
+2. Follow the instructions to ensure `asdf` is shimmed into your terminal or development environment
+
+#### Install `task`
+
+[task](https://github.com/go-task/task) is an alternative to `make` and is used to provide commands for everyday development tasks. To install `task`:
+
+1. Add the asdf task plugin: `asdf plugin add task`
+2. Install `task` with `asdf install task`
+3. Run `task -l` to see available commands
+
+#### Installing Dependencies
+
+Now that you have `asdf` and `task` installed, you can install the dependencies for this repo:
+
+`task install:tools`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,5 +3,8 @@
 version: "3"
 
 includes:
-    lint:
-        taskfile: ./taskfiles/lint/Taskfile.yml
+  install:
+    taskfile: ./taskfiles/install/Taskfile.yml
+
+  lint:
+    taskfile: ./taskfiles/lint/Taskfile.yml

--- a/taskfiles/install/Taskfile.yml
+++ b/taskfiles/install/Taskfile.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+includes:
+  asdf:
+    taskfile: ./asdf.yml
+
+tasks:
+  tools:
+    desc: Installs development tools
+    cmds:
+      - task: asdf:tools

--- a/taskfiles/install/asdf.yml
+++ b/taskfiles/install/asdf.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+tasks:
+  tools:
+    internal: true
+    desc: Installs the tools defined in asdf
+    dir: '{{.USER_WORKING_DIR}}'
+    cmds:
+      # Add all the plugins defined in .tool-versions by reading the first column for the plugin
+      # name and adding it to asdf
+      - awk '{print $1}' .tool-versions | xargs -I _ asdf plugin add _
+
+      # Install all the tools defined in .tool-versions
+      - asdf install

--- a/taskfiles/lint/Taskfile.yml
+++ b/taskfiles/lint/Taskfile.yml
@@ -4,8 +4,7 @@ tasks:
   check:
     desc: "Run Go lint checks"
     cmds:
-      - | 
-        golangci-lint run
+      - golangci-lint run
   fix:
     desc: "Fix Go lint issues"
     cmds:


### PR DESCRIPTION
Adds `.tool-versions` file for asdf to manage the versions of the tools used in the project and adds a taskfile to install the tools. The README file is updated to include the new setup instructions.