### PR TITLE
chore: refactor mcms simulated backend tests

### DIFF
--- a/internal/testutils/evmsim/evmsim.go
+++ b/internal/testutils/evmsim/evmsim.go
@@ -1,0 +1,183 @@
+// package evmsim implements a simulated EVM chain for testing purposes.
+package evmsim
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/internal/utils/safecast"
+	"github.com/smartcontractkit/mcms/sdk/evm"
+	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+const (
+	// DefaultGasLimit is the default gas limit for each transaction in the simulated chain
+	DefaultGasLimit = uint64(8000000)
+
+	// DefaultBalance is the default balance for each account in the simulated chain
+	DefaultBalance = 1e18
+
+	// SimulatedChainID is the chain ID used for the simulated chain. EVM Simulated chains always use 1337
+	//
+	// https://pkg.go.dev/github.com/ethereum/go-ethereum/ethclient/simulated#NewBackend
+	SimulatedChainID = 1337
+)
+
+// SimulatedChain represents a simulated chain with a backend and a list of signers.
+type SimulatedChain struct {
+	Backend *simulated.Backend
+	Signers []*Signer
+}
+
+// Signer represents a signer with a private key.
+type Signer struct {
+	PrivateKey *ecdsa.PrivateKey
+}
+
+// NewTransactOpts creates a new transact options with the signer's private key and sets default
+// values.
+func (s *Signer) NewTransactOpts(t *testing.T) *bind.TransactOpts {
+	t.Helper()
+
+	auth, err := bind.NewKeyedTransactorWithChainID(s.PrivateKey, big.NewInt(SimulatedChainID))
+	require.NoError(t, err)
+
+	// Set default values
+	auth.GasLimit = DefaultGasLimit
+
+	return auth
+}
+
+// Address extracts the address from the signer's private key.
+func (s *Signer) Address(t *testing.T) common.Address {
+	t.Helper()
+
+	publicKeyECDSA, ok := s.PrivateKey.Public().(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("error casting public key from crypto to ecdsa")
+	}
+
+	return crypto.PubkeyToAddress(*publicKeyECDSA)
+}
+
+// NewSimulatedChain creates a new simulated chain with the given number of signers.
+func NewSimulatedChain(t *testing.T, numSigners uint64) SimulatedChain {
+	t.Helper()
+
+	// Generate a private key
+	signers := make([]*Signer, 0, numSigners)
+	for range numSigners {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+
+		signers = append(signers, &Signer{PrivateKey: key})
+	}
+
+	// Setup the simulated backend
+	genesisAlloc := gethTypes.GenesisAlloc{}
+	for _, s := range signers {
+		genesisAlloc[s.Address(t)] = gethTypes.Account{
+			Balance: big.NewInt(DefaultBalance),
+		}
+	}
+
+	sim := simulated.NewBackend(genesisAlloc,
+		simulated.WithBlockGasLimit(DefaultGasLimit),
+	)
+
+	return SimulatedChain{
+		Backend: sim,
+		Signers: signers,
+	}
+}
+
+// Deploy a ManyChainMultiSig contract with the signer
+func (s *SimulatedChain) DeployMCMContract(
+	t *testing.T, signer *Signer,
+) (*bindings.ManyChainMultiSig, *gethTypes.Transaction) {
+	t.Helper()
+
+	// Deploy a ManyChainMultiSig contract with the signer
+	_, tx, contract, err := bindings.DeployManyChainMultiSig(signer.NewTransactOpts(t), s.Backend.Client())
+	require.NoError(t, err)
+
+	// Mine a block
+	s.Backend.Commit()
+
+	return contract, tx
+}
+
+// Set the MCMS contract configuration. The signers of the contract are set to all available signers in the MCMS config
+func (s *SimulatedChain) SetMCMSConfig(
+	t *testing.T, signer *Signer, contract *bindings.ManyChainMultiSig,
+) *gethTypes.Transaction {
+	t.Helper()
+
+	signers := make([]common.Address, 0, len(s.Signers))
+	for _, s := range s.Signers {
+		signers = append(signers, s.Address(t))
+	}
+
+	quorom, err := safecast.IntToUint8(len(s.Signers)) // Quorum is set to the number of signers
+	require.NoError(t, err)
+
+	cfg := &types.Config{
+		Quorum:       quorom,
+		Signers:      signers,
+		GroupSigners: []types.Config{},
+	}
+
+	configurator := evm.EVMConfigurator{}
+	bindConfig, err := configurator.SetConfigInputs(*cfg)
+	require.NoError(t, err)
+
+	signerAddrs := make([]common.Address, len(bindConfig.Signers))
+	signerGroups := make([]uint8, len(bindConfig.Signers))
+	for i, signer := range bindConfig.Signers {
+		signerAddrs[i] = signer.Addr
+		signerGroups[i] = signer.Group
+	}
+
+	tx, err := contract.SetConfig(
+		signer.NewTransactOpts(t), signerAddrs, signerGroups, bindConfig.GroupQuorums, bindConfig.GroupParents, false,
+	)
+	require.NoError(t, err)
+
+	// Mine a block
+	s.Backend.Commit()
+
+	return tx
+}
+
+// Deploy a RBACTimelock contract with the signer. The admin addr is usually set to the MCMS contract address.
+func (s *SimulatedChain) DeployRBACTimelock(
+	t *testing.T, signer *Signer, adminAddr common.Address,
+) (*bindings.RBACTimelock, *gethTypes.Transaction) {
+	t.Helper()
+
+	_, tx, contract, err := bindings.DeployRBACTimelock(
+		signer.NewTransactOpts(t),
+		s.Backend.Client(),
+		big.NewInt(0),
+		adminAddr,
+		[]common.Address{},
+		[]common.Address{},
+		[]common.Address{},
+		[]common.Address{},
+	)
+	require.NoError(t, err)
+
+	// Mine a block
+	s.Backend.Commit()
+
+	return contract, tx
+}

