### PR TITLE
chore: fix gosec G306 file permissions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters-settings:
   gosec:
     excludes:
       - G115 # TODO: Resolve integer overflow issues
-      - G306 # TODO: Resolve WriteFile permissions issues
   govet:
     enable:
       - shadow

--- a/pkg/proposal/mcms/utils.go
+++ b/pkg/proposal/mcms/utils.go
@@ -111,7 +111,7 @@ func WriteProposalToFile(proposal any, filePath string) error {
 		return err
 	}
 
-	err = os.WriteFile(filePath, proposalBytes, 0644)
+	err = os.WriteFile(filePath, proposalBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/proposal/mcms/utils_test.go
+++ b/pkg/proposal/mcms/utils_test.go
@@ -32,7 +32,7 @@ func TestFromFile(t *testing.T) {
 	}
 	sampleJSON, err := json.Marshal(sampleData)
 	require.NoError(t, err)
-	err = os.WriteFile(file.Name(), sampleJSON, 0644)
+	err = os.WriteFile(file.Name(), sampleJSON, 0600)
 	require.NoError(t, err)
 
 	// Call the FromFile function
@@ -62,7 +62,7 @@ func TestProposalFromFile(t *testing.T) {
 
 	proposalBytes, err := json.Marshal(mcmsProposal)
 	require.NoError(t, err)
-	err = os.WriteFile(tempFile.Name(), proposalBytes, 0644)
+	err = os.WriteFile(tempFile.Name(), proposalBytes, 0600)
 	require.NoError(t, err)
 
 	fileProposal, err := NewProposalFromFile(tempFile.Name())

--- a/pkg/proposal/timelock/mcm_with_timelock_test.go
+++ b/pkg/proposal/timelock/mcm_with_timelock_test.go
@@ -1437,7 +1437,7 @@ func TestTimelockProposalFromFile(t *testing.T) {
 
 	proposalBytes, err := json.Marshal(mcmsProposal)
 	require.NoError(t, err)
-	err = os.WriteFile(tempFile.Name(), proposalBytes, 0644)
+	err = os.WriteFile(tempFile.Name(), proposalBytes, 0600)
 	require.NoError(t, err)
 
 	fileProposal, err := NewMCMSWithTimelockProposalFromFile(tempFile.Name())


### PR DESCRIPTION
Fixes gosec G306: Expect file permissions to be 0600 or less on sensitive files