### PR TITLE
refactor: move the AppendSignature method to the BaseProposal

### DIFF
--- a/proposal.go
+++ b/proposal.go
@@ -35,6 +35,11 @@ type BaseProposal struct {
 	useSimulatedBackend bool `json:"-"`
 }
 
+// AppendSignature appends a signature to the proposal's signature list.
+func (p *BaseProposal) AppendSignature(signature types.Signature) {
+	p.Signatures = append(p.Signatures, signature)
+}
+
 // Proposal is a struct where the target contract is an MCMS contract
 // with no forwarder contracts. This type does not support any type of atomic contract
 // call batching, as the MCMS contract natively doesn't support batching
@@ -222,11 +227,6 @@ func (m *Proposal) TransactionNonces() ([]uint64, error) {
 	}
 
 	return txNonces, nil
-}
-
-// AppendSignature appends a signature to the proposal's signature list.
-func (m *Proposal) AppendSignature(signature types.Signature) {
-	m.Signatures = append(m.Signatures, signature)
 }
 
 // GetEncoders generates encoders for each chain in the proposal's chain metadata.

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -26,6 +26,20 @@ var (
 	TestChain3  = types.ChainSelector(cselectors.ETHEREUM_TESTNET_SEPOLIA_BASE_1.Selector) // 10344971235874465080
 )
 
+func Test_BaseProposal_AppendSignature(t *testing.T) {
+	t.Parallel()
+
+	signature := types.Signature{}
+
+	proposal := BaseProposal{}
+
+	assert.Empty(t, proposal.Signatures)
+
+	proposal.AppendSignature(signature)
+
+	assert.Equal(t, []types.Signature{signature}, proposal.Signatures)
+}
+
 func Test_NewProposal(t *testing.T) {
 	t.Parallel()
 
@@ -300,20 +314,6 @@ func Test_Proposal_Validate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_Proposal_AddSignature(t *testing.T) {
-	t.Parallel()
-
-	signature := types.Signature{}
-
-	proposal := Proposal{}
-
-	assert.Empty(t, proposal.Signatures)
-
-	proposal.AppendSignature(signature)
-
-	assert.Equal(t, []types.Signature{signature}, proposal.Signatures)
 }
 
 func Test_Proposal_GetEncoders(t *testing.T) {

--- a/timelock_proposal.go
+++ b/timelock_proposal.go
@@ -156,10 +156,6 @@ func (m *TimelockProposal) Convert() (Proposal, error) {
 	return result, nil
 }
 
-func (m *TimelockProposal) AddSignature(signature types.Signature) {
-	m.Signatures = append(m.Signatures, signature)
-}
-
 // timeLockProposalValidateBasic basic validation for an MCMS proposal
 func timeLockProposalValidateBasic(timelockProposal TimelockProposal) error {
 	// Get the current Unix timestamp as an int64


### PR DESCRIPTION
Fixes an inconsistency in the proposal interface where the naming of the method AppendSignature was not consistent between the two proposals. This moves the AppendSignature method to the BaseProposal so it can be shared between the two proposal types.