### PR TITLE
chore: refactor signable to fetch data from the proposal

### DIFF
--- a/executable_test.go
+++ b/executable_test.go
@@ -146,11 +146,14 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 	}
 	proposal.UseSimulatedBackend(true)
 
+	tree, err := proposal.MerkleTree()
+	require.NoError(t, err)
+
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -184,7 +187,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 	// Validate Contract State and verify root was set
 	root, err := mcmC.GetRoot(&bind.CallOpts{})
 	require.NoError(t, err)
-	require.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
+	require.Equal(t, root.Root, [32]byte(tree.Root.Bytes()))
 	require.Equal(t, root.ValidUntil, proposal.ValidUntil)
 
 	// Execute the proposal
@@ -256,11 +259,14 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 	}
 	proposal.UseSimulatedBackend(true)
 
+	tree, err := proposal.MerkleTree()
+	require.NoError(t, err)
+
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -297,7 +303,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 	// Validate Contract State and verify root was set
 	root, err := mcmC.GetRoot(&bind.CallOpts{})
 	require.NoError(t, err)
-	require.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
+	require.Equal(t, root.Root, [32]byte(tree.Root.Bytes()))
 	require.Equal(t, root.ValidUntil, proposal.ValidUntil)
 
 	// Execute the proposal
@@ -379,11 +385,14 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 	}
 	proposal.UseSimulatedBackend(true)
 
+	tree, err := proposal.MerkleTree()
+	require.NoError(t, err)
+
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -417,7 +426,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 	// Validate Contract State and verify root was set
 	root, err := mcmC.GetRoot(&bind.CallOpts{})
 	require.NoError(t, err)
-	require.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
+	require.Equal(t, root.Root, [32]byte(tree.Root.Bytes()))
 	require.Equal(t, root.ValidUntil, proposal.ValidUntil)
 
 	// Execute the proposal
@@ -505,11 +514,14 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 	}
 	proposal.UseSimulatedBackend(true)
 
+	tree, err := proposal.MerkleTree()
+	require.NoError(t, err)
+
 	// Gen caller map for easy access
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -547,7 +559,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 	// Validate Contract State and verify root was set
 	root, err := mcmC.GetRoot(&bind.CallOpts{})
 	require.NoError(t, err)
-	require.Equal(t, root.Root, [32]byte(signable.GetTree().Root.Bytes()))
+	require.Equal(t, root.Root, [32]byte(tree.Root.Bytes()))
 	require.Equal(t, root.ValidUntil, proposal.ValidUntil)
 
 	// Execute the proposal

--- a/internal/core/proposal/types.go
+++ b/internal/core/proposal/types.go
@@ -1,9 +1,6 @@
 package proposal
 
 import (
-	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/mcms/internal/core/merkle"
 	"github.com/smartcontractkit/mcms/types"
 )
 