--- a/mcms/executable_test.go
+++ b/mcms/executable_test.go
@@ -1,22 +1,15 @@
 package mcms
 
 import (
-	"crypto/ecdsa"
-	"errors"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	gethTypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	proposal_core "github.com/smartcontractkit/mcms/internal/core/proposal"
-	"github.com/smartcontractkit/mcms/internal/utils/safecast"
+	"github.com/smartcontractkit/mcms/internal/testutils/evmsim"
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
@@ -24,133 +17,22 @@ import (
 )
 
 // TODO: This should go to the EVM SDK
-func setupSimulatedBackendWithMCMS(numSigners uint64) ([]*ecdsa.PrivateKey, []*bind.TransactOpts, *backends.SimulatedBackend, *bindings.ManyChainMultiSig, error) {
-	// Generate a private key
-	keys := make([]*ecdsa.PrivateKey, numSigners)
-	auths := make([]*bind.TransactOpts, numSigners)
-	for i := range numSigners {
-		key, _ := crypto.GenerateKey()
-		auth, err := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337))
-		if err != nil {
-			return nil, nil, nil, nil, err
-		}
-		auth.GasLimit = uint64(8000000)
-		keys[i] = key
-		auths[i] = auth
-	}
-
-	// Setup a simulated backend
-	// TODO: remove deprecated call
-	//nolint:staticcheck
-	genesisAlloc := map[common.Address]core.GenesisAccount{}
-	for _, auth := range auths {
-		// TODO: remove deprecated call
-		//nolint:staticcheck
-		genesisAlloc[auth.From] = core.GenesisAccount{Balance: big.NewInt(1e18)}
-	}
-	blockGasLimit := uint64(8000000)
-
-	// TODO: remove deprecated call
-	//nolint:staticcheck
-	sim := backends.NewSimulatedBackend(genesisAlloc, blockGasLimit)
-
-	// Deploy a ManyChainMultiSig contract with any of the signers
-	_, tx, mcmsObj, err := bindings.DeployManyChainMultiSig(auths[0], sim)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
-	// Mine a block
-	sim.Commit()
-
-	// Wait for the contract to be mined
-	receipt, err := bind.WaitMined(auths[0].Context, sim, tx)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
-	// Check the receipt status
-	if receipt.Status != gethTypes.ReceiptStatusSuccessful {
-		return nil, nil, nil, nil, errors.New("contract deployment failed")
-	}
-
-	// Set a valid config
-	signers := make([]common.Address, numSigners)
-	for i, auth := range auths {
-		signers[i] = auth.From
-	}
-
-	// Set the quorum
-	quorum, err := safecast.Uint64ToUint8(numSigners)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	cfg := &types.Config{
-		Quorum:       quorum,
-		Signers:      signers,
-		GroupSigners: []types.Config{},
-	}
-	configurator := evm.EVMConfigurator{}
-	evmConfig, err := configurator.SetConfigInputs(*cfg)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	signerAddresses := make([]common.Address, len(evmConfig.Signers))
-	signerGroups := make([]uint8, len(evmConfig.Signers))
-	for i, signer := range evmConfig.Signers {
-		signerAddresses[i] = signer.Addr
-		signerGroups[i] = signer.Group
-	}
-	tx, err = mcmsObj.SetConfig(auths[0], signerAddresses, signerGroups, evmConfig.GroupQuorums, evmConfig.GroupParents, false)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
-	// Mine a block
-	sim.Commit()
-
-	// Wait for the transaction to be mined
-	_, err = bind.WaitMined(auths[0].Context, sim, tx)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
-	return keys, auths, sim, mcmsObj, nil
-}
-
 func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.T) {
 	t.Parallel()
 
-	keys, auths, sim, mcmsObj, err := setupSimulatedBackendWithMCMS(1)
-	require.NoError(t, err)
-	assert.NotNil(t, keys[0])
-	assert.NotNil(t, auths[0])
-	assert.NotNil(t, sim)
-	assert.NotNil(t, mcmsObj)
+	sim := evmsim.NewSimulatedChain(t, 1)
+	mcmC, _ := sim.DeployMCMContract(t, sim.Signers[0])
+	sim.SetMCMSConfig(t, sim.Signers[0], mcmC)
 
 	// Deploy a timelock contract for testing
-	addr, tx, timelock, err := bindings.DeployRBACTimelock(
-		auths[0],
-		sim,
-		big.NewInt(0),
-		mcmsObj.Address(),
-		[]common.Address{},
-		[]common.Address{},
-		[]common.Address{},
-		[]common.Address{},
-	)
-	require.NoError(t, err)
-	assert.NotNil(t, addr)
-	assert.NotNil(t, tx)
-	assert.NotNil(t, timelock)
-	sim.Commit()
+	timelockC, _ := sim.DeployRBACTimelock(t, sim.Signers[0], mcmC.Address())
 
 	// Construct example transaction
-	role, err := timelock.PROPOSERROLE(&bind.CallOpts{})
+	role, err := timelockC.PROPOSERROLE(&bind.CallOpts{})
 	require.NoError(t, err)
 	timelockAbi, err := bindings.RBACTimelockMetaData.GetAbi()
 	require.NoError(t, err)
-	grantRoleData, err := timelockAbi.Pack("grantRole", role, mcmsObj.Address())
+	grantRoleData, err := timelockAbi.Pack("grantRole", role, mcmC.Address())
 	require.NoError(t, err)
 
 	// Construct a proposal
@@ -163,14 +45,14 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 		ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
-				MCMAddress:      mcmsObj.Address().Hex(),
+				MCMAddress:      mcmC.Address().Hex(),
 			},
 		},
 		Transactions: []types.ChainOperation{
 			{
 				ChainSelector: TestChain1,
 				Operation: evm.NewEVMOperation(
-					timelock.Address(),
+					timelockC.Address(),
 					grantRoleData,
 					big.NewInt(0),
 					"RBACTimelock",
@@ -181,20 +63,20 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 	}
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim)}
+	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := proposal.Signable(true, inspectors)
 	require.NoError(t, err)
