### PR TITLE
chore: removes the signable dependency on the executor

### DIFF
--- a/executable_test.go
+++ b/executable_test.go
@@ -1,12 +1,12 @@
 package mcms
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/mcms/internal/testutils/evmsim"
@@ -34,6 +34,7 @@ func Test_NewExecutable(t *testing.T) {
 			name: "failure: could not get encoders from proposal (invalid chain selector)",
 			giveProposal: &MCMSProposal{
 				BaseProposal: BaseProposal{
+					OverridePreviousRoot: false,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
 						types.ChainSelector(1): {},
 					},
@@ -42,23 +43,46 @@ func Test_NewExecutable(t *testing.T) {
 			giveExecutors: map[types.ChainSelector]sdk.Executor{
 				types.ChainSelector(1): executor,
 			},
-			wantErr: "invalid chain ID: 1",
+			wantErr: "unable to create encoder: invalid chain ID: 1",
 		},
 		{
-			name: "failure: could not create a signable from the proposal",
+			name: "failure: could not generate tx nonces from proposal (tx does not have matching chain metadata)",
 			giveProposal: &MCMSProposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {},
+						TestChain1: {StartingOpCount: 5},
 					},
 				},
 				Transactions: []types.ChainOperation{
-					// transaction does not match any encoder for the chain
-					{ChainSelector: types.ChainSelector(1)},
+					{ChainSelector: TestChain2},
 				},
 			},
-			giveExecutors: map[types.ChainSelector]sdk.Executor{},
-			wantErr:       "encoder not provided for chain 1",
+			giveExecutors: map[types.ChainSelector]sdk.Executor{
+				types.ChainSelector(1): executor,
+			},
+			wantErr: "missing metadata for chain 16015286601757825753",
+		},
+		{
+			name: "failure: could not generate tree from proposal (invalid additional values)",
+			giveProposal: &MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {StartingOpCount: 5},
+					},
+				},
+				Transactions: []types.ChainOperation{
+					{
+						ChainSelector: TestChain1,
+						Operation: types.Operation{
+							AdditionalFields: json.RawMessage([]byte(``)),
+						},
+					},
+				},
+			},
+			giveExecutors: map[types.ChainSelector]sdk.Executor{
+				types.ChainSelector(1): executor,
+			},
+			wantErr: "merkle tree generation error: unexpected end of JSON input",
 		},
 	}
 
@@ -66,11 +90,9 @@ func Test_NewExecutable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.giveProposal.UseSimulatedBackend(true)
-
 			_, err := NewExecutable(tt.giveProposal, tt.giveExecutors)
-			require.Error(t, err)
-			assert.EqualError(t, err, tt.wantErr)
+
+			require.EqualError(t, err, tt.wantErr)
 		})
 	}
 }

--- a/proposal.go
+++ b/proposal.go
@@ -1,6 +1,7 @@
 package mcms
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/go-playground/validator/v10"
 
 	"github.com/smartcontractkit/mcms/internal/core"
@@ -182,6 +184,26 @@ func (m *MCMSProposal) MerkleTree() (*merkle.Tree, error) {
 	return merkle.NewTree(hashLeaves), nil
 }
 
