### PR TITLE
chore: add a docs task and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <div align="center">
   <h1>Many Chain Multisig System</h1>
   <a href='https://github.com/smartcontractkit/mcms/actions/workflows/push-main.yml'><img src="https://github.com/smartcontractkit/mcms/actions/workflows/push-main.yml/badge.svg" /></a>
+  <a href="https://miniature-adventure-5kwz5w3.pages.github.io/" rel="nofollow">
+    <img src="https://img.shields.io/static/v1?label=docs&message=latest&color=blue" alt="Official documentation">
+  </a>
   <br/>
   <br/>
 </div>
@@ -52,9 +55,10 @@ More `lint` commands can be found by running `task -l`
 
 ## Documentation
 
-We use [Docsify](https://docsify.js.org) for our documentations.
+We use [Docsify](https://docsify.js.org) to generate our documentation. You can modify the docs by editing the markdown files in the [`docs`](https://github.com/smartcontractkit/mcms/tree/main/docs) directory.
 
-```bash
-pnpm install
-pnpm run docs
+Run the local documentation server with:
+
+```
+task docs
 ````

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,12 @@
 version: "3"
 
 includes:
+  changeset:
+    taskfile: ./taskfiles/changesets/Taskfile.yml
+
+  docs:
+    taskfile: ./taskfiles/docs/Taskfile.yml
+
   install:
     taskfile: ./taskfiles/install/Taskfile.yml
 
@@ -12,5 +18,3 @@ includes:
   test:
     taskfile: ./taskfiles/test/Taskfile.yml
 
-  changeset:
-    taskfile: ./taskfiles/changesets/Taskfile.yml

--- a/taskfiles/docs/Taskfile.yml
+++ b/taskfiles/docs/Taskfile.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+tasks:
+  default:
+    desc: Run the local docsify server
+    cmds:
+      - pnpm run docs

--- a/taskfiles/install/Taskfile.yml
+++ b/taskfiles/install/Taskfile.yml
@@ -3,9 +3,12 @@ version: '3'
 includes:
   asdf:
     taskfile: ./asdf.yml
+  pnpm:
+    taskfile: ./pnpm.yml
 
 tasks:
   tools:
     desc: Installs development tools
     cmds:
-      - task: asdf:tools
+      - task: asdf:install
+      - task: pnpm:install

--- a/taskfiles/install/asdf.yml
+++ b/taskfiles/install/asdf.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 tasks:
-  tools:
+  install:
     internal: true
     desc: Installs the tools defined in asdf
     dir: '{{.USER_WORKING_DIR}}'

--- a/taskfiles/install/pnpm.yml
+++ b/taskfiles/install/pnpm.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+tasks:
+  install:
+    internal: true
+    desc: Installs the tools defined in package.json
+    dir: '{{.USER_WORKING_DIR}}'
+    cmds:
+      - pnpm install


### PR DESCRIPTION
- Add a new task `task docs` which starts the docs server.
- Update `task install:tools` to include installing npm packages.
- Update the README to include the new task.