### PR TITLE
chore: add whitespace and nlreturn linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,10 +30,10 @@ linters:
     # - mnd # disabled because it currently fails on the codebase
     - nilerr
     - nilnil
-    # - nlreturn # disabled because it currently fails on the codebase
+    - nlreturn
     - nolintlint
     # - paralleltest # Discussion whether we should have this
-    - prealloc # disabled because it currently fails on the codebase
+    - prealloc
     - reassign
     # - revive # disabled because it currently fails on the codebase
     - testifylint
@@ -43,7 +43,7 @@ linters:
     # - unparam # disabled because it currently fails on the codebase
     - usestdlibvars
     - wastedassign
-    # - whitespace # disabled because it currently fails on codebase
+    - whitespace
 linters-settings:
   goconst:
     min-len: 5
@@ -52,6 +52,8 @@ linters-settings:
 #   govet:
 #     enable:
 #       - shadow
+  nlreturn:
+    block-size: 2
 #   revive:
 #     confidence: 1.0
 #     rules:
@@ -76,3 +78,8 @@ linters-settings:
 #       - name: superfluous-else
 #       - name: unreachable-code
 #       - name: redefines-builtin-id
+issues:
+  exclude-dirs:
+    # Exclude the directory from linting because it will soon be removed and only contains
+    # generated code. Can be removed once the gethwrappers directory is removed.
+    - pkg/gethwrappers

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -176,6 +176,7 @@ func (c *Config) ExtractSetConfigInputs() ([32]uint8, [32]uint8, []common.Addres
 	sort.Slice(signerObjs, func(i, j int) bool {
 		addressA := new(big.Int).SetBytes(signerObjs[i].Addr.Bytes())
 		addressB := new(big.Int).SetBytes(signerObjs[j].Addr.Bytes())
+
 		return addressA.Cmp(addressB) < 0
 	})
 

--- a/pkg/merkle/merkle_tree.go
+++ b/pkg/merkle/merkle_tree.go
@@ -65,6 +65,7 @@ func (t *MerkleTree) GetProof(hash common.Hash) ([]common.Hash, error) {
 
 			// Move to the next layer
 			found = true
+
 			break
 		}
 

--- a/pkg/proposal/mcms/encoding.go
+++ b/pkg/proposal/mcms/encoding.go
@@ -21,6 +21,7 @@ func calculateTransactionCounts(transactions []ChainOperation) map[ChainIdentifi
 	for _, tx := range transactions {
 		txCounts[tx.ChainIdentifier]++
 	}
+
 	return txCounts
 }
 
@@ -62,6 +63,7 @@ func buildRootMetadatas(
 			OverridePreviousRoot: overridePreviousRoot,
 		}
 	}
+
 	return rootMetadatas, nil
 }
 
@@ -104,6 +106,7 @@ func sortedChainIdentifiers(chainMetadata map[ChainIdentifier]ChainMetadata) []C
 		chainIdentifiers = append(chainIdentifiers, chainID)
 	}
 	sort.Slice(chainIdentifiers, func(i, j int) bool { return chainIdentifiers[i] < chainIdentifiers[j] })
+
 	return chainIdentifiers
 }
 

--- a/pkg/proposal/mcms/executor.go
+++ b/pkg/proposal/mcms/executor.go
@@ -55,6 +55,7 @@ func (e *Executor) SigningHash() (common.Hash, error) {
 	binary.BigEndian.PutUint32(validUntilBytes[28:], e.Proposal.ValidUntil) // Place the uint32 in the last 4 bytes
 
 	hashToSign := crypto.Keccak256Hash(e.Tree.Root.Bytes(), validUntilBytes[:])
+
 	return toEthSignedMessageHash(hashToSign), nil
 }
 
@@ -329,6 +330,7 @@ func (e *Executor) SetRootOnChain(client bind.ContractBackend, auth *bind.Transa
 	sort.Slice(sortedSignatures, func(i, j int) bool {
 		recoveredSignerA, _ := sortedSignatures[i].Recover(hash)
 		recoveredSignerB, _ := sortedSignatures[j].Recover(hash)
+
 		return recoveredSignerA.Cmp(recoveredSignerB) < 0
 	})
 

--- a/pkg/proposal/mcms/proposal.go
+++ b/pkg/proposal/mcms/proposal.go
@@ -67,6 +67,7 @@ func NewProposalFromFile(filePath string) (*MCMSProposal, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &out, nil
 }
 
@@ -110,6 +111,7 @@ func (m *MCMSProposal) Validate() error {
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/proposal/mcms/signature.go
+++ b/pkg/proposal/mcms/signature.go
@@ -67,5 +67,6 @@ func recoverAddressFromSignature(hash common.Hash, sig []byte) (common.Address, 
 
 	// Derive the Ethereum address from the public key
 	recoveredAddr := crypto.PubkeyToAddress(*pubKey)
+
 	return recoveredAddr, nil
 }

--- a/pkg/proposal/mcms/utils.go
+++ b/pkg/proposal/mcms/utils.go
@@ -24,6 +24,7 @@ func transformMCMAddresses(metadatas map[ChainIdentifier]ChainMetadata) map[Chai
 	for k, v := range metadatas {
 		m[k] = v.MCMAddress
 	}
+
 	return m
 }
 
@@ -32,6 +33,7 @@ func transformSignatures(signatures []Signature) []gethwrappers.ManyChainMultiSi
 	for i, sig := range signatures {
 		sigs[i] = sig.ToGethSignature()
 	}
+
 	return sigs
 }
 
@@ -40,6 +42,7 @@ func transformHashes(hashes []common.Hash) [][32]byte {
 	for i, h := range hashes {
 		m[i] = [32]byte(h)
 	}
+
 	return m
 }
 
@@ -52,6 +55,7 @@ func transformMCMSConfigs(configs map[ChainIdentifier]gethwrappers.ManyChainMult
 		}
 		m[k] = config
 	}
+
 	return m, nil
 }
 
@@ -68,6 +72,7 @@ func ABIEncode(abiStr string, values ...interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return res[4:], nil
 }
 
@@ -79,6 +84,7 @@ func ABIDecode(abiStr string, data []byte) ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return inAbi.Unpack("method", data)
 }
 

--- a/pkg/proposal/sign.go
+++ b/pkg/proposal/sign.go
@@ -41,5 +41,6 @@ func SignPlainKey(privateKey *ecdsa.PrivateKey, proposal Proposal) error {
 
 	// Add signature to proposal
 	proposal.AddSignature(sigObj)
+
 	return nil
 }

--- a/pkg/proposal/timelock/mcm_with_timelock.go
+++ b/pkg/proposal/timelock/mcm_with_timelock.go
@@ -77,6 +77,7 @@ func NewMCMSWithTimelockProposalFromFile(filePath string) (*MCMSWithTimelockProp
 	if err != nil {
 		return nil, err
 	}
+
 	return &out, nil
 }
 


### PR DESCRIPTION
Adds the whitespace linter to check for  unnecessary whitespace and the nlreturn linter to check for newline returns at the end of files (set to a minimum code block of 2 lines).