### PR TITLE
ci: exclude evm bindings from test coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,8 +12,9 @@ sonar.exclusions=\
 
 # Coverage exclusions
 sonar.coverage.exclusions=\
-**/*_test.go \
-**/mocks/**/*
+**/*_test.go, \
+**/mocks/**/*, \
+sdk/evm/bindings/**/*
 
 # Tests' root folder, inclusions (tests to check and count) and exclusions
 sonar.tests=.


### PR DESCRIPTION
Binding files are generated so we should exclude them from test coverage