### PR TITLE
chore: enables the forbidigo, unparam and gosec linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,17 +11,16 @@ linters:
     - dogsled
     - dupword
     - durationcheck
-    # - err113 # disabled because it currently fails on the codebase
     - errchkjson
     # - errname # disabled because it currently fails on the codebase
     - errorlint
     - exhaustive
     - fatcontext
-    # - forbidigo # disabled because it currently fails on the codebase in gethwrappers
+    - forbidigo
     - goconst
     - gofmt
     - goimports
-    # - gosec # disabled because it currently fails on the codebase in many places
+    - gosec
     - intrange
     - makezero
     - loggercheck
@@ -40,7 +39,7 @@ linters:
     - thelper
     - tparallel
     - unconvert
-    # - unparam # disabled because it currently fails on the codebase
+    - unparam
     - usestdlibvars
     - wastedassign
     - whitespace
@@ -49,6 +48,10 @@ linters-settings:
     min-len: 5
   goimports:
     local-prefixes: github.com/smartcontractkit/mcms
+  gosec:
+    excludes:
+      - G115 # TODO: Resolve integer overflow issues
+      - G306 # TODO: Resolve WriteFile permissions issues
 #   govet:
 #     enable:
 #       - shadow
@@ -94,3 +97,7 @@ issues:
     # Exclude the directory from linting because it will soon be removed and only contains
     # generated code. Can be removed once the gethwrappers directory is removed.
     - pkg/gethwrappers
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - unparam # No need to check for unused parameters in tests, since there are often false positives

--- a/pkg/proposal/mcms/encoding.go
+++ b/pkg/proposal/mcms/encoding.go
@@ -55,11 +55,15 @@ func buildRootMetadatas(
 		if isSim {
 			chain.EvmChainID = 1337
 		}
+
+		preOpCount := new(big.Int).SetUint64(metadata.StartingOpCount)
+		postOpCount := new(big.Int).SetUint64(metadata.StartingOpCount + currentTxCount)
+
 		rootMetadatas[chainID] = gethwrappers.ManyChainMultiSigRootMetadata{
 			ChainId:              new(big.Int).SetUint64(chain.EvmChainID),
 			MultiSig:             metadata.MCMAddress,
-			PreOpCount:           big.NewInt(int64(metadata.StartingOpCount)),                         // TODO: handle overflow
-			PostOpCount:          big.NewInt(int64(metadata.StartingOpCount) + int64(currentTxCount)), // TODO: handle overflow
+			PreOpCount:           preOpCount,
+			PostOpCount:          postOpCount,
 			OverridePreviousRoot: overridePreviousRoot,
 		}
 	}


### PR DESCRIPTION
The gosec linter has some excludes rules (G115 and G306) which will still need to be resolved.

The unparam linter is excluded from test files because there are usually
parameters in helper functions which have false positives