### PR TITLE
feat: using EVM simulated chains is now defined on a proposal

### DIFF
--- a/mcms/executable.go
+++ b/mcms/executable.go
@@ -17,34 +17,13 @@ type Executable struct {
 	Executors map[types.ChainSelector]sdk.Executor
 }
 
-// ExecutableOpts contain options for configuring how an Executable runs.
-type ExecutableOpts struct {
-	WithSimulatedBackend bool
-}
-
-// WithSimulatedBackend is an option for configuring an Executable to use a simulated backend.
-func WithSimulatedBackend() func(*ExecutableOpts) {
-	return func(opts *ExecutableOpts) {
-		opts.WithSimulatedBackend = true
-	}
-}
-
 // NewExecutable creates a new Executable from a proposal and a map of executors.
 func NewExecutable(
 	proposal *MCMSProposal,
 	executors map[types.ChainSelector]sdk.Executor,
-	optFuncs ...func(*ExecutableOpts),
 ) (*Executable, error) {
-	opts := ExecutableOpts{
-		WithSimulatedBackend: false,
-	}
-
-	for _, optFunc := range optFuncs {
-		optFunc(&opts)
-	}
-
 	// Get encoders for the proposal
-	encoders, err := proposal.GetEncoders(opts.WithSimulatedBackend)
+	encoders, err := proposal.GetEncoders()
 	if err != nil {
 		return nil, err
 	}

--- a/mcms/executable_test.go
+++ b/mcms/executable_test.go
@@ -66,6 +66,8 @@ func Test_NewExecutable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			tt.giveProposal.UseSimulatedBackend(true)
+
 			_, err := NewExecutable(tt.giveProposal, tt.giveExecutors)
 			require.Error(t, err)
 			assert.EqualError(t, err, tt.wantErr)
@@ -120,12 +122,13 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 			},
 		},
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -138,7 +141,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 	require.True(t, quorumMet)
 
 	// Construct encoders
-	encoders, err := proposal.GetEncoders(true)
+	encoders, err := proposal.GetEncoders()
 	require.NoError(t, err)
 
 	// Construct executors
@@ -147,7 +150,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 	}
 
 	// Construct executable
-	executable, err := NewExecutable(&proposal, executors, WithSimulatedBackend())
+	executable, err := NewExecutable(&proposal, executors)
 	require.NoError(t, err)
 
 	// SetRoot on the contract
@@ -229,12 +232,13 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 			},
 		},
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -250,7 +254,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 	require.True(t, quorumMet)
 
 	// Construct encoders
-	encoders, err := proposal.GetEncoders(true)
+	encoders, err := proposal.GetEncoders()
 	require.NoError(t, err)
 
 	// Construct executors
@@ -259,7 +263,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 	}
 
 	// Construct executable
-	executable, err := NewExecutable(&proposal, executors, WithSimulatedBackend())
+	executable, err := NewExecutable(&proposal, executors)
 	require.NoError(t, err)
 
 	// SetRoot on the contract
@@ -351,12 +355,13 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 		},
 		Transactions: operations,
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -369,7 +374,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 	require.True(t, quorumMet)
 
 	// Construct encoders
-	encoders, err := proposal.GetEncoders(true)
+	encoders, err := proposal.GetEncoders()
 	require.NoError(t, err)
 
 	// Construct executors
@@ -378,7 +383,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 	}
 
 	// Construct executable
-	executable, err := NewExecutable(&proposal, executors, WithSimulatedBackend())
+	executable, err := NewExecutable(&proposal, executors)
 	require.NoError(t, err)
 
 	// SetRoot on the contract
@@ -476,12 +481,13 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 		},
 		Transactions: operations,
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -497,7 +503,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 	require.True(t, quorumMet)
 
 	// Construct encoders
-	encoders, err := proposal.GetEncoders(true)
+	encoders, err := proposal.GetEncoders()
 	require.NoError(t, err)
 
 	// Construct executors
