### PR TITLE
feat: adds a WriteTimelockProposal function

### DIFF
--- a/proposal_test.go
+++ b/proposal_test.go
@@ -152,18 +152,7 @@ func Test_WriteProposal(t *testing.T) {
 			giveWriter: func() io.Writer {
 				return newFakeWriter(0, errors.New("write error"))
 			},
-			give: &Proposal{
-				BaseProposal: BaseProposal{
-					Version:    "1",
-					ValidUntil: 2004259681,
-					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {},
-					},
-				},
-				Transactions: []types.ChainOperation{
-					{ChainSelector: TestChain1},
-				},
-			},
+			give:    &Proposal{},
 			wantErr: "write error",
 		},
 	}

--- a/types/timelock.go
+++ b/types/timelock.go
@@ -17,6 +17,6 @@ const (
 
 // BatchChainOperation is a struct that represents a batch of operations to be executed on a chain.
 type BatchChainOperation struct {
-	ChainSelector ChainSelector `json:"chainIdentifier"`
+	ChainSelector ChainSelector `json:"chainSelector"`
 	Batch         []Operation   `json:"batch"`
 }


### PR DESCRIPTION
Adds a WriteTimelockProposal function to the `mcms`` package that marshals a timelock proposal to JSON and writes it to an io.Writer.