### PR TITLE
chore: add unconvert linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,7 @@ linters:
     - testifylint
     - thelper
     - tparallel
-    # - unconvert # disabled because it currently fails on the codebase
+    - unconvert
     # - unparam # disabled because it currently fails on the codebase
     - usestdlibvars
     - wastedassign

--- a/pkg/proposal/mcms/signature.go
+++ b/pkg/proposal/mcms/signature.go
@@ -23,7 +23,7 @@ func NewSignatureFromBytes(sig []byte) (Signature, error) {
 	return Signature{
 		R: common.BytesToHash(sig[:32]),
 		S: common.BytesToHash(sig[32:64]),
-		V: uint8(sig[64]),
+		V: sig[64],
 	}, nil
 }
 
@@ -40,7 +40,7 @@ func (s Signature) ToGethSignature() gethwrappers.ManyChainMultiSigSignature {
 }
 
 func (s Signature) ToBytes() []byte {
-	return append(s.R.Bytes(), append(s.S.Bytes(), []byte{byte(s.V)}...)...)
+	return append(s.R.Bytes(), append(s.S.Bytes(), []byte{s.V}...)...)
 }
 
 func (s Signature) Recover(hash common.Hash) (common.Address, error) {


### PR DESCRIPTION
Adds the unconvert linter to remove unecessary type conversions.

The fix in the code removes the type conversions of byte to uint8 and uint8 to byte. This is because byte is an alias for uint8 in Go.

https://go.dev/ref/spec#Numeric_types