### PR TITLE
chore: refactor NewExecutable to be the main entry point to creating an executor

### DIFF
--- a/mcms/proposal.go
+++ b/mcms/proposal.go
@@ -157,22 +157,3 @@ func (m *MCMSProposal) Signable(isSim bool, inspectors map[types.ChainSelector]s
 
 	return NewSignable(m, encoders, inspectors)
 }
-
-func (m *MCMSProposal) Executable(isSim bool, executors map[types.ChainSelector]sdk.Executor) (*Executable, error) {
-	encoders, err := m.GetEncoders(isSim)
-	if err != nil {
-		return nil, err
-	}
-
-	inspectors := make(map[types.ChainSelector]sdk.Inspector)
-	for key, executor := range executors {
-		inspectors[key] = executor // since Executor implements Inspector, this works
-	}
-
-	signable, err := NewSignable(m, encoders, inspectors) // TODO: we should be able to pass executors here?
-	if err != nil {
-		return nil, err
-	}
-
-	return NewExecutable(signable, executors), nil
-}

--- a/mcms/signable.go
+++ b/mcms/signable.go
@@ -68,7 +68,12 @@ func NewSignable(
 			return nil, err
 		}
 
-		encodedOp, err := encoders[op.ChainSelector].HashOperation(
+		encoder, ok := encoders[op.ChainSelector]
+		if !ok {
+			return nil, errors.New("encoder not provided for chain " + strconv.FormatUint(uint64(op.ChainSelector), 10))
+		}
+
+		encodedOp, err := encoder.HashOperation(
 			chainNonce,
 			proposal.ChainMetadata[op.ChainSelector],
 			op,

--- a/mcms/timelock/proposal.go
+++ b/mcms/timelock/proposal.go
@@ -32,8 +32,6 @@ type MCMSWithTimelockProposal struct {
 	Transactions []types.BatchChainOperation `json:"transactions"`
 }
 
-var _ proposal.Proposal = (*MCMSWithTimelockProposal)(nil)
-
 // TODO: Could the input params be simplified here?
 func NewProposalWithTimeLock(
 	version string,
@@ -225,19 +223,9 @@ func (m *MCMSWithTimelockProposal) Validate() error {
 	return nil
 }
 
-func (m *MCMSWithTimelockProposal) Executable(sim bool, executors map[types.ChainSelector]sdk.Executor) (*mcms.Executable, error) {
-	// Convert the proposal to an MCMS only proposal
-	mcmOnly, errToMcms := m.toMCMSOnlyProposal()
-	if errToMcms != nil {
-		return nil, errToMcms
-	}
-
-	return mcmOnly.Executable(sim, executors)
-}
-
 func (m *MCMSWithTimelockProposal) Signable(isSim bool, inspectors map[types.ChainSelector]sdk.Inspector) (proposal.Signable, error) {
 	// Convert the proposal to an MCMS only proposal
-	mcmOnly, errToMcms := m.toMCMSOnlyProposal()
+	mcmOnly, errToMcms := m.ToMCMSOnlyProposal()
 	if errToMcms != nil {
 		return nil, errToMcms
 	}
@@ -245,7 +233,7 @@ func (m *MCMSWithTimelockProposal) Signable(isSim bool, inspectors map[types.Cha
 	return mcmOnly.Signable(isSim, inspectors)
 }
 
-func (m *MCMSWithTimelockProposal) toMCMSOnlyProposal() (mcms.MCMSProposal, error) {
+func (m *MCMSWithTimelockProposal) ToMCMSOnlyProposal() (mcms.MCMSProposal, error) {
 	mcmOnly := m.MCMSProposal
 
 	// Start predecessor map with all chains pointing to the zero hash

--- a/mcms/timelock/proposal_test.go
+++ b/mcms/timelock/proposal_test.go
@@ -224,7 +224,7 @@ func TestTimelockProposal_ToMCMSProposal(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	mcmsProposal, err := proposal.toMCMSOnlyProposal()
+	mcmsProposal, err := proposal.ToMCMSOnlyProposal()
 	require.NoError(t, err)
 
 	assert.Equal(t, "1.0", mcmsProposal.Version)


### PR DESCRIPTION
This removes the `ToExecutable` method on the proposal, and changes `NewExecutable` to accept a proposal and return an executor. This aligns more closely with go paradigms to inject dependencies into a struct, rather than the more OO approach of having a method on a struct that returns a new struct.