### PR TITLE
chore: remove verbose flag from test task

### DIFF
--- a/taskfiles/test/Taskfile.yml
+++ b/taskfiles/test/Taskfile.yml
@@ -4,7 +4,7 @@ tasks:
   default:
     desc: "Run the entire test suite"
     cmds:
-      - go test -v ./...
+      - go test {{.CLI_ARGS}} ./...
 
   coverage:
     desc: "Run the entire test suite with coverage"


### PR DESCRIPTION
This removes the verbose flag from the test task in the test Taskfile as it was very noisy and not very useful.

If verbose is needed, this is now available as a flag to the task.

`task test -- -v`