### PR TITLE
chore: setup lint runs in CI and add more linters

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -7,6 +7,19 @@ on:
       - main
 
 jobs:
+  ci-lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Linting Go
+        uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        with:
+          golangci-lint-version: v1.61.0
+
   ci-test:
     name: Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -6,6 +6,19 @@ on:
       - main
 
 jobs:
+  ci-lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Linting Go
+        uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        with:
+          golangci-lint-version: v1.61.0
+
   ci-test:
     runs-on: ubuntu-latest
     permissions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,79 @@
+run:
+  timeout: 5m
+linters:
+  enable:
+    - asciicheck
+    - bidichk
+    - containedctx
+    - contextcheck
+    - copyloopvar
+    - decorder
+    - dogsled
+    - dupword
+    - durationcheck
+    # - err113 # disabled because it currently fails on the codebase
+    - errchkjson
+    # - errname # disabled because it currently fails on the codebase
+    - errorlint
+    - exhaustive
+    - fatcontext
+    # - forbidigo # disabled because it currently fails on the codebase in gethwrappers
+    - gci
+    - goconst
+    - gofmt
+    # - goimports # disabled because it currently fails on the codebase
+    # - gosec # disabled because it currently fails on the codebase in many places
+    # - intrange # disabled because it currently fails on the codebase
+    - makezero
+    - loggercheck
+    - makezero
+    - misspell
+    # - mnd # disabled because it currently fails on the codebase
+    - nilerr
+    - nilnil
+    # - nlreturn # disabled because it currently fails on the codebase
+    - nolintlint
+    # - paralleltest # Discussion whether we should have this
+    # - prealloc # disabled because it currently fails on the codebase
+    - reassign
+    # - revive # disabled because it currently fails on the codebase
+    # - testifylint # disabled because it currently fails on the codebase
+    - thelper
+    - tparallel
+    # - unconvert # disabled because it currently fails on the codebase
+    # - unparam # disabled because it currently fails on the codebase
+    - usestdlibvars
+    - wastedassign
+    # - whitespace # disabled because it currently fails on codebase
+linters-settings:
+  goconst:
+    min-len: 5
+  # goimports:
+  #   local-prefixes: github.com/smartcontractkit/mcms
+#   govet:
+#     enable:
+#       - shadow
+#   revive:
+#     confidence: 1.0
+#     rules:
+#       - name: context-as-argument
+#       - name: context-keys-type
+#       - name: dot-imports
+#       - name: error-return
+#       - name: error-strings
+#       - name: error-naming
+#       - name: if-return
+#       - name: increment-decrement
+#       - name: var-naming
+#       - name: var-declaration
+#       - name: package-comments
+#       - name: range
+#       - name: receiver-naming
+#       - name: time-naming
+#       - name: unexported-return
+#       - name: indent-error-flow
+#       - name: errorf
+#       - name: empty-block
+#       - name: superfluous-else
+#       - name: unreachable-code
+#       - name: redefines-builtin-id

--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ Run the entire test suite with:
 `task test`
 
 More `test` commands can be found by running `task -l`
+
+### Running Linters
+
+Run the linters with:
+
+`task lint`
+
+More `lint` commands can be found by running `task -l`

--- a/taskfiles/lint/Taskfile.yml
+++ b/taskfiles/lint/Taskfile.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 tasks:
-  check:
+  default:
     desc: "Run Go lint checks"
     cmds:
       - golangci-lint run


### PR DESCRIPTION
Adds a CI job to run the linters when a PR is opened against main, or is merged to main. More linters have also been added to the project to ensure that the codebase is of high quality. Some linters have been disabled as they currently fail and will be enabled in follow up PRs.

This also updates the linting taskfile to use the default task so that users can run `task lint` instead of `task lint:check`.