-	assert.NotNil(t, signable)
+	require.NotNil(t, signable)
 
-	err = proposal_core.SignPlainKey(keys[0], &proposal, true, inspectors)
+	err = proposal_core.SignPlainKey(sim.Signers[0].PrivateKey, &proposal, true, inspectors)
 	require.NoError(t, err)
 
 	// Validate the signatures
 	quorumMet, err := signable.ValidateSignatures()
-	assert.True(t, quorumMet)
 	require.NoError(t, err)
+	require.True(t, quorumMet)
 
 	// Construct encoders
 	encoders, err := proposal.GetEncoders(true)
@@ -202,7 +84,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 
 	// Construct executors
 	executors := map[types.ChainSelector]sdk.Executor{
-		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim, auths[0]),
+		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim.Backend.Client(), sim.Signers[0].NewTransactOpts(t)),
 	}
 
 	// Construct executable
@@ -212,77 +94,52 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 	// SetRoot on the contract
 	txHash, err := executable.SetRoot(TestChain1)
 	require.NoError(t, err)
-	assert.NotEqual(t, "", txHash)
-	sim.Commit()
+	require.NotEmpty(t, txHash)
+	sim.Backend.Commit()
 
 	// Validate Contract State and verify root was set
-	root, err := mcmsObj.GetRoot(&bind.CallOpts{})
+	root, err := mcmC.GetRoot(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
-	assert.Equal(t, root.ValidUntil, proposal.ValidUntil)
+	require.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
+	require.Equal(t, root.ValidUntil, proposal.ValidUntil)
 
 	// Execute the proposal
 	txHash, err = executable.Execute(0)
 	require.NoError(t, err)
-	assert.NotEqual(t, "", txHash)
-	sim.Commit()
+	require.NotEmpty(t, txHash)
+	sim.Backend.Commit()
 
-	// Wait for the transaction to be mined
-	receipt, err := bind.WaitMined(auths[0].Context, sim, tx)
+	// Check the state of the MCMS contract
+	newOpCount, err := mcmC.GetOpCount(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.NotNil(t, receipt)
-	assert.Equal(t, gethTypes.ReceiptStatusSuccessful, receipt.Status)
-
-	// // Check the state of the MCMS contract
-	newOpCount, err := mcmsObj.GetOpCount(&bind.CallOpts{})
-	require.NoError(t, err)
-	assert.NotNil(t, newOpCount)
-	assert.Equal(t, uint64(1), newOpCount.Uint64())
+	require.NotNil(t, newOpCount)
+	require.Equal(t, uint64(1), newOpCount.Uint64())
 
 	// Check the state of the timelock contract
-	proposerCount, err := timelock.GetRoleMemberCount(&bind.CallOpts{}, role)
+	proposerCount, err := timelockC.GetRoleMemberCount(&bind.CallOpts{}, role)
 	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(1), proposerCount)
-	proposer, err := timelock.GetRoleMember(&bind.CallOpts{}, role, big.NewInt(0))
+	require.Equal(t, big.NewInt(1), proposerCount)
+	proposer, err := timelockC.GetRoleMember(&bind.CallOpts{}, role, big.NewInt(0))
 	require.NoError(t, err)
-	assert.Equal(t, mcmsObj.Address().Hex(), proposer.Hex())
+	require.Equal(t, mcmC.Address().Hex(), proposer.Hex())
 }
 
 func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testing.T) {
 	t.Parallel()
 
-	keys, auths, sim, mcmsObj, err := setupSimulatedBackendWithMCMS(3)
-	require.NoError(t, err)
-	assert.NotNil(t, sim)
-	assert.NotNil(t, mcmsObj)
-	for i := range 3 {
-		assert.NotNil(t, keys[i])
-		assert.NotNil(t, auths[i])
-	}
+	sim := evmsim.NewSimulatedChain(t, 3)
+	mcmC, _ := sim.DeployMCMContract(t, sim.Signers[0])
+	sim.SetMCMSConfig(t, sim.Signers[0], mcmC)
 
 	// Deploy a timelock contract for testing
-	addr, tx, timelock, err := bindings.DeployRBACTimelock(
-		auths[0],
-		sim,
-		big.NewInt(0),
-		mcmsObj.Address(),
-		[]common.Address{},
-		[]common.Address{},
-		[]common.Address{},
-		[]common.Address{},
-	)
-	require.NoError(t, err)
-	assert.NotNil(t, addr)
-	assert.NotNil(t, tx)
-	assert.NotNil(t, timelock)
-	sim.Commit()
+	timelockC, _ := sim.DeployRBACTimelock(t, sim.Signers[0], mcmC.Address())
 
 	// Construct example transaction
-	role, err := timelock.PROPOSERROLE(&bind.CallOpts{})
+	role, err := timelockC.PROPOSERROLE(&bind.CallOpts{})
 	require.NoError(t, err)
 	timelockAbi, err := bindings.RBACTimelockMetaData.GetAbi()
 	require.NoError(t, err)
-	grantRoleData, err := timelockAbi.Pack("grantRole", role, mcmsObj.Address())
+	grantRoleData, err := timelockAbi.Pack("grantRole", role, mcmC.Address())
 	require.NoError(t, err)
 
 	// Construct a proposal
@@ -295,14 +152,14 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 		ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
-				MCMAddress:      mcmsObj.Address().Hex(),
+				MCMAddress:      mcmC.Address().Hex(),
 			},
 		},
 		Transactions: []types.ChainOperation{
 			{
 				ChainSelector: TestChain1,
 				Operation: evm.NewEVMOperation(
-					timelock.Address(),
+					timelockC.Address(),
 					grantRoleData,
 					big.NewInt(0),
 					"Sample contract",
@@ -313,23 +170,23 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 	}
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim)}
+	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := proposal.Signable(true, inspectors)
 	require.NoError(t, err)
