### PR TITLE
chore: rename ChainIdentifier to ChainSelector

### DIFF
--- a/docs/key-concepts/proposal-timelock.md
+++ b/docs/key-concepts/proposal-timelock.md
@@ -103,7 +103,7 @@ timelock configurations and operations like scheduling, cancelling, or bypassing
     - **timelockAddress**: The address of the timelock contract on the respective chain.
 
 - **transactions**: Contains the list of transactions or batches to be executed:
-    - **chain**: The chain identifier where the transaction will be executed.
+    - **chainSelector**: The chain selector referencing the chain where the transaction will be executed.
     - **to**: The target contract address.
     - **payload**: The hexadecimal payload to send to the contract.
     - **additionalFields**: A chain-specific object with data relevant for the execution of operations on each chain.

--- a/docs/key-concepts/proposals.md
+++ b/docs/key-concepts/proposals.md
@@ -43,7 +43,7 @@ coordinated manner across different chains.
   },
   "transactions": [
     {
-      "chain": "<CHAIN_SELECTOR>",
+      "chainSelector": "<CHAIN_SELECTOR>",
       "to": "<TARGET_CONTRACT>",
       "payload": "<HEX_PAYLOAD>",
       "additionalFields": "<object>",
@@ -53,7 +53,7 @@ coordinated manner across different chains.
       ]
     },
     {
-      "chain": "<CHAIN_SELECTOR>",
+      "chainSelector": "<CHAIN_SELECTOR>",
       "to": "<TARGET_CONTRACT>",
       "payload": "<HEX_PAYLOAD>",
       "additionalFields": "<object>",
@@ -89,7 +89,7 @@ coordinated manner across different chains.
     - **mcmAddress**: The MCM contract address that will process this proposal on the respective chain.
 
 - **transactions**: A list of transactions to be executed across chains:
-    - **chain**: The blockchain identifier for the specific transaction.
+    - **chainSelector**: The blockchain identifier for the specific transaction.
     - **to**: The target contract address.
     - **payload**: The encoded payload (hexadecimal) to be sent with the transaction.
     - **additionalFields**: A chain-specific object with data relevant for the execution of operations on each chain.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ The configuration is a nested tree structure where a given group is considered a
 Signatures and `GroupSigners` that individually are at `quorum` are greater than or equal to the top-level `quorum`
 
 For example, given the following [`Config`](./config/config.go#L13):
- 
+
 ```
 Config{
     Quorum:       3,
@@ -119,7 +119,7 @@ function can be used to revalidate.
 The library provides two functions to help with the execution of an MCMS Proposal:
 
 1. [`SetRootOnChain`](https://github.com/smartcontractkit/mcms/blob/70ec727caf84a3fac4fa280ce5fbda3b07df7ee5/pkg/proposal/mcms/executor.go#L308):
-   Given auth and a ChainIdentifer, calls `setRoot` on the target MCMS for that given chainIdentifier.
+   Given auth and a ChainSelector, calls `setRoot` on the target MCMS for that given chain selector.
 2. [`ExecuteOnChain`](https://github.com/smartcontractkit/mcms/blob/70ec727caf84a3fac4fa280ce5fbda3b07df7ee5/pkg/proposal/mcms/executor.go#L348):
    Given auth and an index, calls `execute` on the target MCMS for that given operation.
 
@@ -132,7 +132,7 @@ is an extension of the `MCMSProposal` and has the following additional fields:
    wrapping calls in `scheduleBatch`,`cancel`, and `bypasserExecuteBatch` calls, respectively
 2. `MinDelay` is a string representation of a Go `time.Duration` ("1s", "1h", "1d", etc.). This field is only required
    when `Operation == Schedule` and sets the delay for each transaction to be the provided value in seconds
-3. `TimelockAddresses` is a map of `ChainIdentifier` to the target `RBACTimelock` address for each chain.
+3. `TimelockAddresses` is a map of `ChainSelector` to the target `RBACTimelock` address for each chain.
 4. Each element in `Transactions` is now an array of operations that are all to be wrapped in a single `scheduleBatch`
    or `bypasserExecuteBatch` call and executed atomically. There is no concept of batching natively available in the
    MCMS contract which is why this is only available in the RBACTimelock flavor.

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -89,7 +89,7 @@ Proposal types all contain a relevant `Validate()` function that can be used to 
 
 The library provides two functions to help with the execution of an MCMS Proposal:
 
-1. [`SetRootOnChain`](./proposal/mcms/executor.go#L234): Given auth and a ChainIdentifer, calls `setRoot` on the target MCMS for that given chainIdentifier.
+1. [`SetRootOnChain`](./proposal/mcms/executor.go#L234): Given auth and a ChainSelector, calls `setRoot` on the target MCMS for that given chainSelector.
 2. [`ExecuteOnChain`](./proposal/mcms/executor.go#L269): Given auth and an index, calls `execute` on the target MCMS for that given operation.
 
 ### Nuances of MCMSWithTimelockProposals
@@ -98,7 +98,7 @@ The [`MCMSWithTimelockProposal`](./proposal/timelock/mcm_with_timelock.go#L24) i
 
 1. `Operation`: One of <`Schedule` | `Cancel` | `Bypass`> which determines how to wrap each call in `Transactions`, wrapping calls in `scheduleBatch`,`cancel`, and `bypasserExecuteBatch` calls, respectively
 2. `MinDelay` is a string representation of a Go `time.Duration` ("1s", "1h", "1d", etc.). This field is only required when `Operation == Schedule` and sets the delay for each transaction to be the provided value in seconds
-3. `TimelockAddresses` is a map of `ChainIdentifier` to the target `RBACTimelock` address for each chain.
+3. `TimelockAddresses` is a map of `ChainSelector` to the target `RBACTimelock` address for each chain.
 4. Each element in `Transactions` is now an array of operations that are all to be wrapped in a single `scheduleBatch` or `bypasserExecuteBatch` call and executed atomically. There is no concept of batching natively available in the MCMS contract which is why this is only available in the RBACTimelock flavor.
 
 ## Development

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -71,23 +71,23 @@ func (e *InvalidVersionError) Error() string {
 
 // MissingChainDetailsError is the error for missing chain metadata.
 type MissingChainDetailsError struct {
-	Parameter       string
-	ChainIdentifier uint64
+	Parameter     string
+	ChainSelector uint64
 }
 
 // Error returns the error message.
 func (e *MissingChainDetailsError) Error() string {
-	return fmt.Sprintf("missing %s for chain %v", e.Parameter, e.ChainIdentifier)
+	return fmt.Sprintf("missing %s for chain %v", e.Parameter, e.ChainSelector)
 }
 
 // MissingChainClientError is the error for missing chain client.
 type MissingChainClientError struct {
-	ChainIdentifier uint64
+	ChainSelector uint64
 }
 
 // Error returns the error message.
 func (e *MissingChainClientError) Error() string {
-	return fmt.Sprintf("missing chain client for chain %v", e.ChainIdentifier)
+	return fmt.Sprintf("missing chain client for chain %v", e.ChainSelector)
 }
 
 type NoChainMetadataError struct {
@@ -105,13 +105,13 @@ func (e *NoTransactionsError) Error() string {
 }
 
 type InvalidSignatureError struct {
-	ChainIdentifier  uint64
+	ChainSelector    uint64
 	MCMSAddress      common.Address
 	RecoveredAddress common.Address
 }
 
 func (e *InvalidSignatureError) Error() string {
-	return fmt.Sprintf("invalid signature: received signature for address %s is not a signer on MCMS %s on chain %v", e.RecoveredAddress, e.MCMSAddress, e.ChainIdentifier)
+	return fmt.Sprintf("invalid signature: received signature for address %s is not a signer on MCMS %s on chain %v", e.RecoveredAddress, e.MCMSAddress, e.ChainSelector)
 }
 
 type InvalidMCMSConfigError struct {
@@ -123,20 +123,20 @@ func (e *InvalidMCMSConfigError) Error() string {
 }
 
 type QuorumNotMetError struct {
-	ChainIdentifier uint64
+	ChainSelector uint64
 }
 
 func (e *QuorumNotMetError) Error() string {
-	return fmt.Sprintf("quorum not met for chain %v", e.ChainIdentifier)
+	return fmt.Sprintf("quorum not met for chain %v", e.ChainSelector)
 }
 
 type InconsistentConfigsError struct {
-	ChainIdentifierA uint64
-	ChainIdentifierB uint64
+	ChainSelectorA uint64
+	ChainSelectorB uint64
 }
 
 func (e *InconsistentConfigsError) Error() string {
-	return fmt.Sprintf("inconsistent configs for chains %v and %v", e.ChainIdentifierA, e.ChainIdentifierB)
+	return fmt.Sprintf("inconsistent configs for chains %v and %v", e.ChainSelectorA, e.ChainSelectorB)
 }
 
 type TooManySignersError struct {

--- a/pkg/proposal/mcms/encoding_test.go
+++ b/pkg/proposal/mcms/encoding_test.go
@@ -16,12 +16,12 @@ func TestCalculateTransactionCounts(t *testing.T) {
 	t.Parallel()
 
 	transactions := []ChainOperation{
-		{ChainIdentifier: TestChain1},
-		{ChainIdentifier: TestChain1},
-		{ChainIdentifier: TestChain2},
+		{ChainSelector: TestChain1},
+		{ChainSelector: TestChain1},
+		{ChainSelector: TestChain2},
 	}
 
-	expected := map[ChainIdentifier]uint64{
+	expected := map[ChainSelector]uint64{
 		TestChain1: 2,
 		TestChain2: 1,
 	}
@@ -33,16 +33,16 @@ func TestCalculateTransactionCounts(t *testing.T) {
 func TestBuildRootMetadatas_Success(t *testing.T) {
 	t.Parallel()
 
-	chainMetadata := map[ChainIdentifier]ChainMetadata{
+	chainMetadata := map[ChainSelector]ChainMetadata{
 		TestChain1: {MCMAddress: common.HexToAddress("0x1"), StartingOpCount: 0},
 		TestChain2: {MCMAddress: common.HexToAddress("0x2"), StartingOpCount: 3},
 	}
-	txCounts := map[ChainIdentifier]uint64{
+	txCounts := map[ChainSelector]uint64{
 		TestChain1: 2,
 		TestChain2: 1,
 	}
 
-	expected := map[ChainIdentifier]gethwrappers.ManyChainMultiSigRootMetadata{
+	expected := map[ChainSelector]gethwrappers.ManyChainMultiSigRootMetadata{
 		TestChain1: {
 			ChainId:              new(big.Int).SetUint64(uint64(1337)),
 			MultiSig:             common.HexToAddress("0x1"),
@@ -67,10 +67,10 @@ func TestBuildRootMetadatas_Success(t *testing.T) {
 func TestBuildRootMetadatas_InvalidChainID(t *testing.T) {
 	t.Parallel()
 
-	chainMetadata := map[ChainIdentifier]ChainMetadata{
+	chainMetadata := map[ChainSelector]ChainMetadata{
 		0: {MCMAddress: common.HexToAddress("0x1"), StartingOpCount: 0},
 	}
-	txCounts := map[ChainIdentifier]uint64{
+	txCounts := map[ChainSelector]uint64{
 		0: 1,
 	}
 
@@ -84,23 +84,23 @@ func TestBuildOperations(t *testing.T) {
 	t.Parallel()
 
 	transactions := []ChainOperation{
-		{ChainIdentifier: TestChain1,
+		{ChainSelector: TestChain1,
 			Operation: Operation{
 				To: common.HexToAddress("0x1"), Data: common.Hex2Bytes("0x"), Value: big.NewInt(1),
 			},
 		},
-		{ChainIdentifier: TestChain1,
+		{ChainSelector: TestChain1,
 			Operation: Operation{
 				To: common.HexToAddress("0x2"), Data: common.Hex2Bytes("0x"), Value: big.NewInt(2),
 			},
 		},
-		{ChainIdentifier: TestChain2,
+		{ChainSelector: TestChain2,
 			Operation: Operation{
 				To: common.HexToAddress("0x3"), Data: common.Hex2Bytes("0x"), Value: big.NewInt(3),
 			},
 		},
 	}
-	rootMetadatas := map[ChainIdentifier]gethwrappers.ManyChainMultiSigRootMetadata{
+	rootMetadatas := map[ChainSelector]gethwrappers.ManyChainMultiSigRootMetadata{
 		TestChain1: {
 			ChainId:    new(big.Int).SetUint64(uint64(1337)),
 			MultiSig:   common.HexToAddress("0x1"),
@@ -112,12 +112,12 @@ func TestBuildOperations(t *testing.T) {
 			PreOpCount: big.NewInt(0),
 		},
 	}
-	txCounts := map[ChainIdentifier]uint64{
+	txCounts := map[ChainSelector]uint64{
 		TestChain1: 2,
 		TestChain2: 1,
 	}
 
-	expected := map[ChainIdentifier][]gethwrappers.ManyChainMultiSigOp{
+	expected := map[ChainSelector][]gethwrappers.ManyChainMultiSigOp{
 		TestChain1: {
 			{
 				ChainId:  new(big.Int).SetUint64(uint64(1337)),
@@ -152,26 +152,26 @@ func TestBuildOperations(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
-func TestSortedChainIdentifiers(t *testing.T) {
+func TestSortedChainSelectors(t *testing.T) {
 	t.Parallel()
 
-	chainMetadata := map[ChainIdentifier]ChainMetadata{
+	chainMetadata := map[ChainSelector]ChainMetadata{
 		TestChain2: {},
 		TestChain1: {},
 		TestChain3: {},
 	}
 
-	expected := []ChainIdentifier{TestChain1, TestChain3, TestChain2}
+	expected := []ChainSelector{TestChain1, TestChain3, TestChain2}
 
-	result := sortedChainIdentifiers(chainMetadata)
+	result := sortedChainSelectors(chainMetadata)
 	assert.Equal(t, expected, result)
 }
 
 func TestBuildMerkleTree(t *testing.T) {
 	t.Parallel()
 
-	chainIdentifiers := []ChainIdentifier{TestChain1, TestChain2}
-	ops := map[ChainIdentifier][]gethwrappers.ManyChainMultiSigOp{
+	selectors := []ChainSelector{TestChain1, TestChain2}
+	ops := map[ChainSelector][]gethwrappers.ManyChainMultiSigOp{
 		TestChain1: {
 			{
 				ChainId:  new(big.Int).SetUint64(uint64(1337)),
@@ -193,7 +193,7 @@ func TestBuildMerkleTree(t *testing.T) {
 			},
 		},
 	}
-	rootMetadatas := map[ChainIdentifier]gethwrappers.ManyChainMultiSigRootMetadata{
+	rootMetadatas := map[ChainSelector]gethwrappers.ManyChainMultiSigRootMetadata{
 		TestChain1: {
 			ChainId:              big.NewInt(1),
 			MultiSig:             common.HexToAddress("0x1"),
@@ -210,7 +210,7 @@ func TestBuildMerkleTree(t *testing.T) {
 		},
 	}
 
-	tree, err := buildMerkleTree(chainIdentifiers, rootMetadatas, ops)
+	tree, err := buildMerkleTree(selectors, rootMetadatas, ops)
 	require.NoError(t, err)
 	assert.NotNil(t, tree)
 	assert.NotEmpty(t, tree.Root)

--- a/pkg/proposal/mcms/executor_test.go
+++ b/pkg/proposal/mcms/executor_test.go
@@ -148,7 +148,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 		ValidUntil:           2004259681,
 		Signatures:           []Signature{},
 		OverridePreviousRoot: false,
-		ChainMetadata: map[ChainIdentifier]ChainMetadata{
+		ChainMetadata: map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcms.Address(),
@@ -156,7 +156,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 		},
 		Transactions: []ChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Operation: Operation{
 					To:    timelock.Address(),
 					Value: big.NewInt(0),
@@ -167,7 +167,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 	}
 
 	// Gen caller map for easy access
-	callers := map[ChainIdentifier]ContractDeployBackend{TestChain1: sim}
+	callers := map[ChainSelector]ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -278,7 +278,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 		ValidUntil:           2004259681,
 		Signatures:           []Signature{},
 		OverridePreviousRoot: false,
-		ChainMetadata: map[ChainIdentifier]ChainMetadata{
+		ChainMetadata: map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcms.Address(),
@@ -286,7 +286,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 		},
 		Transactions: []ChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Operation: Operation{
 					To:    timelock.Address(),
 					Value: big.NewInt(0),
@@ -297,7 +297,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 	}
 
 	// Gen caller map for easy access
-	callers := map[ChainIdentifier]ContractDeployBackend{TestChain1: sim}
+	callers := map[ChainSelector]ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -407,7 +407,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 		data, perr := timelockAbi.Pack("grantRole", role, mcms.Address())
 		require.NoError(t, perr)
 		operations[i] = ChainOperation{
-			ChainIdentifier: TestChain1,
+			ChainSelector: TestChain1,
 			Operation: Operation{
 				To:    timelock.Address(),
 				Value: big.NewInt(0),
@@ -422,7 +422,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 		ValidUntil:           2004259681,
 		Signatures:           []Signature{},
 		OverridePreviousRoot: false,
-		ChainMetadata: map[ChainIdentifier]ChainMetadata{
+		ChainMetadata: map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcms.Address(),
@@ -432,7 +432,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 	}
 
 	// Gen caller map for easy access
-	callers := map[ChainIdentifier]ContractDeployBackend{TestChain1: sim}
+	callers := map[ChainSelector]ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -547,7 +547,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 		data, perr := timelockAbi.Pack("grantRole", role, mcms.Address())
 		require.NoError(t, perr)
 		operations[i] = ChainOperation{
-			ChainIdentifier: TestChain1,
+			ChainSelector: TestChain1,
 			Operation: Operation{
 				To:    timelock.Address(),
 				Value: big.NewInt(0),
@@ -562,7 +562,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 		ValidUntil:           2004259681,
 		Signatures:           []Signature{},
 		OverridePreviousRoot: false,
-		ChainMetadata: map[ChainIdentifier]ChainMetadata{
+		ChainMetadata: map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcms.Address(),
@@ -572,7 +572,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 	}
 
 	// Gen caller map for easy access
-	callers := map[ChainIdentifier]ContractDeployBackend{TestChain1: sim}
+	callers := map[ChainSelector]ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -689,7 +689,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_FailureMissingQ
 		data, perr := timelockAbi.Pack("grantRole", role, mcms.Address())
 		require.NoError(t, perr)
 		operations[i] = ChainOperation{
-			ChainIdentifier: TestChain1,
+			ChainSelector: TestChain1,
 			Operation: Operation{
 				To:    timelock.Address(),
 				Value: big.NewInt(0),
@@ -704,7 +704,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_FailureMissingQ
 		ValidUntil:           2004259681,
 		Signatures:           []Signature{},
 		OverridePreviousRoot: false,
-		ChainMetadata: map[ChainIdentifier]ChainMetadata{
+		ChainMetadata: map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcms.Address(),
@@ -714,7 +714,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_FailureMissingQ
 	}
 
 	// Gen caller map for easy access
-	callers := map[ChainIdentifier]ContractDeployBackend{TestChain1: sim}
+	callers := map[ChainSelector]ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -795,7 +795,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_FailureInvalidS
 		data, perr := timelockAbi.Pack("grantRole", role, mcms.Address())
 		require.NoError(t, perr)
 		operations[i] = ChainOperation{
-			ChainIdentifier: TestChain1,
+			ChainSelector: TestChain1,
 			Operation: Operation{
 				To:    timelock.Address(),
 				Value: big.NewInt(0),
@@ -810,7 +810,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_FailureInvalidS
 		ValidUntil:           2004259681,
 		Signatures:           []Signature{},
 		OverridePreviousRoot: false,
-		ChainMetadata: map[ChainIdentifier]ChainMetadata{
+		ChainMetadata: map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcms.Address(),
@@ -820,7 +820,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_FailureInvalidS
 	}
 
 	// Gen caller map for easy access
-	callers := map[ChainIdentifier]ContractDeployBackend{TestChain1: sim}
+	callers := map[ChainSelector]ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)

--- a/pkg/proposal/mcms/operations.go
+++ b/pkg/proposal/mcms/operations.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type ChainIdentifier uint64
+type ChainSelector uint64
 
 type Operation struct {
 	To               common.Address `json:"to"`
@@ -19,6 +19,6 @@ type Operation struct {
 }
 
 type ChainOperation struct {
-	ChainIdentifier `json:"chainIdentifier"`
+	ChainSelector `json:"chainSelector"`
 	Operation
 }

--- a/pkg/proposal/mcms/operations_validation.go
+++ b/pkg/proposal/mcms/operations_validation.go
@@ -14,8 +14,8 @@ type Validator interface {
 	Validate() error
 }
 
-func ValidateAdditionalFields(operation json.RawMessage, identifier ChainIdentifier) error {
-	chainFamily, err := chain_selectors.GetSelectorFamily(uint64(identifier))
+func ValidateAdditionalFields(operation json.RawMessage, selector ChainSelector) error {
+	chainFamily, err := chain_selectors.GetSelectorFamily(uint64(selector))
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func ValidateAdditionalFields(operation json.RawMessage, identifier ChainIdentif
 		panic("not implemented")
 
 	default:
-		return NewUnknownChainSelectorFamilyError(uint64(identifier), chainFamily)
+		return NewUnknownChainSelectorFamilyError(uint64(selector), chainFamily)
 	}
 
 	// Call Validate on the chain-specific struct

--- a/pkg/proposal/mcms/operations_validation_test.go
+++ b/pkg/proposal/mcms/operations_validation_test.go
@@ -36,7 +36,7 @@ func TestValidateAdditionalFields(t *testing.T) {
 		{
 			name: "valid EVM fields",
 			operation: ChainOperation{
-				ChainIdentifier: ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+				ChainSelector: ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 				Operation: Operation{
 					AdditionalFields: validEVMFieldsJSON,
 				},
@@ -47,7 +47,7 @@ func TestValidateAdditionalFields(t *testing.T) {
 		{
 			name: "invalid EVM fields",
 			operation: ChainOperation{
-				ChainIdentifier: ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+				ChainSelector: ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 				Operation: Operation{
 					AdditionalFields: invalidEVMFieldsJSON,
 				},
@@ -57,7 +57,7 @@ func TestValidateAdditionalFields(t *testing.T) {
 		{
 			name: "unknown chain family",
 			operation: ChainOperation{
-				ChainIdentifier: 999,
+				ChainSelector: 999,
 				Operation: Operation{
 					AdditionalFields: nil,
 				},
@@ -67,7 +67,7 @@ func TestValidateAdditionalFields(t *testing.T) {
 		{
 			name: "invalid JSON for EVM fields",
 			operation: ChainOperation{
-				ChainIdentifier: ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+				ChainSelector: ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 				Operation: Operation{
 					AdditionalFields: []byte("invalid JSON"),
 				},
@@ -80,7 +80,7 @@ func TestValidateAdditionalFields(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := ValidateAdditionalFields(tt.operation.AdditionalFields, tt.operation.ChainIdentifier)
+			err := ValidateAdditionalFields(tt.operation.AdditionalFields, tt.operation.ChainSelector)
 
 			if tt.expectedErr != nil {
 				require.Error(t, err)

--- a/pkg/proposal/mcms/proposal.go
+++ b/pkg/proposal/mcms/proposal.go
@@ -23,8 +23,8 @@ type MCMSProposal struct {
 	Signatures           []Signature `json:"signatures"`
 	OverridePreviousRoot bool        `json:"overridePreviousRoot"`
 
-	// Map of chain identifier to chain metadata
-	ChainMetadata map[ChainIdentifier]ChainMetadata `json:"chainMetadata"`
+	// Map of chain selector to chain metadata
+	ChainMetadata map[ChainSelector]ChainMetadata `json:"chainMetadata"`
 
 	// This is intended to be displayed as-is to signers, to give them
 	// context for the change. File authors should templatize strings for
@@ -40,7 +40,7 @@ func NewProposal(
 	validUntil uint32,
 	signatures []Signature,
 	overridePreviousRoot bool,
-	chainMetadata map[ChainIdentifier]ChainMetadata,
+	chainMetadata map[ChainSelector]ChainMetadata,
 	description string,
 	transactions []ChainOperation,
 ) (*MCMSProposal, error) {
@@ -153,14 +153,14 @@ func (m *MCMSProposal) Validate() error {
 
 	// Validate all chains in transactions have an entry in chain metadata
 	for _, t := range m.Transactions {
-		if _, ok := m.ChainMetadata[t.ChainIdentifier]; !ok {
+		if _, ok := m.ChainMetadata[t.ChainSelector]; !ok {
 			return &errors.MissingChainDetailsError{
-				ChainIdentifier: uint64(t.ChainIdentifier),
-				Parameter:       "chain metadata",
+				ChainSelector: uint64(t.ChainSelector),
+				Parameter:     "chain metadata",
 			}
 		}
 		// Chain specific validations.
-		if err := ValidateAdditionalFields(t.Operation.AdditionalFields, t.ChainIdentifier); err != nil {
+		if err := ValidateAdditionalFields(t.Operation.AdditionalFields, t.ChainSelector); err != nil {
 			return err
 		}
 	}

--- a/pkg/proposal/mcms/proposal_test.go
+++ b/pkg/proposal/mcms/proposal_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 var TestAddress = common.HexToAddress("0x1234567890abcdef")
-var TestChain1 = ChainIdentifier(3379446385462418246)
-var TestChain2 = ChainIdentifier(16015286601757825753)
-var TestChain3 = ChainIdentifier(10344971235874465080)
+var TestChain1 = ChainSelector(3379446385462418246)
+var TestChain2 = ChainSelector(16015286601757825753)
+var TestChain3 = ChainSelector(10344971235874465080)
 
 func TestMCMSOnlyProposal_Validate_Success(t *testing.T) {
 	t.Parallel()
@@ -32,7 +32,7 @@ func TestMCMSOnlyProposal_Validate_Success(t *testing.T) {
 		2004259681,
 		[]Signature{},
 		false,
-		map[ChainIdentifier]ChainMetadata{
+		map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
@@ -41,7 +41,7 @@ func TestMCMSOnlyProposal_Validate_Success(t *testing.T) {
 		"Sample description",
 		[]ChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Operation: Operation{
 					To:               TestAddress,
 					Value:            big.NewInt(0),
@@ -66,7 +66,7 @@ func TestMCMSOnlyProposal_Validate_InvalidVersion(t *testing.T) {
 		2004259681,
 		[]Signature{},
 		false,
-		map[ChainIdentifier]ChainMetadata{
+		map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
@@ -75,7 +75,7 @@ func TestMCMSOnlyProposal_Validate_InvalidVersion(t *testing.T) {
 		"Sample description",
 		[]ChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Operation: Operation{
 					To:           TestAddress,
 					Value:        big.NewInt(0),
@@ -100,7 +100,7 @@ func TestMCMSOnlyProposal_Validate_InvalidValidUntil(t *testing.T) {
 		0,
 		[]Signature{},
 		false,
-		map[ChainIdentifier]ChainMetadata{
+		map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
@@ -109,7 +109,7 @@ func TestMCMSOnlyProposal_Validate_InvalidValidUntil(t *testing.T) {
 		"Sample description",
 		[]ChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Operation: Operation{
 					To:           TestAddress,
 					Value:        big.NewInt(0),
@@ -134,11 +134,11 @@ func TestMCMSOnlyProposal_Validate_InvalidChainMetadata(t *testing.T) {
 		2004259681,
 		[]Signature{},
 		false,
-		map[ChainIdentifier]ChainMetadata{},
+		map[ChainSelector]ChainMetadata{},
 		"Sample description",
 		[]ChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Operation: Operation{
 					To:           TestAddress,
 					Value:        big.NewInt(0),
@@ -163,7 +163,7 @@ func TestMCMSOnlyProposal_Validate_InvalidDescription(t *testing.T) {
 		2004259681,
 		[]Signature{},
 		false,
-		map[ChainIdentifier]ChainMetadata{
+		map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
@@ -172,7 +172,7 @@ func TestMCMSOnlyProposal_Validate_InvalidDescription(t *testing.T) {
 		"",
 		[]ChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Operation: Operation{
 					To:           TestAddress,
 					Value:        big.NewInt(0),
@@ -197,7 +197,7 @@ func TestMCMSOnlyProposal_Validate_NoTransactions(t *testing.T) {
 		2004259681,
 		[]Signature{},
 		false,
-		map[ChainIdentifier]ChainMetadata{
+		map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
@@ -220,7 +220,7 @@ func TestMCMSOnlyProposal_Validate_MissingChainMetadataForTransaction(t *testing
 		2004259681,
 		[]Signature{},
 		false,
-		map[ChainIdentifier]ChainMetadata{
+		map[ChainSelector]ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
@@ -229,7 +229,7 @@ func TestMCMSOnlyProposal_Validate_MissingChainMetadataForTransaction(t *testing
 		"Sample description",
 		[]ChainOperation{
 			{
-				ChainIdentifier: 3,
+				ChainSelector: 3,
 				Operation: Operation{
 					To:           TestAddress,
 					Value:        big.NewInt(0),
@@ -267,8 +267,8 @@ func TestMCMSProposal_MarshalJSON(t *testing.T) {
 				ValidUntil:           uint32(4128029039),
 				Signatures:           []Signature{},
 				OverridePreviousRoot: false,
-				ChainMetadata: map[ChainIdentifier]ChainMetadata{
-					ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
+				ChainMetadata: map[ChainSelector]ChainMetadata{
+					ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
 						StartingOpCount: 0,
 						MCMAddress:      common.HexToAddress("0x0000000000000000000000000000000000000000"),
 					},
@@ -279,7 +279,7 @@ func TestMCMSProposal_MarshalJSON(t *testing.T) {
 						Operation: Operation{
 							AdditionalFields: additionalFields,
 						},
-						ChainIdentifier: ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+						ChainSelector: ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 					},
 				},
 			},
@@ -292,8 +292,8 @@ func TestMCMSProposal_MarshalJSON(t *testing.T) {
 				ValidUntil:           uint32(4128029039),
 				Signatures:           []Signature{},
 				OverridePreviousRoot: false,
-				ChainMetadata: map[ChainIdentifier]ChainMetadata{
-					ChainIdentifier(1): {
+				ChainMetadata: map[ChainSelector]ChainMetadata{
+					ChainSelector(1): {
 						StartingOpCount: 0,
 						MCMAddress:      common.HexToAddress("0x0000000000000000000000000000000000000000"),
 					},
@@ -344,7 +344,7 @@ func TestMCMSProposal_UnmarshalJSON(t *testing.T) {
 				"description": "Test Proposal",
                 "transactions": [
                   {
-                     "chainIdentifier": 16015286601757825753,
+                     "chainSelector": 16015286601757825753,
                      "additionalFields": {"value": 0}
                   }]
 			}`,
@@ -366,7 +366,7 @@ func TestMCMSProposal_UnmarshalJSON(t *testing.T) {
 				"description": "Test Proposal",
                 "transactions": [
                   {
-                     "chainIdentifier": 16015286601757825753,
+                     "chainSelector": 16015286601757825753,
                      "additionalFields": null
                   }]
 			}`,
@@ -384,7 +384,7 @@ func TestMCMSProposal_UnmarshalJSON(t *testing.T) {
 				"description": "Test Proposal",
                 "transactions": [
                   {
-                     "chainIdentifier": 16015286601757825753,
+                     "chainSelector": 16015286601757825753,
                      "additionalFields": null
                   }]
 			}`,
@@ -407,7 +407,7 @@ func TestMCMSProposal_UnmarshalJSON(t *testing.T) {
 				"description": "Test Proposal",
                 "transactions": [
                   {
-                     "chainIdentifier": 16015286601757825753,
+                     "chainSelector": 16015286601757825753,
                      "additionalFields": null
                   }]
 			}`,

--- a/pkg/proposal/mcms/utils.go
+++ b/pkg/proposal/mcms/utils.go
@@ -24,8 +24,8 @@ type ContractDeployBackend interface {
 	bind.DeployBackend
 }
 
-func transformMCMAddresses(metadatas map[ChainIdentifier]ChainMetadata) map[ChainIdentifier]common.Address {
-	m := make(map[ChainIdentifier]common.Address)
+func transformMCMAddresses(metadatas map[ChainSelector]ChainMetadata) map[ChainSelector]common.Address {
+	m := make(map[ChainSelector]common.Address)
 	for k, v := range metadatas {
 		m[k] = v.MCMAddress
 	}
@@ -51,8 +51,8 @@ func transformHashes(hashes []common.Hash) [][32]byte {
 	return m
 }
 
-func transformMCMSConfigs(configs map[ChainIdentifier]gethwrappers.ManyChainMultiSigConfig) (map[ChainIdentifier]*config.Config, error) {
-	m := make(map[ChainIdentifier]*config.Config)
+func transformMCMSConfigs(configs map[ChainSelector]gethwrappers.ManyChainMultiSigConfig) (map[ChainSelector]*config.Config, error) {
+	m := make(map[ChainSelector]*config.Config)
 	for k, v := range configs {
 		cfg, err := config.NewConfigFromRaw(v)
 		if err != nil {

--- a/pkg/proposal/mcms/utils_test.go
+++ b/pkg/proposal/mcms/utils_test.go
@@ -65,7 +65,7 @@ func TestProposalFromFile(t *testing.T) {
 		Signatures: []Signature{},
 		Transactions: []ChainOperation{
 			{
-				ChainIdentifier: ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+				ChainSelector: ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 				Operation: Operation{
 					AdditionalFields: additionalFields,
 				},
@@ -73,8 +73,8 @@ func TestProposalFromFile(t *testing.T) {
 		},
 		OverridePreviousRoot: false,
 		Description:          "Test Proposal",
-		ChainMetadata: map[ChainIdentifier]ChainMetadata{
-			ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
+		ChainMetadata: map[ChainSelector]ChainMetadata{
+			ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
 				StartingOpCount: 0,
 				MCMAddress:      common.HexToAddress("0x5b38da6a701c568545dcfcb03fcb875f56beddc4"),
 			},
@@ -109,7 +109,7 @@ func TestWriteProposalToFile(t *testing.T) {
 		Signatures: []Signature{},
 		Transactions: []ChainOperation{
 			{
-				ChainIdentifier: ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+				ChainSelector: ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 				Operation: Operation{
 					AdditionalFields: additionalFields,
 				},
@@ -117,8 +117,8 @@ func TestWriteProposalToFile(t *testing.T) {
 		},
 		OverridePreviousRoot: false,
 		Description:          "Test Proposal",
-		ChainMetadata: map[ChainIdentifier]ChainMetadata{
-			ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
+		ChainMetadata: map[ChainSelector]ChainMetadata{
+			ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
 				StartingOpCount: 0,
 				MCMAddress:      common.HexToAddress("0x5b38da6a701c568545dcfcb03fcb875f56beddc4"),
 			},

--- a/pkg/proposal/timelock/mcm_with_timelock_test.go
+++ b/pkg/proposal/timelock/mcm_with_timelock_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 var TestAddress = common.HexToAddress("0x1234567890abcdef")
-var TestChain1 = mcms.ChainIdentifier(3379446385462418246)
-var TestChain2 = mcms.ChainIdentifier(16015286601757825753)
-var TestChain3 = mcms.ChainIdentifier(10344971235874465080)
+var TestChain1 = mcms.ChainSelector(3379446385462418246)
+var TestChain2 = mcms.ChainSelector(16015286601757825753)
+var TestChain3 = mcms.ChainSelector(10344971235874465080)
 
 func TestValidate_ValidProposal(t *testing.T) {
 	t.Parallel()
@@ -46,19 +46,19 @@ func TestValidate_ValidProposal(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: TestAddress,
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               TestAddress,
@@ -93,19 +93,19 @@ func TestValidate_InvalidOperation(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: TestAddress,
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               TestAddress,
@@ -141,19 +141,19 @@ func TestValidate_InvalidMinDelaySchedule(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: TestAddress,
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               TestAddress,
@@ -189,19 +189,19 @@ func TestValidate_InvalidUntilTimeError(t *testing.T) {
 		1697398311, // Old date (2023-10-15)
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: TestAddress,
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               TestAddress,
@@ -237,14 +237,14 @@ func TestValidate_InvalidNoChainMetadata(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]mcms.ChainMetadata{},
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: TestAddress,
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               TestAddress,
@@ -274,13 +274,13 @@ func TestValidate_InvalidNoTransactions(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: TestAddress,
 		},
 		"Sample description",
@@ -308,19 +308,19 @@ func TestValidate_InvalidNoDescription(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: TestAddress,
 		},
 		"",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               TestAddress,
@@ -356,19 +356,19 @@ func TestValidate_InvalidVersion(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: TestAddress,
 		},
 		"test",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               TestAddress,
@@ -404,19 +404,19 @@ func TestValidate_InvalidMinDelayBypassShouldBeValid(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 1,
 				MCMAddress:      TestAddress,
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: TestAddress,
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               TestAddress,
@@ -666,19 +666,19 @@ func TestE2E_ValidScheduleAndExecuteProposalOneTx(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcmsObj.Address(),
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: timelock.Address(),
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               timelock.Address(),
@@ -696,7 +696,7 @@ func TestE2E_ValidScheduleAndExecuteProposalOneTx(t *testing.T) {
 	assert.NotNil(t, proposal)
 
 	// Gen caller map for easy access
-	callers := map[mcms.ChainIdentifier]mcms.ContractDeployBackend{TestChain1: sim}
+	callers := map[mcms.ChainSelector]mcms.ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -846,19 +846,19 @@ func TestE2E_ValidScheduleAndCancelProposalOneTx(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcmsObj.Address(),
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: timelock.Address(),
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               timelock.Address(),
@@ -876,7 +876,7 @@ func TestE2E_ValidScheduleAndCancelProposalOneTx(t *testing.T) {
 	assert.NotNil(t, proposal)
 
 	// Gen caller map for easy access
-	callers := map[mcms.ChainIdentifier]mcms.ContractDeployBackend{TestChain1: sim}
+	callers := map[mcms.ChainSelector]mcms.ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -1054,19 +1054,19 @@ func TestE2E_ValidBypassProposalOneTx(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcmsObj.Address(),
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: timelock.Address(),
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
+				ChainSelector: TestChain1,
 				Batch: []mcms.Operation{
 					{
 						To:               timelock.Address(),
@@ -1084,7 +1084,7 @@ func TestE2E_ValidBypassProposalOneTx(t *testing.T) {
 	assert.NotNil(t, proposal)
 
 	// Gen caller map for easy access
-	callers := map[mcms.ChainIdentifier]mcms.ContractDeployBackend{TestChain1: sim}
+	callers := map[mcms.ChainSelector]mcms.ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -1195,20 +1195,20 @@ func TestE2E_ValidScheduleAndExecuteProposalOneBatchTx(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcmsObj.Address(),
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: timelock.Address(),
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
-				Batch:           operations,
+				ChainSelector: TestChain1,
+				Batch:         operations,
 			},
 		},
 		Schedule,
@@ -1218,7 +1218,7 @@ func TestE2E_ValidScheduleAndExecuteProposalOneBatchTx(t *testing.T) {
 	assert.NotNil(t, proposal)
 
 	// Gen caller map for easy access
-	callers := map[mcms.ChainIdentifier]mcms.ContractDeployBackend{TestChain1: sim}
+	callers := map[mcms.ChainSelector]mcms.ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -1404,20 +1404,20 @@ func TestE2E_ValidScheduleAndCancelProposalOneBatchTx(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcmsObj.Address(),
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: timelock.Address(),
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
-				Batch:           operations,
+				ChainSelector: TestChain1,
+				Batch:         operations,
 			},
 		},
 		Schedule,
@@ -1427,7 +1427,7 @@ func TestE2E_ValidScheduleAndCancelProposalOneBatchTx(t *testing.T) {
 	assert.NotNil(t, proposal)
 
 	// Gen caller map for easy access
-	callers := map[mcms.ChainIdentifier]mcms.ContractDeployBackend{TestChain1: sim}
+	callers := map[mcms.ChainSelector]mcms.ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -1625,20 +1625,20 @@ func TestE2E_ValidBypassProposalOneBatchTx(t *testing.T) {
 		2004259681,
 		[]mcms.Signature{},
 		false,
-		map[mcms.ChainIdentifier]mcms.ChainMetadata{
+		map[mcms.ChainSelector]mcms.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
 				MCMAddress:      mcmsObj.Address(),
 			},
 		},
-		map[mcms.ChainIdentifier]common.Address{
+		map[mcms.ChainSelector]common.Address{
 			TestChain1: timelock.Address(),
 		},
 		"Sample description",
 		[]BatchChainOperation{
 			{
-				ChainIdentifier: TestChain1,
-				Batch:           operations,
+				ChainSelector: TestChain1,
+				Batch:         operations,
 			},
 		},
 		Bypass,
@@ -1648,7 +1648,7 @@ func TestE2E_ValidBypassProposalOneBatchTx(t *testing.T) {
 	assert.NotNil(t, proposal)
 
 	// Gen caller map for easy access
-	callers := map[mcms.ChainIdentifier]mcms.ContractDeployBackend{TestChain1: sim}
+	callers := map[mcms.ChainSelector]mcms.ContractDeployBackend{TestChain1: sim}
 
 	// Construct executor
 	executor, err := proposal.ToExecutor(true)
@@ -1725,17 +1725,17 @@ func TestTimelockProposalFromFile(t *testing.T) {
 			Signatures:           []mcms.Signature{},
 			OverridePreviousRoot: false,
 			Description:          "Test Proposal",
-			ChainMetadata: map[mcms.ChainIdentifier]mcms.ChainMetadata{
-				mcms.ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
+			ChainMetadata: map[mcms.ChainSelector]mcms.ChainMetadata{
+				mcms.ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
 					StartingOpCount: 0,
 					MCMAddress:      common.Address{},
 				},
 			},
 		},
-		TimelockAddresses: make(map[mcms.ChainIdentifier]common.Address),
+		TimelockAddresses: make(map[mcms.ChainSelector]common.Address),
 		Transactions: []BatchChainOperation{
 			{
-				ChainIdentifier: mcms.ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+				ChainSelector: mcms.ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 				Batch: []mcms.Operation{
 					{
 						AdditionalFields: additionalFields,
@@ -1787,7 +1787,7 @@ const validJsonProposal = `{
           "value": 0
         }
       ],
-      "chainIdentifier": 16015286601757825753
+      "chainSelector": 16015286601757825753
     }
   ],
   "validUntil": 4128029039,
