### PR TITLE
chore: moves the newEncoder constructor back into the mcms package

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -1,0 +1,47 @@
+package mcms
+
+import (
+	cselectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/mcms/internal/core"
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/sdk/evm"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+// newEncoder returns a new Encoder that can encode operations and metadata for the given chain.
+// Additional arguments are used to configure the encoder.
+func newEncoder(
+	csel types.ChainSelector, txCount uint64, overridePreviousRoot bool, isSim bool,
+) (sdk.Encoder, error) {
+	chain, exists := cselectors.ChainBySelector(uint64(csel))
+	if !exists {
+		return nil, &core.InvalidChainIDError{
+			ReceivedChainID: uint64(csel),
+		}
+	}
+
+	family, err := types.GetChainSelectorFamily(csel)
+	if err != nil {
+		return nil, err
+	}
+
+	var encoder sdk.Encoder
+	switch family {
+	case cselectors.FamilyEVM:
+		// Simulated chains always have block.chainid = 1337
+		// So for setRoot to execute (not throw WrongChainId) we must
+		// override the evmChainID to be 1337.
+		if isSim {
+			chain.EvmChainID = 1337
+		}
+
+		encoder = evm.NewEVMEncoder(
+			txCount,
+			chain.EvmChainID,
+			overridePreviousRoot,
+		)
+	}
+
+	return encoder, nil
+}

--- a/factory_test.go
+++ b/factory_test.go
@@ -1,4 +1,4 @@
-package sdk
+package mcms
 
 import (
 	"testing"
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -24,7 +25,7 @@ func Test_NewEncoder(t *testing.T) {
 		name         string
 		giveSelector types.ChainSelector
 		giveIsSim    bool
-		want         Encoder
+		want         sdk.Encoder
 		wantErr      string
 	}{
 		{
@@ -59,7 +60,7 @@ func Test_NewEncoder(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := NewEncoder(
+			got, err := newEncoder(
 				tt.giveSelector,
 				giveTxCount,
 				giveOverridePreviousRoot,

--- a/proposal.go
+++ b/proposal.go
@@ -255,7 +255,7 @@ func (m *MCMSProposal) GetEncoders() (map[types.ChainSelector]sdk.Encoder, error
 	txCounts := m.TransactionCounts()
 	encoders := make(map[types.ChainSelector]sdk.Encoder)
 	for chainSelector := range m.ChainMetadata {
-		encoder, err := sdk.NewEncoder(chainSelector, txCounts[chainSelector], m.OverridePreviousRoot, m.useSimulatedBackend)
+		encoder, err := newEncoder(chainSelector, txCounts[chainSelector], m.OverridePreviousRoot, m.useSimulatedBackend)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create encoder: %w", err)
 		}

--- a/sdk/encoder.go
+++ b/sdk/encoder.go
@@ -3,10 +3,6 @@ package sdk
 import (
 	"github.com/ethereum/go-ethereum/common"
 
-	cselectors "github.com/smartcontractkit/chain-selectors"
-
-	"github.com/smartcontractkit/mcms/internal/core"
-	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/types"
 )
 
@@ -14,41 +10,4 @@ import (
 type Encoder interface {
 	HashOperation(opCount uint32, metadata types.ChainMetadata, op types.ChainOperation) (common.Hash, error)
 	HashMetadata(metadata types.ChainMetadata) (common.Hash, error)
-}
-
-// NewEncoder returns a new Encoder that can encode operations and metadata for the given chain.
-// Additional arguments are used to configure the encoder.
-func NewEncoder(
-	csel types.ChainSelector, txCount uint64, overridePreviousRoot bool, isSim bool,
-) (Encoder, error) {
-	chain, exists := cselectors.ChainBySelector(uint64(csel))
-	if !exists {
-		return nil, &core.InvalidChainIDError{
-			ReceivedChainID: uint64(csel),
-		}
-	}
-
-	family, err := types.GetChainSelectorFamily(csel)
-	if err != nil {
-		return nil, err
-	}
-
-	var encoder Encoder
-	switch family {
-	case cselectors.FamilyEVM:
-		// Simulated chains always have block.chainid = 1337
-		// So for setRoot to execute (not throw WrongChainId) we must
-		// override the evmChainID to be 1337.
-		if isSim {
-			chain.EvmChainID = 1337
-		}
-
-		encoder = evm.NewEVMEncoder(
-			txCount,
-			chain.EvmChainID,
-			overridePreviousRoot,
-		)
-	}
-
-	return encoder, nil
 }

--- a/sdk/evm/encoder.go
+++ b/sdk/evm/encoder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -24,6 +25,8 @@ var (
 	// https://github.com/smartcontractkit/ccip-owner-contracts/blob/main/src/ManyChainMultiSig.sol#L17
 	mcmDomainSeparatorMetadata = crypto.Keccak256Hash([]byte("MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_METADATA"))
 )
+
+var _ sdk.Encoder = (*EVMEncoder)(nil)
 
 // EVMEncoder is a struct that encodes ChainOperations and ChainMetadata into the format expected
 // by the EVM ManyChainMultiSig contract.

--- a/sdk/evm/inspector.go
+++ b/sdk/evm/inspector.go
@@ -4,9 +4,12 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
 	"github.com/smartcontractkit/mcms/types"
 )
+
+var _ sdk.Inspector = (*EVMInspector)(nil)
 
 // EVMInspector is an Inspector implementation for EVM chains, giving access to the state of the MCMS contract
 type EVMInspector struct {

--- a/sdk/evm/timelock_converter.go
+++ b/sdk/evm/timelock_converter.go
@@ -9,11 +9,14 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/smartcontractkit/mcms/internal/core"
+	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
 	"github.com/smartcontractkit/mcms/types"
 )
 
 var ZERO_HASH = common.Hash{}
+
+var _ sdk.TimelockConverter = (*TimelockConverterEVM)(nil)
 
 type TimelockConverterEVM struct{}
 

--- a/sdk/evm/timelock_inspector.go
+++ b/sdk/evm/timelock_inspector.go
@@ -7,8 +7,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/mcms/internal/utils/safecast"
+	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
 )
+
+var _ sdk.TimelockInspector = (*TimelockEVMInspector)(nil)
 
 // TimelockEVMInspector is an Inspector implementation for EVM chains for accessing the RBACTimelock contract
 type TimelockEVMInspector struct {


### PR DESCRIPTION
The `newEncoder` function was causing a circular dependency problem when it was in the `sdk` package. This commit moves it back into the `mcms` package where it was originally.