-	assert.NotNil(t, signable)
+	require.NotNil(t, signable)
 
 	// Sign the hash
 	for i := range 3 {
-		err = proposal_core.SignPlainKey(keys[i], &proposal, true, inspectors)
+		err = proposal_core.SignPlainKey(sim.Signers[i].PrivateKey, &proposal, true, inspectors)
 		require.NoError(t, err)
 	}
 
 	// Validate the signatures
 	quorumMet, err := signable.ValidateSignatures()
-	assert.True(t, quorumMet)
 	require.NoError(t, err)
+	require.True(t, quorumMet)
 
 	// Construct encoders
 	encoders, err := proposal.GetEncoders(true)
@@ -337,7 +194,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 
 	// Construct executors
 	executors := map[types.ChainSelector]sdk.Executor{
-		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim, auths[0]),
+		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim.Backend.Client(), sim.Signers[0].NewTransactOpts(t)),
 	}
 
 	// Construct executable
@@ -347,89 +204,67 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 	// SetRoot on the contract
 	txHash, err := executable.SetRoot(TestChain1)
 	require.NoError(t, err)
-	assert.NotEqual(t, "", txHash)
-	sim.Commit()
+	require.NotEmpty(t, txHash)
+	sim.Backend.Commit()
 
 	// Validate Contract State and verify root was set
