### PR TITLE
chore: moves safe casting funcs to their own package

### DIFF
--- a/internal/core/utils.go
+++ b/internal/core/utils.go
@@ -2,12 +2,9 @@ package core
 
 import (
 	"encoding/json"
-	"fmt"
-	"math"
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/spf13/cast"
 )
 
 const FilePermissionsUserOnly = 0600
@@ -51,47 +48,4 @@ func WriteProposalToFile(proposal any, filePath string) error {
 	}
 
 	return nil
-}
-
-// SafeCastIntToUint32 safely converts an int to uint32 using cast and checks for overflow
-func SafeCastIntToUint32(value int) (uint32, error) {
-	if value < 0 || value > math.MaxUint32 {
-		return 0, fmt.Errorf("value %d exceeds uint32 range", value)
-	}
-
-	return cast.ToUint32E(value)
-}
-
-// SafeCastInt64ToUint32 safely converts an int64 to uint32 and checks for overflow and negative values
-func SafeCastInt64ToUint32(value int64) (uint32, error) {
-	// Check if the value is negative
-	if value < 0 {
-		return 0, fmt.Errorf("value %d is negative and cannot be converted to uint32", value)
-	}
-
-	// Check if the value exceeds the maximum value of uint32
-	if value > int64(math.MaxUint32) {
-		return 0, fmt.Errorf("value %d exceeds uint32 range", value)
-	}
-
-	// Use cast to convert value to uint32 safely
-	return cast.ToUint32E(value)
-}
-
-// SafeCastUint64ToUint8 safely converts an int to uint8 using cast and checks for overflow
-func SafeCastUint64ToUint8(value uint64) (uint8, error) {
-	if value > math.MaxUint8 {
-		return 0, fmt.Errorf("value %d exceeds uint8 range", value)
-	}
-
-	return cast.ToUint8E(value)
-}
-
-// SafeCastUint64ToUint32 safely converts an int to uint32 using cast and checks for overflow
-func SafeCastUint64ToUint32(value uint64) (uint32, error) {
-	if value > math.MaxUint32 {
-		return 0, fmt.Errorf("value %d exceeds uint32 range", value)
-	}
-
-	return cast.ToUint32E(value)
 }

--- a/internal/core/utils_test.go
+++ b/internal/core/utils_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"encoding/json"
 
-	"math"
 	"os"
 	"testing"
 
@@ -75,85 +74,4 @@ func TestWriteProposalToFile(t *testing.T) {
 	err = FromFile(tempFile.Name(), &fileProposal)
 	require.NoError(t, err)
 	assert.Equal(t, proposal, fileProposal)
-}
-
-func TestSafeCastIntToUint32(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		value       int
-		expected    uint32
-		expectError bool
-	}{
-		{name: "Valid int within range", value: 42, expected: 42, expectError: false},
-		{name: "Negative int", value: -1, expected: 0, expectError: true},
-		{name: "Int exceeds uint32 max value", value: int(math.MaxUint32 + 1), expected: 0, expectError: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result, err := SafeCastIntToUint32(tt.value)
-			if tt.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestSafeCastInt64ToUint32(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name        string
-		value       int64
-		expected    uint32
-		expectError bool
-	}{
-		{name: "Valid int64 within range", value: 42, expected: 42, expectError: false},
-		{name: "Negative int64", value: -1, expected: 0, expectError: true},
-		{name: "Int64 exceeds uint32 max value", value: int64(math.MaxUint32 + 1), expected: 0, expectError: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result, err := SafeCastInt64ToUint32(tt.value)
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestSafeCastUint64ToUint8(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name        string
-		value       uint64
-		expected    uint8
-		expectError bool
-	}{
-		{name: "Valid uint64 within range", value: 42, expected: 42, expectError: false},
-		{name: "Uint64 exceeds uint8 max value", value: uint64(math.MaxUint8 + 1), expected: 0, expectError: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result, err := SafeCastUint64ToUint8(tt.value)
-			if tt.expectError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
-			}
-		})
-	}
 }

--- a/internal/evm/config/configurator.go
+++ b/internal/evm/config/configurator.go
@@ -6,11 +6,11 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/spf13/cast"
 
 	"github.com/smartcontractkit/mcms/internal/core"
 	"github.com/smartcontractkit/mcms/internal/core/config"
 	"github.com/smartcontractkit/mcms/internal/evm/bindings"
+	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 )
 
 const maxUint8Value = 255
