### PR TITLE
chore: git ignore vscode config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,13 +14,13 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
 # Go workspace file
 go.work
 go.work.sum
 
 # env file
 .env
+
+# Editor config directories
 .idea/
+.vscode/


### PR DESCRIPTION
Exclude the `vscode` config directory from git history