-	root, err := mcmsObj.GetRoot(&bind.CallOpts{})
+	root, err := mcmC.GetRoot(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
-	assert.Equal(t, root.ValidUntil, proposal.ValidUntil)
+	require.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
+	require.Equal(t, root.ValidUntil, proposal.ValidUntil)
 
 	// Execute the proposal
 	txHash, err = executable.Execute(0)
 	require.NoError(t, err)
-	assert.NotEqual(t, "", txHash)
-	sim.Commit()
-
-	// Wait for the transaction to be mined
-	receipt, err := bind.WaitMined(auths[0].Context, sim, tx)
-	require.NoError(t, err)
-	assert.NotNil(t, receipt)
-	assert.Equal(t, gethTypes.ReceiptStatusSuccessful, receipt.Status)
+	require.NotEqual(t, "", txHash)
+	sim.Backend.Commit()
 
 	// Check the state of the MCMS contract
-	newOpCount, err := mcmsObj.GetOpCount(&bind.CallOpts{})
+	newOpCount, err := mcmC.GetOpCount(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.NotNil(t, newOpCount)
-	assert.Equal(t, uint64(1), newOpCount.Uint64())
+	require.NotNil(t, newOpCount)
+	require.Equal(t, uint64(1), newOpCount.Uint64())
 
 	// Check the state of the timelock contract
-	proposerCount, err := timelock.GetRoleMemberCount(&bind.CallOpts{}, role)
+	proposerCount, err := timelockC.GetRoleMemberCount(&bind.CallOpts{}, role)
 	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(1), proposerCount)
-	proposer, err := timelock.GetRoleMember(&bind.CallOpts{}, role, big.NewInt(0))
+	require.Equal(t, big.NewInt(1), proposerCount)
+	proposer, err := timelockC.GetRoleMember(&bind.CallOpts{}, role, big.NewInt(0))
 	require.NoError(t, err)
-	assert.Equal(t, mcmsObj.Address().Hex(), proposer.Hex())
+	require.Equal(t, mcmC.Address().Hex(), proposer.Hex())
 }
 
 func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testing.T) {
 	t.Parallel()
 
-	keys, auths, sim, mcmsObj, err := setupSimulatedBackendWithMCMS(1)
-	require.NoError(t, err)
-	assert.NotNil(t, keys[0])
-	assert.NotNil(t, auths[0])
-	assert.NotNil(t, sim)
-	assert.NotNil(t, mcmsObj)
+	sim := evmsim.NewSimulatedChain(t, 1)
+	mcmC, _ := sim.DeployMCMContract(t, sim.Signers[0])
+	sim.SetMCMSConfig(t, sim.Signers[0], mcmC)
 
-	// Deploy a timelock contract for testing
-	addr, tx, timelock, err := bindings.DeployRBACTimelock(
-		auths[0],
-		sim,
-		big.NewInt(0),
-		mcmsObj.Address(),
-		[]common.Address{},
-		[]common.Address{},
-		[]common.Address{},
-		[]common.Address{},
-	)
-	require.NoError(t, err)
-	assert.NotNil(t, addr)
-	assert.NotNil(t, tx)
-	assert.NotNil(t, timelock)
-	sim.Commit()
+	// Deploy a timelockC contract for testing
+	timelockC, _ := sim.DeployRBACTimelock(t, sim.Signers[0], mcmC.Address())
 
 	// Construct example transactions
-	proposerRole, err := timelock.PROPOSERROLE(&bind.CallOpts{})
+	proposerRole, err := timelockC.PROPOSERROLE(&bind.CallOpts{})
 	require.NoError(t, err)
-	bypasserRole, err := timelock.BYPASSERROLE(&bind.CallOpts{})
+	bypasserRole, err := timelockC.BYPASSERROLE(&bind.CallOpts{})
 	require.NoError(t, err)
-	cancellerRole, err := timelock.CANCELLERROLE(&bind.CallOpts{})
+	cancellerRole, err := timelockC.CANCELLERROLE(&bind.CallOpts{})
 	require.NoError(t, err)
-	executorRole, err := timelock.EXECUTORROLE(&bind.CallOpts{})
+	executorRole, err := timelockC.EXECUTORROLE(&bind.CallOpts{})
 	require.NoError(t, err)
 	timelockAbi, err := bindings.RBACTimelockMetaData.GetAbi()
 	require.NoError(t, err)
 
 	operations := make([]types.ChainOperation, 4)
 	for i, role := range []common.Hash{proposerRole, bypasserRole, cancellerRole, executorRole} {
-		data, perr := timelockAbi.Pack("grantRole", role, mcmsObj.Address())
+		data, perr := timelockAbi.Pack("grantRole", role, mcmC.Address())
 		require.NoError(t, perr)
+
 		operations[i] = types.ChainOperation{
 			ChainSelector: TestChain1,
 			Operation: evm.NewEVMOperation(
-				timelock.Address(),
+				timelockC.Address(),
 				data,
 				big.NewInt(0),
 				"Sample contract",
@@ -448,27 +283,27 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 		ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
-				MCMAddress:      mcmsObj.Address().Hex(),
+				MCMAddress:      mcmC.Address().Hex(),
 			},
 		},
 		Transactions: operations,
 	}
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim)}
+	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := proposal.Signable(true, inspectors)
 	require.NoError(t, err)