@@ -506,7 +512,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 	}
 
 	// Construct executable
-	executable, err := NewExecutable(&proposal, executors, WithSimulatedBackend())
+	executable, err := NewExecutable(&proposal, executors)
 	require.NoError(t, err)
 
 	// SetRoot on the contract

--- a/mcms/proposal_test.go
+++ b/mcms/proposal_test.go
@@ -274,6 +274,19 @@ func TestProposalFromFile(t *testing.T) {
 	assert.Equal(t, mcmsProposal, *fileProposal)
 }
 
+func Test_Proposal_UseSimulatedBackend(t *testing.T) {
+	t.Parallel()
+
+	proposal := MCMSProposal{
+		BaseProposal: BaseProposal{},
+	}
+
+	assert.False(t, proposal.useSimulatedBackend)
+
+	proposal.UseSimulatedBackend(true)
+	assert.True(t, proposal.useSimulatedBackend)
+}
+
 func Test_Proposal_ChainSelectors(t *testing.T) {
 	t.Parallel()
 

--- a/mcms/sign_test.go
+++ b/mcms/sign_test.go
@@ -86,7 +86,7 @@ func Test_Sign(t *testing.T) {
 			// Ensure that there are no signatures to being with
 			require.Empty(t, tt.give.Signatures)
 
-			signable, err := tt.give.Signable(true, inspectors)
+			signable, err := tt.give.Signable(inspectors)
 			require.NoError(t, err)
 			require.NotNil(t, signable)
 

--- a/mcms/signable_test.go
+++ b/mcms/signable_test.go
@@ -64,12 +64,13 @@ func TestSignable_SingleChainSingleSignerSingleTX_Success(t *testing.T) {
 			},
 		},
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -128,12 +129,13 @@ func TestSignable_SingleChainMultipleSignerSingleTX_Success(t *testing.T) {
 			},
 		},
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -204,12 +206,13 @@ func TestSignable_SingleChainSingleSignerMultipleTX_Success(t *testing.T) {
 		},
 		Transactions: operations,
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -277,12 +280,13 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_Success(t *testing.T) {
 		},
 		Transactions: operations,
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -353,12 +357,13 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureMissingQuorum(t *te
 		},
 		Transactions: operations,
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -435,12 +440,13 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureInvalidSigner(t *te
 		},
 		Transactions: operations,
 	}
+	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(true, inspectors)
+	signable, err := proposal.Signable(inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 

--- a/mcms/timelock/proposal.go
+++ b/mcms/timelock/proposal.go
@@ -121,14 +121,14 @@ func (m *MCMSWithTimelockProposal) Validate() error {
 	return nil
 }
 
-func (m *MCMSWithTimelockProposal) Signable(isSim bool, inspectors map[types.ChainSelector]sdk.Inspector) (proposal.Signable, error) {
+func (m *MCMSWithTimelockProposal) Signable(inspectors map[types.ChainSelector]sdk.Inspector) (proposal.Signable, error) {
 	// Convert the proposal to an MCMS only proposal
 	mcmOnly, errToMcms := m.toMCMSOnlyProposal()
 	if errToMcms != nil {
 		return nil, errToMcms
 	}
 
-	return mcmOnly.Signable(isSim, inspectors)
+	return mcmOnly.Signable(inspectors)
 }
 
 func (m *MCMSWithTimelockProposal) toMCMSOnlyProposal() (mcms.MCMSProposal, error) {


### PR DESCRIPTION
A new private field `useSimulatedBackend` has been added to the MCMSProposal struct, which is used to determine whether the proposal should be executed on a simulated chain. For EVM, this overwrites the EVMChainID, however every chain family sdk may implement this differently.

This does not aim to modify the JSON representation of the proposal. Instead, usage of simulated backends will be done by calling the `UseSimulatedBackend` function on the proposal after marshalling the JSON.

This allows us to avoid passing in an `isSim` boolean around to multiple functions, so that we can read it from the proposal itself.