+func (m *MCMSProposal) SigningHash() (common.Hash, error) {
+	tree, err := m.MerkleTree()
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	// Convert validUntil to [32]byte
+	var validUntilBytes [32]byte
+	binary.BigEndian.PutUint32(validUntilBytes[28:], m.ValidUntil) // Place the uint32 in the last 4 bytes
+
+	hashToSign := crypto.Keccak256Hash(tree.Root.Bytes(), validUntilBytes[:])
+
+	return toEthSignedMessageHash(hashToSign), nil
+}
+
+// We may need to put this back in
+// func (e *Executor) SigningMessage() ([]byte, error) {
+// 	return ABIEncode(`[{"type":"bytes32"},{"type":"uint32"}]`, s.Tree.Root, s.Proposal.ValidUntil)
+// }
+
 // TransactionCounts returns a map of chain selectors to the number of transactions for that chain
 func (m *MCMSProposal) TransactionCounts() map[types.ChainSelector]uint64 {
 	txCounts := make(map[types.ChainSelector]uint64)
@@ -235,7 +257,7 @@ func (m *MCMSProposal) GetEncoders() (map[types.ChainSelector]sdk.Encoder, error
 	for chainSelector := range m.ChainMetadata {
 		encoder, err := sdk.NewEncoder(chainSelector, txCounts[chainSelector], m.OverridePreviousRoot, m.useSimulatedBackend)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to create encoder: %w", err)
 		}
 
 		encoders[chainSelector] = encoder
@@ -252,6 +274,15 @@ func (m *MCMSProposal) Signable(inspectors map[types.ChainSelector]sdk.Inspector
 	}
 
 	return NewSignable(m, encoders, inspectors)
+}
+
+func toEthSignedMessageHash(messageHash common.Hash) common.Hash {
+	// Add the Ethereum signed message prefix
+	prefix := []byte("\x19Ethereum Signed Message:\n32")
+	data := append(prefix, messageHash.Bytes()...)
+
+	// Hash the prefixed message
+	return crypto.Keccak256Hash(data)
 }
 
 // proposalValidateBasic basic validation for an MCMS proposal

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -49,7 +49,7 @@ func Test_Proposal_Validate(t *testing.T) {
 						ChainSelector: TestChain1,
 						Operation: types.Operation{
 							To:               TestAddress,
-							AdditionalFields: json.RawMessage([]byte(`{"value": "0"}`)),
+							AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
 							Data:             common.Hex2Bytes("0x"),
 							OperationMetadata: types.OperationMetadata{
 								ContractType: "Sample contract",
@@ -269,7 +269,7 @@ func Test_Proposal_GetEncoders(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "invalid chain ID: 1",
+			wantErr: "unable to create encoder: invalid chain ID: 1",
 		},
 	}
 
@@ -376,7 +376,7 @@ func Test_Proposal_MerkleTree(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "merkle tree generation error: invalid chain ID: 1",
+			wantErr: "merkle tree generation error: unable to create encoder: invalid chain ID: 1",
 		},
 		{
 			name: "failure: missing metadata when fetching nonces",

--- a/signable.go
+++ b/signable.go
@@ -1,13 +1,11 @@
 package mcms
 
 import (
-	"encoding/binary"
 	"errors"
 	"sort"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/smartcontractkit/mcms/internal/core/merkle"
 	coreProposal "github.com/smartcontractkit/mcms/internal/core/proposal"
@@ -108,29 +106,6 @@ func (s *Signable) GetTree() *merkle.Tree {
 
 func (s *Signable) ChainNonce(index int) uint64 {
 	return s.ChainNonces[index]
-}
-
-func (s *Signable) SigningHash() (common.Hash, error) {
-	// Convert validUntil to [32]byte
-	var validUntilBytes [32]byte
-	binary.BigEndian.PutUint32(validUntilBytes[28:], s.ValidUntil) // Place the uint32 in the last 4 bytes
-
-	hashToSign := crypto.Keccak256Hash(s.Tree.Root.Bytes(), validUntilBytes[:])
-
-	return toEthSignedMessageHash(hashToSign), nil
-}
-
-// func (e *Executor) SigningMessage() ([]byte, error) {
-// 	return ABIEncode(`[{"type":"bytes32"},{"type":"uint32"}]`, s.Tree.Root, s.Proposal.ValidUntil)
-// }
-
-func toEthSignedMessageHash(messageHash common.Hash) common.Hash {
-	// Add the Ethereum signed message prefix
-	prefix := []byte("\x19Ethereum Signed Message:\n32")
-	data := append(prefix, messageHash.Bytes()...)
-
-	// Hash the prefixed message
-	return crypto.Keccak256Hash(data)
 }
 
 func (s *Signable) GetCurrentOpCounts() (map[types.ChainSelector]uint64, error) {


### PR DESCRIPTION
The Executor now fetches all the data it requires directly from the proposal. This simplifies the code and decouples the Executor from Signable, ensuring all shared code is in the proposal struct itself