-	assert.NotNil(t, signable)
+	require.NotNil(t, signable)
 
-	err = proposal_core.SignPlainKey(keys[0], &proposal, true, inspectors)
+	err = proposal_core.SignPlainKey(sim.Signers[0].PrivateKey, &proposal, true, inspectors)
 	require.NoError(t, err)
 
 	// Validate the signatures
 	quorumMet, err := signable.ValidateSignatures()
-	assert.True(t, quorumMet)
 	require.NoError(t, err)
+	require.True(t, quorumMet)
 
 	// Construct encoders
 	encoders, err := proposal.GetEncoders(true)
@@ -476,7 +311,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 
 	// Construct executors
 	executors := map[types.ChainSelector]sdk.Executor{
-		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim, auths[0]),
+		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim.Backend.Client(), sim.Signers[0].NewTransactOpts(t)),
 	}
 
 	// Construct executable
@@ -486,96 +321,73 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 	// SetRoot on the contract
 	txHash, err := executable.SetRoot(TestChain1)
 	require.NoError(t, err)
-	assert.NotEqual(t, "", txHash)
-	sim.Commit()
+	require.NotEmpty(t, txHash)
+	sim.Backend.Commit()
 
 	// Validate Contract State and verify root was set
-	root, err := mcmsObj.GetRoot(&bind.CallOpts{})
+	root, err := mcmC.GetRoot(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
-	assert.Equal(t, root.ValidUntil, proposal.ValidUntil)
+	require.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
+	require.Equal(t, root.ValidUntil, proposal.ValidUntil)
 
 	// Execute the proposal
 	for i := range 4 {
 		// Execute the proposal
 		txHash, err = executable.Execute(i)
 		require.NoError(t, err)
-		assert.NotEqual(t, "", txHash)
-		sim.Commit()
+		require.NotEqual(t, "", txHash)
 
-		// Wait for the transaction to be mined
-		receipt, merr := bind.WaitMined(auths[0].Context, sim, tx)
-		require.NoError(t, merr)
-		assert.NotNil(t, receipt)
-		assert.Equal(t, gethTypes.ReceiptStatusSuccessful, receipt.Status)
+		sim.Backend.Commit()
 	}
 
 	// Check the state of the MCMS contract
-	newOpCount, err := mcmsObj.GetOpCount(&bind.CallOpts{})
+	newOpCount, err := mcmC.GetOpCount(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.NotNil(t, newOpCount)
-	// assert.Equal(t, uint64(4), newOpCount.Uint64())
+	require.NotNil(t, newOpCount)
+	require.Equal(t, uint64(4), newOpCount.Uint64())
 
 	// Check the state of the timelock contract
 	for _, role := range []common.Hash{proposerRole, bypasserRole, cancellerRole, executorRole} {
-		roleCount, err := timelock.GetRoleMemberCount(&bind.CallOpts{}, role)
+		roleCount, err := timelockC.GetRoleMemberCount(&bind.CallOpts{}, role)
 		require.NoError(t, err)
-		assert.Equal(t, big.NewInt(1), roleCount)
-		roleMember, err := timelock.GetRoleMember(&bind.CallOpts{}, role, big.NewInt(0))
+		require.Equal(t, big.NewInt(1), roleCount)
+
+		roleMember, err := timelockC.GetRoleMember(&bind.CallOpts{}, role, big.NewInt(0))
 		require.NoError(t, err)
-		assert.Equal(t, mcmsObj.Address().Hex(), roleMember.Hex())
+		require.Equal(t, mcmC.Address().Hex(), roleMember.Hex())
 	}
 }
 
 func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *testing.T) {
 	t.Parallel()
 
-	keys, auths, sim, mcmsObj, err := setupSimulatedBackendWithMCMS(3)
-	require.NoError(t, err)
-	assert.NotNil(t, sim)
-	assert.NotNil(t, mcmsObj)
-	for i := range 3 {
-		assert.NotNil(t, keys[i])
-		assert.NotNil(t, auths[i])
-	}
+	sim := evmsim.NewSimulatedChain(t, 3)
+	mcmC, _ := sim.DeployMCMContract(t, sim.Signers[0])
+	sim.SetMCMSConfig(t, sim.Signers[0], mcmC)
 
-	// Deploy a timelock contract for testing
-	addr, tx, timelock, err := bindings.DeployRBACTimelock(
-		auths[0],
-		sim,
-		big.NewInt(0),
-		mcmsObj.Address(),
-		[]common.Address{},
-		[]common.Address{},
-		[]common.Address{},
-		[]common.Address{},
-	)
-	require.NoError(t, err)
-	assert.NotNil(t, addr)
-	assert.NotNil(t, tx)
-	assert.NotNil(t, timelock)
-	sim.Commit()
+	// Deploy a timelockC contract for testing
+	timelockC, _ := sim.DeployRBACTimelock(t, sim.Signers[0], mcmC.Address())
 
 	// Construct example transactions
-	proposerRole, err := timelock.PROPOSERROLE(&bind.CallOpts{})
+	proposerRole, err := timelockC.PROPOSERROLE(&bind.CallOpts{})
 	require.NoError(t, err)
-	bypasserRole, err := timelock.BYPASSERROLE(&bind.CallOpts{})
+	bypasserRole, err := timelockC.BYPASSERROLE(&bind.CallOpts{})
 	require.NoError(t, err)
-	cancellerRole, err := timelock.CANCELLERROLE(&bind.CallOpts{})
+	cancellerRole, err := timelockC.CANCELLERROLE(&bind.CallOpts{})
 	require.NoError(t, err)
-	executorRole, err := timelock.EXECUTORROLE(&bind.CallOpts{})
+	executorRole, err := timelockC.EXECUTORROLE(&bind.CallOpts{})
 	require.NoError(t, err)
 	timelockAbi, err := bindings.RBACTimelockMetaData.GetAbi()
 	require.NoError(t, err)
 
 	operations := make([]types.ChainOperation, 4)
 	for i, role := range []common.Hash{proposerRole, bypasserRole, cancellerRole, executorRole} {
-		data, perr := timelockAbi.Pack("grantRole", role, mcmsObj.Address())
+		data, perr := timelockAbi.Pack("grantRole", role, mcmC.Address())
 		require.NoError(t, perr)
 		operations[i] = types.ChainOperation{
 			ChainSelector: TestChain1,
 			Operation: evm.NewEVMOperation(
-				timelock.Address(),
+				timelockC.Address(),
 				data,
 				big.NewInt(0),
 				"Sample contract",
@@ -594,30 +406,30 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 		ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
 			TestChain1: {
 				StartingOpCount: 0,
-				MCMAddress:      mcmsObj.Address().Hex(),
+				MCMAddress:      mcmC.Address().Hex(),
 			},
 		},
 		Transactions: operations,
 	}
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim)}
+	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := proposal.Signable(true, inspectors)
 	require.NoError(t, err)
