### PR TITLE
chore: renames ChainIdentifier to ChainSelector for clarity

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ The configuration is a nested tree structure where a given group is considered a
 Signatures and `GroupSigners` that individually are at `quorum` are greater than or equal to the top-level `quorum`
 
 For example, given the following [`Config`](./config/config.go#L13):
- 
+
 ```
 Config{
     Quorum:       3,
@@ -119,7 +119,7 @@ function can be used to revalidate.
 The library provides two functions to help with the execution of an MCMS Proposal:
 
 1. [`SetRootOnChain`](https://github.com/smartcontractkit/mcms/blob/70ec727caf84a3fac4fa280ce5fbda3b07df7ee5/pkg/proposal/mcms/executor.go#L308):
-   Given auth and a ChainIdentifer, calls `setRoot` on the target MCMS for that given chainIdentifier.
+   Given auth and a ChainIdentifer, calls `setRoot` on the target MCMS for that given chainSelector.
 2. [`ExecuteOnChain`](https://github.com/smartcontractkit/mcms/blob/70ec727caf84a3fac4fa280ce5fbda3b07df7ee5/pkg/proposal/mcms/executor.go#L348):
    Given auth and an index, calls `execute` on the target MCMS for that given operation.
 
@@ -132,7 +132,7 @@ is an extension of the `MCMSProposal` and has the following additional fields:
    wrapping calls in `scheduleBatch`,`cancel`, and `bypasserExecuteBatch` calls, respectively
 2. `MinDelay` is a string representation of a Go `time.Duration` ("1s", "1h", "1d", etc.). This field is only required
    when `Operation == Schedule` and sets the delay for each transaction to be the provided value in seconds
-3. `TimelockAddresses` is a map of `ChainIdentifier` to the target `RBACTimelock` address for each chain.
+3. `TimelockAddresses` is a map of `ChainSelector` to the target `RBACTimelock` address for each chain.
 4. Each element in `Transactions` is now an array of operations that are all to be wrapped in a single `scheduleBatch`
    or `bypasserExecuteBatch` call and executed atomically. There is no concept of batching natively available in the
    MCMS contract which is why this is only available in the RBACTimelock flavor.

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -69,27 +69,6 @@ func (e *InvalidVersionError) Error() string {
 	return fmt.Sprintf("invalid version: %s", e.ReceivedVersion)
 }
 
-// MissingChainDetailsError is the error for missing chain metadata.
-type MissingChainDetailsError struct {
-	Parameter       string
-	ChainIdentifier uint64
-}
-
-// Error returns the error message.
-func (e *MissingChainDetailsError) Error() string {
-	return fmt.Sprintf("missing %s for chain %v", e.Parameter, e.ChainIdentifier)
-}
-
-// MissingChainClientError is the error for missing chain client.
-type MissingChainClientError struct {
-	ChainIdentifier uint64
-}
-
-// Error returns the error message.
-func (e *MissingChainClientError) Error() string {
-	return fmt.Sprintf("missing chain client for chain %v", e.ChainIdentifier)
-}
-
 type NoChainMetadataError struct {
 }
 
@@ -105,13 +84,11 @@ func (e *NoTransactionsError) Error() string {
 }
 
 type InvalidSignatureError struct {
-	ChainIdentifier  uint64
-	MCMSAddress      common.Address
 	RecoveredAddress common.Address
 }
 
 func (e *InvalidSignatureError) Error() string {
-	return fmt.Sprintf("invalid signature: received signature for address %s is not a signer on MCMS %s on chain %v", e.RecoveredAddress, e.MCMSAddress, e.ChainIdentifier)
+	return fmt.Sprintf("invalid signature: received signature for address %s is not a signer on the MCMS contract", e.RecoveredAddress)
 }
 
 type InvalidMCMSConfigError struct {
@@ -120,23 +97,6 @@ type InvalidMCMSConfigError struct {
 
 func (e *InvalidMCMSConfigError) Error() string {
 	return fmt.Sprintf("invalid MCMS config: %s", e.Reason)
-}
-
-type QuorumNotMetError struct {
-	ChainIdentifier uint64
-}
-
-func (e *QuorumNotMetError) Error() string {
-	return fmt.Sprintf("quorum not met for chain %v", e.ChainIdentifier)
-}
-
-type InconsistentConfigsError struct {
-	ChainIdentifierA uint64
-	ChainIdentifierB uint64
-}
-
-func (e *InconsistentConfigsError) Error() string {
-	return fmt.Sprintf("inconsistent configs for chains %v and %v", e.ChainIdentifierA, e.ChainIdentifierB)
 }
 
 type TooManySignersError struct {

--- a/mcms/errors.go
+++ b/mcms/errors.go
@@ -1,0 +1,56 @@
+package mcms
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/mcms/types"
+)
+
+// ChainMetadataNotFoundError is returned when the chain metadata for a chain is not found in a
+// proposal.
+type ChainMetadataNotFoundError struct {
+	ChainSelector types.ChainSelector
+}
+
+// NewChainMetadataNotFoundError creates a new ChainMetadataNotFoundError.
+func NewChainMetadataNotFoundError(sel types.ChainSelector) *ChainMetadataNotFoundError {
+	return &ChainMetadataNotFoundError{ChainSelector: sel}
+}
+
+// Error implements the error interface.
+func (e *ChainMetadataNotFoundError) Error() string {
+	return fmt.Sprintf("missing metadata for chain %d", e.ChainSelector)
+}
+
+// InconsistentConfigsError is returned when the configs for two chains are not equal to each
+// other.
+type InconsistentConfigsError struct {
+	ChainSelectorA types.ChainSelector
+	ChainSelectorB types.ChainSelector
+}
+
+// NewInconsistentConfigsError creates a new InconsistentConfigsError.
+func NewInconsistentConfigsError(selA, selB types.ChainSelector) *InconsistentConfigsError {
+	return &InconsistentConfigsError{ChainSelectorA: selA, ChainSelectorB: selB}
+}
+
+// Error implements the error interface.
+func (e *InconsistentConfigsError) Error() string {
+	return fmt.Sprintf("inconsistent configs for chains %d and %d", e.ChainSelectorA, e.ChainSelectorB)
+}
+
+// QuorumNotReachedError is returned when the quorum has not been reach as defined in a chain's
+// MCM contract configuration.
+type QuorumNotReachedError struct {
+	ChainSelector types.ChainSelector
+}
+
+// NewQuorumNotReachedError creates a new QuorumNotReachedError.
+func NewQuorumNotReachedError(sel types.ChainSelector) *QuorumNotReachedError {
+	return &QuorumNotReachedError{ChainSelector: sel}
+}
+
+// Error implements the error interface.
+func (e *QuorumNotReachedError) Error() string {
+	return fmt.Sprintf("quorum not reached for chain %d", e.ChainSelector)
+}

--- a/mcms/errors_test.go
+++ b/mcms/errors_test.go
@@ -1,0 +1,31 @@
+package mcms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ChainMetadataNotFoundError_Error(t *testing.T) {
+	t.Parallel()
+
+	err := NewChainMetadataNotFoundError(1)
+
+	assert.EqualError(t, err, "missing metadata for chain 1")
+}
+
+func Test_InconsistentConfigsError_Error(t *testing.T) {
+	t.Parallel()
+
+	err := NewInconsistentConfigsError(1, 2)
+
+	assert.EqualError(t, err, "inconsistent configs for chains 1 and 2")
+}
+
+func Test_QuorumNotReachedError_Error(t *testing.T) {
+	t.Parallel()
+
+	err := NewQuorumNotReachedError(1)
+
+	assert.EqualError(t, err, "quorum not reached for chain 1")
+}

--- a/mcms/proposal.go
+++ b/mcms/proposal.go
@@ -3,7 +3,8 @@ package mcms
 import (
 	"encoding/json"
 	"io"
-	"sort"
+	"maps"
+	"slices"
 	"time"
 
 	"github.com/smartcontractkit/mcms/internal/core"
@@ -113,24 +114,16 @@ func (m *MCMSProposal) Validate() error {
 	// Validate all chains in transactions have an entry in chain metadata
 	for _, t := range m.Transactions {
 		if _, ok := m.ChainMetadata[t.ChainSelector]; !ok {
-			return &core.MissingChainDetailsError{
-				ChainIdentifier: uint64(t.ChainSelector),
-				Parameter:       "chain metadata",
-			}
+			return NewChainMetadataNotFoundError(t.ChainSelector)
 		}
 	}
 
 	return nil
 }
 
-func (m *MCMSProposal) ChainIdentifiers() []types.ChainSelector {
-	chainIdentifiers := make([]types.ChainSelector, 0, len(m.ChainMetadata))
-	for chainID := range m.ChainMetadata {
-		chainIdentifiers = append(chainIdentifiers, chainID)
-	}
-	sort.Slice(chainIdentifiers, func(i, j int) bool { return chainIdentifiers[i] < chainIdentifiers[j] })
-
-	return chainIdentifiers
+// ChainSelectors returns a sorted list of chain selectors from the chains' metadata
+func (m *MCMSProposal) ChainSelectors() []types.ChainSelector {
+	return slices.Sorted(maps.Keys(m.ChainMetadata))
 }
 
 func (m *MCMSProposal) TransactionCounts() map[types.ChainSelector]uint64 {

--- a/mcms/proposal_test.go
+++ b/mcms/proposal_test.go
@@ -35,21 +35,6 @@ var TestChain3 = types.ChainSelector(10344971235874465080)
 // 	assert.Equal(t, expected, result)
 // }
 
-// func TestSortedChainIdentifiers(t *testing.T) {
-// 	t.Parallel()
-
-// 	chainMetadata := map[ChainIdentifier]ChainMetadata{
-// 		TestChain2: {},
-// 		TestChain1: {},
-// 		TestChain3: {},
-// 	}
-
-// 	expected := []ChainIdentifier{TestChain1, TestChain3, TestChain2}
-
-// 	result := sortedChainIdentifiers(chainMetadata)
-// 	assert.Equal(t, expected, result)
-// }
-
 func TestMCMSOnlyProposal_Validate_Success(t *testing.T) {
 	t.Parallel()
 
@@ -279,7 +264,7 @@ func TestMCMSOnlyProposal_Validate_MissingChainMetadataForTransaction(t *testing
 	)
 
 	require.Error(t, err)
-	require.EqualError(t, err, "missing chain metadata for chain 3")
+	require.EqualError(t, err, "missing metadata for chain 3")
 	assert.Nil(t, proposal)
 }
 
@@ -307,4 +292,19 @@ func TestProposalFromFile(t *testing.T) {
 	fileProposal, err := NewProposalFromReader(tempFile)
 	require.NoError(t, err)
 	assert.Equal(t, mcmsProposal, *fileProposal)
+}
+
+func Test_Proposal_ChainSelectors(t *testing.T) {
+	t.Parallel()
+
+	proposal := MCMSProposal{
+		ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+			TestChain1: {},
+			TestChain2: {},
+			TestChain3: {},
+		},
+	}
+
+	want := []types.ChainSelector{TestChain1, TestChain3, TestChain2} // Sorted in ascending order
+	assert.Equal(t, want, proposal.ChainSelectors())
 }

--- a/mcms/signable_test.go
+++ b/mcms/signable_test.go
@@ -362,7 +362,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureMissingQuorum(t *te
 	// Validate the signatures
 	quorumMet, err := signable.ValidateSignatures()
 	require.Error(t, err)
-	require.IsType(t, &mcms_core.QuorumNotMetError{}, err)
+	require.IsType(t, &QuorumNotReachedError{}, err)
 	require.False(t, quorumMet)
 }
 

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -327,7 +327,7 @@ func Test_Config_CanSetRoot(t *testing.T) {
 			},
 			recoveredSigners: []common.Address{signer4},
 			want:             false,
-			wantErr:          "invalid signature: received signature for address 0x0000000000000000000000000000000000000004 is not a signer on MCMS 0x0000000000000000000000000000000000000000 on chain 0",
+			wantErr:          "invalid signature: received signature for address 0x0000000000000000000000000000000000000004 is not a signer on the MCMS contract",
 		},
 	}
 


### PR DESCRIPTION
Renames fields which are referencing the ChainSelector but are named ChainIdentifier.

Since some errors were also using this name, a small refactoring to move some errors out of `internal` and into the `mcms` package has also been made.