### PR TITLE
chore: add the goimports linter for standard import ordering

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,10 +18,9 @@ linters:
     - exhaustive
     - fatcontext
     # - forbidigo # disabled because it currently fails on the codebase in gethwrappers
-    - gci
     - goconst
     - gofmt
-    # - goimports # disabled because it currently fails on the codebase
+    - goimports
     # - gosec # disabled because it currently fails on the codebase in many places
     # - intrange # disabled because it currently fails on the codebase
     - makezero
@@ -48,8 +47,8 @@ linters:
 linters-settings:
   goconst:
     min-len: 5
-  # goimports:
-  #   local-prefixes: github.com/smartcontractkit/mcms
+  goimports:
+    local-prefixes: github.com/smartcontractkit/mcms
 #   govet:
 #     enable:
 #       - shadow

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/smartcontractkit/mcms/pkg/errors"
 	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 )

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 )
 
 func TestNewConfig(t *testing.T) {

--- a/pkg/proposal/mcms/encoding.go
+++ b/pkg/proposal/mcms/encoding.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/mcms/pkg/errors"
 	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 	"github.com/smartcontractkit/mcms/pkg/merkle"

--- a/pkg/proposal/mcms/encoding_test.go
+++ b/pkg/proposal/mcms/encoding_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/smartcontractkit/mcms/pkg/errors"
 	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCalculateTransactionCounts(t *testing.T) {

--- a/pkg/proposal/mcms/executor.go
+++ b/pkg/proposal/mcms/executor.go
@@ -9,11 +9,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/exp/slices"
+
 	c "github.com/smartcontractkit/mcms/pkg/config"
 	"github.com/smartcontractkit/mcms/pkg/errors"
 	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 	"github.com/smartcontractkit/mcms/pkg/merkle"
-	"golang.org/x/exp/slices"
 )
 
 type Executor struct {

--- a/pkg/proposal/mcms/executor_test.go
+++ b/pkg/proposal/mcms/executor_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/smartcontractkit/mcms/pkg/config"
 	owner_errors "github.com/smartcontractkit/mcms/pkg/errors"
 	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
-	"github.com/stretchr/testify/assert"
 )
 
 func setupSimulatedBackendWithMCMS(numSigners uint64) ([]*ecdsa.PrivateKey, []*bind.TransactOpts, *backends.SimulatedBackend, *gethwrappers.ManyChainMultiSig, error) {

--- a/pkg/proposal/mcms/proposal.go
+++ b/pkg/proposal/mcms/proposal.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/smartcontractkit/mcms/pkg/errors"
 )
 

--- a/pkg/proposal/mcms/signature.go
+++ b/pkg/proposal/mcms/signature.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+
 	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 )
 

--- a/pkg/proposal/mcms/signature_test.go
+++ b/pkg/proposal/mcms/signature_test.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 )
 
 func TestToGethSignature(t *testing.T) {

--- a/pkg/proposal/mcms/utils.go
+++ b/pkg/proposal/mcms/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/smartcontractkit/mcms/pkg/config"
 	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 )

--- a/pkg/proposal/sign.go
+++ b/pkg/proposal/sign.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 
 	"github.com/ethereum/go-ethereum/crypto"
+
 	"github.com/smartcontractkit/mcms/pkg/proposal/mcms"
 )
 

--- a/pkg/proposal/timelock/mcm_with_timelock.go
+++ b/pkg/proposal/timelock/mcm_with_timelock.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+
 	"github.com/smartcontractkit/mcms/pkg/errors"
 	owner "github.com/smartcontractkit/mcms/pkg/gethwrappers"
 	"github.com/smartcontractkit/mcms/pkg/proposal/mcms"

--- a/pkg/proposal/timelock/mcm_with_timelock_test.go
+++ b/pkg/proposal/timelock/mcm_with_timelock_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/mcms/pkg/config"
 	mcm_errors "github.com/smartcontractkit/mcms/pkg/errors"
 	"github.com/smartcontractkit/mcms/pkg/gethwrappers"
 	"github.com/smartcontractkit/mcms/pkg/proposal/mcms"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var TestAddress = common.HexToAddress("0x1234567890abcdef")


### PR DESCRIPTION
Adds the `goimports` linter and fixes import order issues 