-	assert.NotNil(t, signable)
+	require.NotNil(t, signable)
 
 	// Sign the hash
 	for i := range 3 {
-		err = proposal_core.SignPlainKey(keys[i], &proposal, true, inspectors)
+		err = proposal_core.SignPlainKey(sim.Signers[i].PrivateKey, &proposal, true, inspectors)
 		require.NoError(t, err)
 	}
 
 	// Validate the signatures
 	quorumMet, err := signable.ValidateSignatures()
-	assert.True(t, quorumMet)
 	require.NoError(t, err)
+	require.True(t, quorumMet)
 
 	// Construct encoders
 	encoders, err := proposal.GetEncoders(true)
@@ -625,7 +437,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 
 	// Construct executors
 	executors := map[types.ChainSelector]sdk.Executor{
-		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim, auths[0]),
+		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim.Backend.Client(), sim.Signers[0].NewTransactOpts(t)),
 	}
 
 	// Construct executable
@@ -635,43 +447,40 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 	// SetRoot on the contract
 	txHash, err := executable.SetRoot(TestChain1)
 	require.NoError(t, err)
-	assert.NotEqual(t, "", txHash)
-	sim.Commit()
+	require.NotEmpty(t, txHash)
+
+	sim.Backend.Commit()
 
 	// Validate Contract State and verify root was set