@@ -19,16 +16,6 @@ const (
 var StringToProposalType = map[string]ProposalType{
 	"MCMS":             MCMS,
 	"MCMSWithTimelock": MCMSWithTimelock,
-}
-
-type Signable interface {
-	SigningHash() (common.Hash, error)
-	GetCurrentOpCounts() (map[types.ChainSelector]uint64, error)
-	GetConfigs() (map[types.ChainSelector]*types.Config, error)
-	CheckQuorum(chain types.ChainSelector) (bool, error)
-	ValidateSignatures() (bool, error)
-	ValidateConfigs() error
-	GetTree() *merkle.Tree
 }
 
 type Executable interface {

--- a/proposal.go
+++ b/proposal.go
@@ -266,16 +266,6 @@ func (m *MCMSProposal) GetEncoders() (map[types.ChainSelector]sdk.Encoder, error
 	return encoders, nil
 }
 
-// TODO: isSim is very EVM and test Specific. Should be removed
-func (m *MCMSProposal) Signable(inspectors map[types.ChainSelector]sdk.Inspector) (*Signable, error) {
-	encoders, err := m.GetEncoders()
-	if err != nil {
-		return nil, err
-	}
-
-	return NewSignable(m, encoders, inspectors)
-}
-
 func toEthSignedMessageHash(messageHash common.Hash) common.Hash {
 	// Add the Ethereum signed message prefix
 	prefix := []byte("\x19Ethereum Signed Message:\n32")

--- a/sign.go
+++ b/sign.go
@@ -14,7 +14,7 @@ import (
 // Sign signs the proposal using the provided signer.
 func Sign(signable *Signable, signer Signer) error {
 	// Validate proposal
-	if err := signable.MCMSProposal.Validate(); err != nil {
+	if err := signable.Validate(); err != nil {
 		return err
 	}
 

--- a/signable.go
+++ b/signable.go
@@ -2,145 +2,89 @@ package mcms
 
 import (
 	"errors"
-	"sort"
+	"fmt"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/mcms/internal/core/merkle"
-	coreProposal "github.com/smartcontractkit/mcms/internal/core/proposal"
-	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/types"
 )
 
+var (
+	ErrInspectorsNotProvided = errors.New("inspectors not provided")
+)
+
+// Signable provides signing functionality for an MCMSProposal. It contains all the necessary
+// information required to validate, sign, and check the quorum of a proposal.
+
+// Signable contains the proposal itself, a Merkle tree representation of the proposal, encoders for
+// different chains to perform the signing, while the inspectors are used for retrieving contract
+// configurations and operational counts on chain.
 type Signable struct {
-	*MCMSProposal
-	*merkle.Tree
-
-	// Map of operation to chain index where tx i is the ChainNonce[i]th
-	// operation of chain Transaction[i].ChainSelector
-	ChainNonces []uint64
-
-	Encoders   map[types.ChainSelector]sdk.Encoder
-	Inspectors map[types.ChainSelector]sdk.Inspector // optional, skip any inspections
-	Simulators map[types.ChainSelector]sdk.Simulator // optional, skip simulations
-	Decoders   map[types.ChainSelector]sdk.Decoder   // optional, skip decoding
+	proposal   *MCMSProposal
+	tree       *merkle.Tree
+	encoders   map[types.ChainSelector]sdk.Encoder
+	inspectors map[types.ChainSelector]sdk.Inspector
 }
 
-var _ coreProposal.Signable = (*Signable)(nil)
-
+// NewSignable creates a new Signable from a proposal and inspectors, and initializes the encoders
+// and merkle tree.
 func NewSignable(
 	proposal *MCMSProposal,
-	encoders map[types.ChainSelector]sdk.Encoder,
 	inspectors map[types.ChainSelector]sdk.Inspector,
 ) (*Signable, error) {
-	hashLeaves := make([]common.Hash, 0)
-	chainIdx := make(map[types.ChainSelector]uint64, len(proposal.ChainMetadata))
-
-	for _, chain := range proposal.ChainSelectors() {
-		encoder, ok := encoders[chain]
-		if !ok {
-			return nil, errors.New("encoder not provided for chain " + strconv.FormatUint(uint64(chain), 10))
-		}
-
-		metadata, ok := proposal.ChainMetadata[chain]
-		if !ok {
-			return nil, errors.New("metadata not provided for chain " + strconv.FormatUint(uint64(chain), 10))
-		}
-
-		encodedRootMetadata, err := encoder.HashMetadata(metadata)
-		if err != nil {
-			return nil, err
-		}
-		hashLeaves = append(hashLeaves, encodedRootMetadata)
-
-		// Set the initial chainIdx to the starting nonce in the metadata
-		chainIdx[chain] = metadata.StartingOpCount
+	encoders, err := proposal.GetEncoders()
+	if err != nil {
+		return nil, err
 	}
 
-	chainNonces := make([]uint64, len(proposal.Transactions))
-	for i, op := range proposal.Transactions {
-		chainNonce, err := safecast.Uint64ToUint32(chainIdx[op.ChainSelector])
-		if err != nil {
-			return nil, err
-		}
-
-		encoder, ok := encoders[op.ChainSelector]
-		if !ok {
-			return nil, errors.New("encoder not provided for chain " + strconv.FormatUint(uint64(op.ChainSelector), 10))
-		}
-
-		encodedOp, err := encoder.HashOperation(
-			chainNonce,
-			proposal.ChainMetadata[op.ChainSelector],
-			op,
-		)
-		if err != nil {
-			return nil, err
-		}
-		hashLeaves = append(hashLeaves, encodedOp)
-
-		// Increment chain idx
-		chainNonces[i] = chainIdx[op.ChainSelector]
-		chainIdx[op.ChainSelector]++
+	tree, err := proposal.MerkleTree()
+	if err != nil {
+		return nil, err
 	}
-
-	// sort the hashes and sort the pairs
-	sort.Slice(hashLeaves, func(i, j int) bool {
-		return hashLeaves[i].String() < hashLeaves[j].String()
-	})
 
 	return &Signable{
-		MCMSProposal: proposal,
-		Tree:         merkle.NewTree(hashLeaves),
-		Encoders:     encoders,
-		Inspectors:   inspectors,
-		ChainNonces:  chainNonces,
+		proposal:   proposal,
+		tree:       tree,
+		encoders:   encoders,
+		inspectors: inspectors,
 	}, nil
 }
 
-func (s *Signable) GetTree() *merkle.Tree {
-	return s.Tree
+// Validate checks the proposal is valid and signable.
+//
+// This can be removed once the Sign method is implemented on this struct.
+func (s *Signable) Validate() error {
+	return s.proposal.Validate()
 }
 
-func (s *Signable) ChainNonce(index int) uint64 {
-	return s.ChainNonces[index]
+// SigningHash returns the hash of the proposal that should be signed. This is a delegate method to
+// the underlying proposal.
+//
+// This can be removed once the Sign method is implemented on this struct.
+func (s *Signable) SigningHash() (common.Hash, error) {
+	return s.proposal.SigningHash()
 }
 
-func (s *Signable) GetCurrentOpCounts() (map[types.ChainSelector]uint64, error) {
-	if s.Inspectors == nil {
-		return nil, errors.New("inspectors not provided")
-	}
-
-	opCounts := make(map[types.ChainSelector]uint64)
-	for chain, metadata := range s.ChainMetadata {
-		inspector, ok := s.Inspectors[chain]
-		if !ok {
-			return nil, errors.New("inspector not found for chain " + strconv.FormatUint(uint64(chain), 10))
-		}
-
-		opCount, err := inspector.GetOpCount(metadata.MCMAddress)
-		if err != nil {
-			return nil, err
-		}
-
-		opCounts[chain] = opCount
-	}
-
-	return opCounts, nil
+// AddSignature adds a signature to the underlying proposal. This is a delegate method to the
+// underlying proposal.
+func (s *Signable) AddSignature(signature types.Signature) {
+	s.proposal.AddSignature(signature)
 }
 
+// GetConfigs retrieves the MCMS contract configurations for each chain in the proposal.
 func (s *Signable) GetConfigs() (map[types.ChainSelector]*types.Config, error) {
-	if s.Inspectors == nil {
-		return nil, errors.New("inspectors not provided")
+	if s.inspectors == nil {
+		return nil, ErrInspectorsNotProvided
 	}
 
 	configs := make(map[types.ChainSelector]*types.Config)
-	for chain, metadata := range s.ChainMetadata {
-		inspector, ok := s.Inspectors[chain]
+	for chain, metadata := range s.proposal.ChainMetadata {
+		inspector, ok := s.inspectors[chain]
 		if !ok {
-			return nil, errors.New("inspector not found for chain " + strconv.FormatUint(uint64(chain), 10))
+			return nil, fmt.Errorf("inspector not found for chain %d", chain)
 		}
 
 		configuration, err := inspector.GetConfig(metadata.MCMAddress)
@@ -154,23 +98,26 @@ func (s *Signable) GetConfigs() (map[types.ChainSelector]*types.Config, error) {
 	return configs, nil
 }
 
+// CheckQuorum checks if the quorum for the proposal on the given chain has been reached. This will
+// fetch the current configuration for the chain and check if the recovered signers from the
+// proposal's signatures can set the root.
 func (s *Signable) CheckQuorum(chain types.ChainSelector) (bool, error) {
-	if s.Inspectors == nil {
-		return false, errors.New("inspectors not provided")
+	if s.inspectors == nil {
+		return false, ErrInspectorsNotProvided
 	}
 
-	inspector, ok := s.Inspectors[chain]
+	inspector, ok := s.inspectors[chain]
 	if !ok {
 		return false, errors.New("inspector not found for chain " + strconv.FormatUint(uint64(chain), 10))
 	}
 
-	hash, err := s.SigningHash()
+	hash, err := s.proposal.SigningHash()
 	if err != nil {
 		return false, err
 	}
 
-	recoveredSigners := make([]common.Address, len(s.Signatures))
-	for i, sig := range s.Signatures {
+	recoveredSigners := make([]common.Address, len(s.proposal.Signatures))
+	for i, sig := range s.proposal.Signatures {
 		recoveredAddr, rerr := sig.Recover(hash)
 		if rerr != nil {
 			return false, rerr
@@ -179,7 +126,7 @@ func (s *Signable) CheckQuorum(chain types.ChainSelector) (bool, error) {
 		recoveredSigners[i] = recoveredAddr
 	}
 
-	configuration, err := inspector.GetConfig(s.ChainMetadata[chain].MCMAddress)
+	configuration, err := inspector.GetConfig(s.proposal.ChainMetadata[chain].MCMAddress)
 	if err != nil {
 		return false, err
 	}
@@ -188,7 +135,7 @@ func (s *Signable) CheckQuorum(chain types.ChainSelector) (bool, error) {
 }
 
 func (s *Signable) ValidateSignatures() (bool, error) {
-	for chain := range s.ChainMetadata {
+	for chain := range s.proposal.ChainMetadata {
 		checkQuorum, err := s.CheckQuorum(chain)
 		if err != nil {
 			return false, err
@@ -202,24 +149,56 @@ func (s *Signable) ValidateSignatures() (bool, error) {
 	return true, nil
 }
 
+// ValidateConfigs checks the MCMS contract configurations for each chain in the proposal for
+// consistency.
+//
+// We expect that the configurations for each chain are the same so that the same quorum can be
+// reached across all chains in the proposal.
 func (s *Signable) ValidateConfigs() error {
 	configs, err := s.GetConfigs()
 	if err != nil {
 		return err
 	}
 
-	for i, chain := range s.ChainSelectors() {
+	for i, sel := range s.proposal.ChainSelectors() {
 		if i == 0 {
 			continue
 		}
 
-		if !configs[chain].Equals(configs[s.ChainSelectors()[i-1]]) {
+		if !configs[sel].Equals(configs[s.proposal.ChainSelectors()[i-1]]) {
 			return &InconsistentConfigsError{
-				ChainSelectorA: chain,
-				ChainSelectorB: s.ChainSelectors()[i-1],
+				ChainSelectorA: sel,
+				ChainSelectorB: s.proposal.ChainSelectors()[i-1],
 			}
 		}
 	}
 
 	return nil
+}
+
+// getCurrentOpCounts returns the current op counts for the MCM contract on each chain in the
+// proposal. This data is fetched from the contract on the chain using the provided inspectors.
+//
+// Note: This function is currently not used but left for potential future use.
+func (s *Signable) getCurrentOpCounts() (map[types.ChainSelector]uint64, error) {
+	if s.inspectors == nil {
+		return nil, ErrInspectorsNotProvided
+	}
+
+	opCounts := make(map[types.ChainSelector]uint64)
+	for sel, metadata := range s.proposal.ChainMetadata {
+		inspector, ok := s.inspectors[sel]
+		if !ok {
+			return nil, fmt.Errorf("inspector not found for chain %d", sel)
+		}
+
+		opCount, err := inspector.GetOpCount(metadata.MCMAddress)
+		if err != nil {
+			return nil, err
+		}
+
+		opCounts[sel] = opCount
+	}
+
+	return opCounts, nil
 }

--- a/signable_test.go
+++ b/signable_test.go
@@ -1,12 +1,14 @@
 package mcms
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	mcms_core "github.com/smartcontractkit/mcms/internal/core"
@@ -14,10 +16,79 @@ import (
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
+	"github.com/smartcontractkit/mcms/sdk/mocks"
+	sdkmocks "github.com/smartcontractkit/mcms/sdk/mocks"
 	"github.com/smartcontractkit/mcms/types"
 )
 
-// TODO: Should go to EVM SDK
+type inspectorMocks struct {
+	inspector1 *sdkmocks.Inspector
+	inspector2 *sdkmocks.Inspector
+}
+
+func Test_NewSignable(t *testing.T) {
+	t.Parallel()
+
+	var (
+		inspector = mocks.NewInspector(t) // We only need this to fulfill the interface argument requirements
+	)
+
+	tests := []struct {
+		name           string
+		giveProposal   *MCMSProposal
+		giveInspectors map[types.ChainSelector]sdk.Inspector
+		wantErr        string
+	}{
+		{
+			name: "failure: could not get encoders from proposal (invalid chain selector)",
+			giveProposal: &MCMSProposal{
+				BaseProposal: BaseProposal{
+					OverridePreviousRoot: false,
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						types.ChainSelector(1): {},
+					},
+				},
+			},
+			giveInspectors: map[types.ChainSelector]sdk.Inspector{
+				types.ChainSelector(1): inspector,
+			},
+			wantErr: "unable to create encoder: invalid chain ID: 1",
+		},
+		{
+			name: "failure: could not generate tree from proposal (invalid additional values)",
+			giveProposal: &MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {StartingOpCount: 5},
+					},
+				},
+				Transactions: []types.ChainOperation{
+					{
+						ChainSelector: TestChain1,
+						Operation: types.Operation{
+							AdditionalFields: json.RawMessage([]byte(``)),
+						},
+					},
+				},
+			},
+			giveInspectors: map[types.ChainSelector]sdk.Inspector{
+				types.ChainSelector(1): inspector,
+			},
+			wantErr: "merkle tree generation error: unexpected end of JSON input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewSignable(tt.giveProposal, tt.giveInspectors)
+
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestSignable_SingleChainSingleSignerSingleTX_Success(t *testing.T) {
 	t.Parallel()
 
@@ -70,7 +141,7 @@ func TestSignable_SingleChainSingleSignerSingleTX_Success(t *testing.T) {
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -135,7 +206,7 @@ func TestSignable_SingleChainMultipleSignerSingleTX_Success(t *testing.T) {
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -212,7 +283,7 @@ func TestSignable_SingleChainSingleSignerMultipleTX_Success(t *testing.T) {
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -286,7 +357,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_Success(t *testing.T) {
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -363,7 +434,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureMissingQuorum(t *te
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -446,7 +517,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureInvalidSigner(t *te
 	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
-	signable, err := proposal.Signable(inspectors)
+	signable, err := NewSignable(&proposal, inspectors)
 	require.NoError(t, err)
 	require.NotNil(t, signable)
 
@@ -465,4 +536,336 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureInvalidSigner(t *te
 	require.Error(t, err)
 	require.IsType(t, &mcms_core.InvalidSignatureError{}, err)
 	require.False(t, quorumMet)
+}
+
+func Test_Signable_AddSignature(t *testing.T) {
+	t.Parallel()
+
+	proposal := MCMSProposal{}
+	signable := &Signable{proposal: &proposal}
+
+	require.Empty(t, proposal.Signatures)
+	signable.AddSignature(types.Signature{})
+	require.Len(t, proposal.Signatures, 1)
+}
+
+func Test_Signable_GetConfigs(t *testing.T) {
+	t.Parallel()
+
+	var (
+		config1 = &types.Config{}
+		config2 = &types.Config{}
+	)
+
+	tests := []struct {
+		name           string
+		give           MCMSProposal
+		giveInspectors func(*inspectorMocks) map[types.ChainSelector]sdk.Inspector
+		want           map[types.ChainSelector]*types.Config
+		wantErr        string
+	}{
+		{
+			name: "success",
+			give: MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {MCMAddress: "0x01"},
+						TestChain2: {MCMAddress: "0x02"},
+					},
+				},
+			},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				m.inspector1.EXPECT().GetConfig("0x01").Return(config1, nil)
+				m.inspector2.EXPECT().GetConfig("0x02").Return(config2, nil)
+
+				return map[types.ChainSelector]sdk.Inspector{
+					TestChain1: m.inspector1,
+					TestChain2: m.inspector2,
+				}
+			},
+			want: map[types.ChainSelector]*types.Config{
+				TestChain1: config1,
+				TestChain2: config2,
+			},
+		},
+		{
+			name: "failure: no inspectors",
+			give: MCMSProposal{},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				return nil
+			},
+			wantErr: ErrInspectorsNotProvided.Error(),
+		},
+		{
+			name: "failure: inspector not found",
+			give: MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {MCMAddress: "0x01"},
+					},
+				},
+			},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				return map[types.ChainSelector]sdk.Inspector{}
+			},
+			wantErr: "inspector not found for chain 3379446385462418246",
+		},
+		{
+			name: "failure: on chain get config failure",
+			give: MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {MCMAddress: "0x01"},
+					},
+				},
+			},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				m.inspector1.EXPECT().GetConfig("0x01").Return(nil, assert.AnError)
+
+				return map[types.ChainSelector]sdk.Inspector{
+					TestChain1: m.inspector1,
+				}
+			},
+			wantErr: assert.AnError.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			inspector1 := sdkmocks.NewInspector(t)
+			inspector2 := sdkmocks.NewInspector(t)
+
+			giveInspectors := tt.giveInspectors(&inspectorMocks{
+				inspector1: inspector1,
+				inspector2: inspector2,
+			})
+
+			signable := &Signable{
+				proposal:   &tt.give,
+				inspectors: giveInspectors,
+			}
+
+			configs, err := signable.GetConfigs()
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, configs)
+			}
+		})
+	}
+}
+
+func Test_Signable_ValidateConfigs(t *testing.T) {
+	t.Parallel()
+
+	var (
+		signer1 = common.HexToAddress("0x1")
+		signer2 = common.HexToAddress("0x2")
+
+		config1 = &types.Config{
+			Quorum:  1,
+			Signers: []common.Address{signer1},
+		}
+		config2 = &types.Config{ // Same as config1
+			Quorum:  1,
+			Signers: []common.Address{signer1},
+		}
+		config3 = &types.Config{ // Different from config1
+			Quorum:  2,
+			Signers: []common.Address{signer1, signer2},
+		}
+	)
+
+	tests := []struct {
+		name           string
+		give           MCMSProposal
+		giveInspectors func(*inspectorMocks) map[types.ChainSelector]sdk.Inspector
+		wantErr        string
+	}{
+		{
+			name: "success",
+			give: MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {MCMAddress: "0x01"},
+						TestChain2: {MCMAddress: "0x02"},
+					},
+				},
+			},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				m.inspector1.EXPECT().GetConfig("0x01").Return(config1, nil)
+				m.inspector2.EXPECT().GetConfig("0x02").Return(config2, nil)
+
+				return map[types.ChainSelector]sdk.Inspector{
+					TestChain1: m.inspector1,
+					TestChain2: m.inspector2,
+				}
+			},
+		},
+		{
+			name: "failure: could not get configs",
+			give: MCMSProposal{},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				return nil
+			},
+			wantErr: ErrInspectorsNotProvided.Error(),
+		},
+		{
+			name: "failure: not equal",
+			give: MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {MCMAddress: "0x01"},
+						TestChain2: {MCMAddress: "0x02"},
+					},
+				},
+			},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				m.inspector1.EXPECT().GetConfig("0x01").Return(config1, nil)
+				m.inspector2.EXPECT().GetConfig("0x02").Return(config3, nil)
+
+				return map[types.ChainSelector]sdk.Inspector{
+					TestChain1: m.inspector1,
+					TestChain2: m.inspector2,
+				}
+			},
+			wantErr: "inconsistent configs for chains 16015286601757825753 and 3379446385462418246",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			inspector1 := sdkmocks.NewInspector(t)
+			inspector2 := sdkmocks.NewInspector(t)
+
+			giveInspectors := tt.giveInspectors(&inspectorMocks{
+				inspector1: inspector1,
+				inspector2: inspector2,
+			})
+
+			signable := &Signable{
+				proposal:   &tt.give,
+				inspectors: giveInspectors,
+			}
+
+			err := signable.ValidateConfigs()
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_Signable_getCurrentOpCounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		give           MCMSProposal
+		giveInspectors func(*inspectorMocks) map[types.ChainSelector]sdk.Inspector
+		want           map[types.ChainSelector]uint64
+		wantErr        string
+	}{
+		{
+			name: "success",
+			give: MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {MCMAddress: "0x01"},
+						TestChain2: {MCMAddress: "0x02"},
+					},
+				},
+			},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				m.inspector1.EXPECT().GetOpCount("0x01").Return(100, nil)
+				m.inspector2.EXPECT().GetOpCount("0x02").Return(200, nil)
+
+				return map[types.ChainSelector]sdk.Inspector{
+					TestChain1: m.inspector1,
+					TestChain2: m.inspector2,
+				}
+			},
+			want: map[types.ChainSelector]uint64{
+				TestChain1: 100,
+				TestChain2: 200,
+			},
+		},
+		{
+			name: "failure: could not get configs",
+			give: MCMSProposal{},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				return nil
+			},
+			wantErr: ErrInspectorsNotProvided.Error(),
+		},
+		{
+			name: "failure: inspector not found",
+			give: MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {MCMAddress: "0x01"},
+					},
+				},
+			},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				return map[types.ChainSelector]sdk.Inspector{}
+			},
+			wantErr: "inspector not found for chain 3379446385462418246",
+		},
+		{
+			name: "failure: on chain GetOpCount failure",
+			give: MCMSProposal{
+				BaseProposal: BaseProposal{
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						TestChain1: {MCMAddress: "0x01"},
+					},
+				},
+			},
+			giveInspectors: func(m *inspectorMocks) map[types.ChainSelector]sdk.Inspector {
+				m.inspector1.EXPECT().GetOpCount("0x01").Return(0, assert.AnError)
+
+				return map[types.ChainSelector]sdk.Inspector{
+					TestChain1: m.inspector1,
+				}
+			},
+			wantErr: assert.AnError.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			inspector1 := sdkmocks.NewInspector(t)
+			inspector2 := sdkmocks.NewInspector(t)
+
+			giveInspectors := tt.giveInspectors(&inspectorMocks{
+				inspector1: inspector1,
+				inspector2: inspector2,
+			})
+
+			signable := &Signable{
+				proposal:   &tt.give,
+				inspectors: giveInspectors,
+			}
+
+			got, err := signable.getCurrentOpCounts()
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
 }