@@ -128,13 +128,11 @@ func extractGroupsAndSigners(group *config.Config, parentIdx uint8, groupQuorums
 	// Assign the current group index
 	currentGroupIdx := len(*groupQuorums) - 1
 
-	// Check if currentGroupIdx is within the uint8 range
-	if currentGroupIdx > int(maxUint8Value) {
+	// Safe to cast currentGroupIdx to uint8
+	currentGroupIdxUint8, err := safecast.IntToUint8(currentGroupIdx)
+	if err != nil {
 		return fmt.Errorf("group index %d exceeds uint8 range", currentGroupIdx)
 	}
-
-	// Safe to cast currentGroupIdx to uint8
-	currentGroupIdxUint8 := cast.ToUint8(currentGroupIdx)
 
 	// For each string signer, append the signer and its group index
 	for _, signer := range group.Signers {

--- a/internal/proposal/mcms/executable.go
+++ b/internal/proposal/mcms/executable.go
@@ -3,8 +3,8 @@ package mcms
 import (
 	"sort"
 
-	"github.com/smartcontractkit/mcms/internal/core"
 	"github.com/smartcontractkit/mcms/internal/core/proposal/mcms"
+	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 )
 
 type Executable struct {
@@ -62,7 +62,7 @@ func (e *Executable) Execute(index int) (string, error) {
 	chainSelector := transaction.ChainSelector
 	metadata := e.ChainMetadata[chainSelector]
 
-	chainNonce, err := core.SafeCastUint64ToUint32(e.ChainNonce(index))
+	chainNonce, err := safecast.Uint64ToUint32(e.ChainNonce(index))
 	if err != nil {
 		return "", err
 	}

--- a/internal/proposal/mcms/executable_test.go
+++ b/internal/proposal/mcms/executable_test.go
@@ -17,8 +17,8 @@ import (
 
 	evm_config "github.com/smartcontractkit/mcms/internal/evm/config"
 	evm_mcms "github.com/smartcontractkit/mcms/internal/evm/proposal/mcms"
+	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 
-	mcms_core "github.com/smartcontractkit/mcms/internal/core"
 	"github.com/smartcontractkit/mcms/internal/core/config"
 	proposal_core "github.com/smartcontractkit/mcms/internal/core/proposal"
 	"github.com/smartcontractkit/mcms/internal/core/proposal/mcms"
@@ -82,7 +82,7 @@ func setupSimulatedBackendWithMCMS(numSigners uint64) ([]*ecdsa.PrivateKey, []*b
 	}
 
 	// Set the quorum
-	quorum, err := mcms_core.SafeCastUint64ToUint8(numSigners)
+	quorum, err := safecast.Uint64ToUint8(numSigners)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/internal/proposal/mcms/proposal.go
+++ b/internal/proposal/mcms/proposal.go
@@ -70,19 +70,14 @@ func NewProposalFromFile(filePath string) (*MCMSProposal, error) {
 
 // proposalValidateBasic basic validation for an MCMS proposal
 func proposalValidateBasic(proposalObj MCMSProposal) error {
-	// Get the current Unix timestamp as an int64
-	currentTime := time.Now().Unix()
+	validUntil := time.Unix(int64(proposalObj.ValidUntil), 0)
 
-	currentTimeCasted, err := core.SafeCastIntToUint32(int(currentTime))
-	if err != nil {
-		return err
-	}
-	if proposalObj.ValidUntil <= currentTimeCasted {
-		// ValidUntil is a Unix timestamp, so it should be greater than the current time
+	if time.Now().After(validUntil) {
 		return &core.InvalidValidUntilError{
 			ReceivedValidUntil: proposalObj.ValidUntil,
 		}
 	}
+
 	if len(proposalObj.ChainMetadata) == 0 {
 		return &core.NoChainMetadataError{}
 	}

--- a/internal/proposal/mcms/signable.go
+++ b/internal/proposal/mcms/signable.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/mcms/internal/core/config"
 	"github.com/smartcontractkit/mcms/internal/core/merkle"
 	"github.com/smartcontractkit/mcms/internal/core/proposal/mcms"
+	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 )
 
 type Signable struct {
@@ -60,7 +61,7 @@ func NewSignable(
 
 	chainNonces := make([]uint64, len(proposal.Transactions))
 	for i, op := range proposal.Transactions {
-		chainNonce, err := core.SafeCastUint64ToUint32(chainIdx[op.ChainSelector])
+		chainNonce, err := safecast.Uint64ToUint32(chainIdx[op.ChainSelector])
 		if err != nil {
 			return nil, err
 		}

--- a/internal/utils/safecast/safecast.go
+++ b/internal/utils/safecast/safecast.go
@@ -1,0 +1,37 @@
+// Package safecast implements functions to safely cast types to avoid panics
+
+package safecast
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/spf13/cast"
+)
+
+// IntToUint8 safely converts an int to uint8 using cast and checks for overflow
+func IntToUint8(value int) (uint8, error) {
+	if value < 0 || value > math.MaxUint8 {
+		return 0, fmt.Errorf("value %d exceeds uint8 range", value)
+	}
+
+	return cast.ToUint8E(value)
+}
+
+// Uint64ToUint8 safely converts an int64 to uint8 using cast and checks for overflow
+func Uint64ToUint8(value uint64) (uint8, error) {
+	if value > math.MaxUint8 {
+		return 0, fmt.Errorf("value %d exceeds uint8 range", value)
+	}
+
+	return cast.ToUint8E(value)
+}
+
+// Uint64ToUint32 safely converts an uint64 to uint32 using cast and checks for overflow
+func Uint64ToUint32(value uint64) (uint32, error) {
+	if value > math.MaxUint32 {
+		return 0, fmt.Errorf("value %d exceeds uint32 range", value)
+	}
+
+	return cast.ToUint32E(value)
+}

--- a/internal/utils/safecast/safecast_test.go
+++ b/internal/utils/safecast/safecast_test.go
@@ -1,0 +1,97 @@
+package safecast
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_IntToUint8(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    int
+		want    uint8
+		wantErr bool
+	}{
+		{name: "Valid int within range", give: 42, want: 42},
+		{name: "Negative int", give: -1, wantErr: true},
+		{name: "Int exceeds uint32 max value", give: int(math.MaxUint8 + 1), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := IntToUint8(tt.give)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_Uint64ToUint8(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    uint64
+		want    uint8
+		wantErr bool
+	}{
+		{name: "Valid uint64 within range", give: 42, want: 42},
+		{name: "Uint64 exceeds uint8 max value", give: uint64(math.MaxUint8 + 1), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := Uint64ToUint8(tt.give)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_UInt64ToUint32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    uint64
+		want    uint32
+		wantErr bool
+	}{
+		{name: "Valid int64 within range", give: 42, want: 42},
+		{name: "Int64 exceeds uint32 max value", give: math.MaxUint32 + 1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := Uint64ToUint32(tt.give)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
To avoid overloading a utils file, safe casting functions are moved to their own package.

A time comparison was also changed to used the time package comparison functions, allowing us to remove one of the casting functions.