@@ -1816,8 +1816,8 @@ func TestMCMSWithTimelockProposal_MarshalJSON(t *testing.T) {
 					Version:     "MCMSWithTimelock",
 					ValidUntil:  4128029039,
 					Description: "Test proposal",
-					ChainMetadata: map[mcms.ChainIdentifier]mcms.ChainMetadata{
-						mcms.ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
+					ChainMetadata: map[mcms.ChainSelector]mcms.ChainMetadata{
+						mcms.ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector): {
 							StartingOpCount: 0,
 							MCMAddress:      common.Address{},
 						},
@@ -1826,10 +1826,10 @@ func TestMCMSWithTimelockProposal_MarshalJSON(t *testing.T) {
 				},
 				Operation:         Schedule,
 				MinDelay:          "1d",
-				TimelockAddresses: map[mcms.ChainIdentifier]common.Address{},
+				TimelockAddresses: map[mcms.ChainSelector]common.Address{},
 				Transactions: []BatchChainOperation{
 					{
-						ChainIdentifier: mcms.ChainIdentifier(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+						ChainSelector: mcms.ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 						Batch: []mcms.Operation{
 							{
 								To:               common.HexToAddress("0x0"),
@@ -1849,8 +1849,8 @@ func TestMCMSWithTimelockProposal_MarshalJSON(t *testing.T) {
 			proposal: MCMSWithTimelockProposal{
 				Transactions: []BatchChainOperation{
 					{
-						ChainIdentifier: mcms.ChainIdentifier(1),
-						Batch:           nil, // This will cause an error because Batch should not be nil
+						ChainSelector: mcms.ChainSelector(1),
+						Batch:         nil, // This will cause an error because Batch should not be nil
 					},
 				},
 			},
@@ -1907,8 +1907,8 @@ func TestMCMSWithTimelockProposal_UnmarshalJSON(t *testing.T) {
 					Version:     "MCMSWithTimelock",
 					ValidUntil:  4128029039,
 					Description: "Test proposal",
-					ChainMetadata: map[mcms.ChainIdentifier]mcms.ChainMetadata{
-						mcms.ChainIdentifier(16015286601757825753): {
+					ChainMetadata: map[mcms.ChainSelector]mcms.ChainMetadata{
+						mcms.ChainSelector(16015286601757825753): {
 							StartingOpCount: 0,
 							MCMAddress:      common.Address{},
 						},
@@ -1917,10 +1917,10 @@ func TestMCMSWithTimelockProposal_UnmarshalJSON(t *testing.T) {
 				},
 				Operation:         Schedule,
 				MinDelay:          "1d",
-				TimelockAddresses: map[mcms.ChainIdentifier]common.Address{},
+				TimelockAddresses: map[mcms.ChainSelector]common.Address{},
 				Transactions: []BatchChainOperation{
 					{
-						ChainIdentifier: mcms.ChainIdentifier(16015286601757825753),
+						ChainSelector: mcms.ChainSelector(16015286601757825753),
 						Batch: []mcms.Operation{
 							{
 								To:               common.HexToAddress("0x0000000000000000000000000000000000000000"),
@@ -1939,7 +1939,7 @@ func TestMCMSWithTimelockProposal_UnmarshalJSON(t *testing.T) {
 				"version":"1.0",
 				"validUntil":123456789,
 				"description":"Test proposal",
-				"operation":"invalid_operation" 
+				"operation":"invalid_operation"
 			}`, // invalid operation field
 			wantErr: true,
 		},

--- a/pkg/proposal/timelock/operations.go
+++ b/pkg/proposal/timelock/operations.go
@@ -3,6 +3,6 @@ package timelock
 import "github.com/smartcontractkit/mcms/pkg/proposal/mcms"
 
 type BatchChainOperation struct {
-	ChainIdentifier mcms.ChainIdentifier `json:"chainIdentifier"`
-	Batch           []mcms.Operation     `json:"batch"`
+	ChainSelector mcms.ChainSelector `json:"chainSelector"`
+	Batch         []mcms.Operation   `json:"batch"`
 }


### PR DESCRIPTION
ChainIdentifier is renamed to ChainSelector to better reflect what it is actually referencing.