--- a/timelock_proposal.go
+++ b/timelock_proposal.go
@@ -8,9 +8,7 @@ import (
 	"github.com/go-playground/validator/v10"
 
 	"github.com/smartcontractkit/mcms/internal/core"
-	"github.com/smartcontractkit/mcms/internal/core/proposal"
 	"github.com/smartcontractkit/mcms/internal/utils/safecast"
-	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/types"
 )
 
@@ -118,16 +116,6 @@ func (m *MCMSWithTimelockProposal) Validate() error {
 	}
 
 	return nil
-}
-
-func (m *MCMSWithTimelockProposal) Signable(inspectors map[types.ChainSelector]sdk.Inspector) (proposal.Signable, error) {
-	// Convert the proposal to an MCMS only proposal
-	mcmOnly, errToMcms := m.Convert()
-	if errToMcms != nil {
-		return nil, errToMcms
-	}
-
-	return mcmOnly.Signable(inspectors)
 }
 
 // Convert the proposal to an MCMS only proposal.

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/types"
 )
 
@@ -230,27 +229,6 @@ func TestTimelockProposal_Convert(t *testing.T) {
 	assert.Equal(t, validChainMetadata, mcmsProposal.ChainMetadata)
 	assert.Equal(t, "description", mcmsProposal.Description)
 	assert.Len(t, mcmsProposal.Transactions, 1)
-}
-
-func TestTimelockProposal_Signable(t *testing.T) {
-	t.Parallel()
-
-	proposal, err := NewProposalWithTimeLock(
-		"1.0",
-		2004259681,
-		[]types.Signature{},
-		false,
-		validChainMetadata,
-		"description",
-		validTimelockAddresses,
-		validBatches,
-		types.TimelockActionSchedule,
-		"1h",
-	)
-	require.NoError(t, err)
-
-	_, err = proposal.Signable(map[types.ChainSelector]sdk.Inspector{})
-	require.NoError(t, err)
 }
 
 const validJsonProposal = `{


### PR DESCRIPTION
This is a large refactor to signable to remove it's own internal calculation of state, and use the methods provided by the proposal.

- Removes encoders as an argument to NewSignable and source from the proposal
- Simulators and Decoders fields were not required and are removed
- MerkleTree is fetched from the proposal
- `MCMSProposal` is no longer an embedded struct