-	root, err := mcmsObj.GetRoot(&bind.CallOpts{})
+	root, err := mcmC.GetRoot(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
-	assert.Equal(t, root.ValidUntil, proposal.ValidUntil)
+	require.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
+	require.Equal(t, root.ValidUntil, proposal.ValidUntil)
 
 	// Execute the proposal
 	for i := range 4 {
 		// Execute the proposal
 		txHash, err = executable.Execute(i)
 		require.NoError(t, err)
-		assert.NotEqual(t, "", txHash)
-		sim.Commit()
+		require.NotEqual(t, "", txHash)
 
-		// Wait for the transaction to be mined
-		receipt, merr := bind.WaitMined(auths[0].Context, sim, tx)
-		require.NoError(t, merr)
-		assert.NotNil(t, receipt)
-		assert.Equal(t, gethTypes.ReceiptStatusSuccessful, receipt.Status)
+		sim.Backend.Commit()
 	}
 
 	// Check the state of the MCMS contract
-	newOpCount, err := mcmsObj.GetOpCount(&bind.CallOpts{})
+	newOpCount, err := mcmC.GetOpCount(&bind.CallOpts{})
 	require.NoError(t, err)
-	assert.NotNil(t, newOpCount)
-	assert.Equal(t, uint64(4), newOpCount.Uint64())
+	require.NotNil(t, newOpCount)
+	require.Equal(t, uint64(4), newOpCount.Uint64())
 
 	// Check the state of the timelock contract
 	for _, role := range []common.Hash{proposerRole, bypasserRole, cancellerRole, executorRole} {
-		roleCount, err := timelock.GetRoleMemberCount(&bind.CallOpts{}, role)
+		roleCount, err := timelockC.GetRoleMemberCount(&bind.CallOpts{}, role)
 		require.NoError(t, err)
-		assert.Equal(t, big.NewInt(1), roleCount)
-		roleMember, err := timelock.GetRoleMember(&bind.CallOpts{}, role, big.NewInt(0))
+		require.Equal(t, big.NewInt(1), roleCount)
+
+		roleMember, err := timelockC.GetRoleMember(&bind.CallOpts{}, role, big.NewInt(0))
 		require.NoError(t, err)
-		assert.Equal(t, mcmsObj.Address().Hex(), roleMember.Hex())
+		require.Equal(t, mcmC.Address().Hex(), roleMember.Hex())
 	}
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,8 @@ sonar.exclusions=\
 sonar.coverage.exclusions=\
 **/*_test.go, \
 **/mocks/**/*, \
-sdk/evm/bindings/**/*
+sdk/evm/bindings/**/*, \
+internal/testutils/**/*
 
 # Tests' root folder, inclusions (tests to check and count) and exclusions
 sonar.tests=.


### PR DESCRIPTION
This adds a new package `internal/testutils/evmsim` which provides a wrapper around the go-ethereum simulated backend. It provides a `SimulatedBackend` struct which exposes methods to deploy and call MCM related contracts. This splits up the previous single function setup call so it gives the caller more control over how they want to build their tests.

This can later be extended to add more common methods for interacting with MCM contracts on the simulated backend as we expand the test suite.