### PR TITLE
Disable changesets npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "ci:changeset:version": "pnpm changeset version && pnpm version --patch"
   },
   "author": "@smartcontractkit",
-  "license": "MIT",
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "~2.26.2",


### PR DESCRIPTION
The `package.json` needs to be kept private in order to prevent change sets tools to attempt running `npm publish`