### PR TITLE
refactor: removes the EVM Chain ID argument from newEncoder

### DIFF
--- a/executable_test.go
+++ b/executable_test.go
@@ -45,7 +45,7 @@ func Test_NewExecutable(t *testing.T) {
 			giveExecutors: map[types.ChainSelector]sdk.Executor{
 				types.ChainSelector(1): executor,
 			},
-			wantErr: "unable to create encoder: invalid chain ID: 1",
+			wantErr: "unable to create encoder: chain family not found for selector 1",
 		},
 		{
 			name: "failure: could not generate tx nonces from proposal (tx does not have matching chain metadata)",

--- a/factory.go
+++ b/factory.go
@@ -4,7 +4,6 @@ import (
 	cselectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/mcms/sdk"
-	sdkerrors "github.com/smartcontractkit/mcms/sdk/errors"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -14,13 +13,6 @@ import (
 func newEncoder(
 	csel types.ChainSelector, txCount uint64, overridePreviousRoot bool, isSim bool,
 ) (sdk.Encoder, error) {
-	chain, exists := cselectors.ChainBySelector(uint64(csel))
-	if !exists {
-		return nil, &sdkerrors.InvalidChainIDError{
-			ReceivedChainID: csel,
-		}
-	}
-
 	family, err := types.GetChainSelectorFamily(csel)
 	if err != nil {
 		return nil, err
@@ -29,17 +21,11 @@ func newEncoder(
 	var encoder sdk.Encoder
 	switch family {
 	case cselectors.FamilyEVM:
-		// Simulated chains always have block.chainid = 1337
-		// So for setRoot to execute (not throw WrongChainId) we must
-		// override the evmChainID to be 1337.
-		if isSim {
-			chain.EvmChainID = 1337
-		}
-
 		encoder = evm.NewEVMEncoder(
+			csel,
 			txCount,
-			chain.EvmChainID,
 			overridePreviousRoot,
+			isSim,
 		)
 	}
 

--- a/factory_test.go
+++ b/factory_test.go
@@ -34,8 +34,9 @@ func Test_NewEncoder(t *testing.T) {
 			giveIsSim:    false,
 			want: &evm.EVMEncoder{
 				TxCount:              giveTxCount,
-				ChainID:              chaintest.Chain2EVMID,
+				ChainSelector:        chaintest.Chain2Selector,
 				OverridePreviousRoot: false,
+				IsSim:                false,
 			},
 		},
 		{
@@ -43,16 +44,17 @@ func Test_NewEncoder(t *testing.T) {
 			giveSelector: chaintest.Chain2Selector,
 			giveIsSim:    true,
 			want: &evm.EVMEncoder{
+				ChainSelector:        chaintest.Chain2Selector,
 				TxCount:              giveTxCount,
-				ChainID:              1337,
 				OverridePreviousRoot: false,
+				IsSim:                true,
 			},
 		},
 		{
 			name:         "failure: chain not found for selector",
-			giveSelector: chaintest.TestInvalidChainSelector,
+			giveSelector: chaintest.ChainInvalidSelector,
 			giveIsSim:    true,
-			wantErr:      "invalid chain ID: 0",
+			wantErr:      "chain family not found for selector 0",
 		},
 	}
 

--- a/internal/testutils/chaintest/testchain.go
+++ b/internal/testutils/chaintest/testchain.go
@@ -19,6 +19,6 @@ var (
 	Chain3Selector    = types.ChainSelector(Chain3RawSelector)                // 10344971235874465080
 	Chain3EVMID       = cselectors.ETHEREUM_TESTNET_SEPOLIA_BASE_1.EvmChainID // 84532
 
-	// TestInvalidChainSelector is a chain selector that doesn't exist.
-	TestInvalidChainSelector = types.ChainSelector(0)
+	// ChainInvalidSelector is a chain selector that doesn't exist.
+	ChainInvalidSelector = types.ChainSelector(0)
 )

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -367,8 +367,8 @@ func Test_Proposal_GetEncoders(t *testing.T) {
 				},
 			},
 			want: map[types.ChainSelector]sdk.Encoder{
-				chaintest.Chain1Selector: evm.NewEVMEncoder(2, 1337, false),
-				chaintest.Chain2Selector: evm.NewEVMEncoder(1, 11155111, false),
+				chaintest.Chain1Selector: evm.NewEVMEncoder(chaintest.Chain1Selector, 2, false, false),
+				chaintest.Chain2Selector: evm.NewEVMEncoder(chaintest.Chain2Selector, 1, false, false),
 			},
 		},
 		{
@@ -377,11 +377,11 @@ func Test_Proposal_GetEncoders(t *testing.T) {
 				BaseProposal: BaseProposal{
 					OverridePreviousRoot: false,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						types.ChainSelector(1): {},
+						types.ChainSelector(0): {},
 					},
 				},
 			},
-			wantErr: "unable to create encoder: invalid chain ID: 1",
+			wantErr: "unable to create encoder: chain family not found for selector 0",
 		},
 	}
 
@@ -493,7 +493,7 @@ func Test_Proposal_MerkleTree(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "merkle tree generation error: unable to create encoder: invalid chain ID: 1",
+			wantErr: "merkle tree generation error: unable to create encoder: chain family not found for selector 1",
 		},
 		{
 			name: "failure: missing metadata when fetching nonces",

--- a/sdk/evm/encoder.go
+++ b/sdk/evm/encoder.go
@@ -32,17 +32,21 @@ var _ sdk.Encoder = (*EVMEncoder)(nil)
 // EVMEncoder is a struct that encodes ChainOperations and ChainMetadata into the format expected
 // by the EVM ManyChainMultiSig contract.
 type EVMEncoder struct {
+	ChainSelector        types.ChainSelector
 	TxCount              uint64
-	ChainID              uint64
 	OverridePreviousRoot bool
+	IsSim                bool
 }
 
 // NewEVMEncoder returns a new EVMEncoder.
-func NewEVMEncoder(txCount uint64, chainID uint64, overridePreviousRoot bool) *EVMEncoder {
+func NewEVMEncoder(
+	csel types.ChainSelector, txCount uint64, overridePreviousRoot bool, isSim bool,
+) *EVMEncoder {
 	return &EVMEncoder{
+		ChainSelector:        csel,
 		TxCount:              txCount,
-		ChainID:              chainID,
 		OverridePreviousRoot: overridePreviousRoot,
+		IsSim:                isSim,
 	}
 }
 
@@ -70,8 +74,13 @@ func (e *EVMEncoder) HashOperation(
 // HashMetadata converts the MCMS ChainMetadata into the format expected by the EVM
 // ManyChainMultiSig contract, and hashes it.
 func (e *EVMEncoder) HashMetadata(metadata types.ChainMetadata) (common.Hash, error) {
+	bindMeta, err := e.ToGethRootMetadata(metadata)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
 	abi := `[{"type":"bytes32"},{"type":"tuple","components":[{"name":"chainId","type":"uint256"},{"name":"multiSig","type":"address"},{"name":"preOpCount","type":"uint40"},{"name":"postOpCount","type":"uint40"},{"name":"overridePreviousRoot","type":"bool"}]}]`
-	encoded, err := abiUtils.ABIEncode(abi, mcmDomainSeparatorMetadata, e.ToGethRootMetadata(metadata))
+	encoded, err := abiUtils.ABIEncode(abi, mcmDomainSeparatorMetadata, bindMeta)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -86,6 +95,11 @@ func (e *EVMEncoder) ToGethOperation(
 	metadata types.ChainMetadata,
 	op types.Operation,
 ) (bindings.ManyChainMultiSigOp, error) {
+	evmChainID, err := getEVMChainID(e.ChainSelector, e.IsSim)
+	if err != nil {
+		return bindings.ManyChainMultiSigOp{}, err
+	}
+
 	// Unmarshal the AdditionalFields from the operation
 	var additionalFields EVMAdditionalFields
 	if err := json.Unmarshal(op.Transaction.AdditionalFields, &additionalFields); err != nil {
@@ -93,7 +107,7 @@ func (e *EVMEncoder) ToGethOperation(
 	}
 
 	return bindings.ManyChainMultiSigOp{
-		ChainId:  new(big.Int).SetUint64(e.ChainID),
+		ChainId:  new(big.Int).SetUint64(evmChainID),
 		MultiSig: common.HexToAddress(metadata.MCMAddress),
 		Nonce:    new(big.Int).SetUint64(metadata.StartingOpCount + uint64(opCount)),
 		To:       common.HexToAddress(op.Transaction.To),
@@ -104,122 +118,17 @@ func (e *EVMEncoder) ToGethOperation(
 
 // ToGethRootMetadata converts the MCMS ChainMetadata into the format expected by the EVM
 // ManyChainMultiSig contract.
-func (e *EVMEncoder) ToGethRootMetadata(metadata types.ChainMetadata) bindings.ManyChainMultiSigRootMetadata {
+func (e *EVMEncoder) ToGethRootMetadata(metadata types.ChainMetadata) (bindings.ManyChainMultiSigRootMetadata, error) {
+	evmChainID, err := getEVMChainID(e.ChainSelector, e.IsSim)
+	if err != nil {
+		return bindings.ManyChainMultiSigRootMetadata{}, err
+	}
+
 	return bindings.ManyChainMultiSigRootMetadata{
-		ChainId:              new(big.Int).SetUint64(e.ChainID),
+		ChainId:              new(big.Int).SetUint64(evmChainID),
 		MultiSig:             common.HexToAddress(metadata.MCMAddress),
 		PreOpCount:           new(big.Int).SetUint64(metadata.StartingOpCount),
 		PostOpCount:          new(big.Int).SetUint64(metadata.StartingOpCount + e.TxCount),
 		OverridePreviousRoot: e.OverridePreviousRoot,
-	}
+	}, nil
 }
-
-// func buildRootMetadatas(
-// 	chainMetadata map[ChainIdentifier]ChainMetadata,
-// 	txCounts map[ChainIdentifier]uint64,
-// 	overridePreviousRoot bool,
-// 	isSim bool,
-// ) (map[ChainIdentifier]bindings.ManyChainMultiSigRootMetadata, error) {
-// 	rootMetadatas := make(map[ChainIdentifier]bindings.ManyChainMultiSigRootMetadata)
-
-// 	for chainID, metadata := range chainMetadata {
-// 		chain, exists := chain_selectors.ChainBySelector(uint64(chainID))
-// 		if !exists {
-// 			return nil, &errors.InvalidChainIDError{
-// 				ReceivedChainID: uint64(chainID),
-// 			}
-// 		}
-
-// 		currentTxCount, ok := txCounts[chainID]
-// 		if !ok {
-// 			return nil, &errors.MissingChainDetailsError{
-// 				ChainIdentifier: uint64(chainID),
-// 				Parameter:       "transaction count",
-// 			}
-// 		}
-
-// 		// Simulated chains always have block.chainid = 1337
-// 		// So for setRoot to execute (not throw WrongChainId) we must
-// 		// override the evmChainID to be 1337.
-// 		if isSim {
-// 			chain.EvmChainID = 1337
-// 		}
-
-// 		preOpCount := new(big.Int).SetUint64(metadata.StartingOpCount)
-// 		postOpCount := new(big.Int).SetUint64(metadata.StartingOpCount + currentTxCount)
-
-// 		rootMetadatas[chainID] = bindings.ManyChainMultiSigRootMetadata{
-// 			ChainId:              new(big.Int).SetUint64(chain.EvmChainID),
-// 			MultiSig:             metadata.MCMAddress,
-// 			PreOpCount:           preOpCount,
-// 			PostOpCount:          postOpCount,
-// 			OverridePreviousRoot: overridePreviousRoot,
-// 		}
-// 	}
-
-// 	return rootMetadatas, nil
-// }
-
-// func buildOperations(
-// 	transactions []ChainOperation,
-// 	rootMetadatas map[ChainIdentifier]bindings.ManyChainMultiSigRootMetadata,
-// 	txCounts map[ChainIdentifier]uint64,
-// ) (map[ChainIdentifier][]bindings.ManyChainMultiSigOp, []bindings.ManyChainMultiSigOp) {
-// 	ops := make(map[ChainIdentifier][]bindings.ManyChainMultiSigOp)
-// 	chainAgnosticOps := make([]bindings.ManyChainMultiSigOp, 0)
-// 	chainIdx := make(map[ChainIdentifier]uint32, len(rootMetadatas))
-
-// 	for _, tx := range transactions {
-// 		rootMetadata := rootMetadatas[tx.ChainIdentifier]
-// 		if _, ok := ops[tx.ChainIdentifier]; !ok {
-// 			ops[tx.ChainIdentifier] = make([]bindings.ManyChainMultiSigOp, txCounts[tx.ChainIdentifier])
-// 			chainIdx[tx.ChainIdentifier] = 0
-// 		}
-
-// 		op := bindings.ManyChainMultiSigOp{
-// 			ChainId:  rootMetadata.ChainId,
-// 			MultiSig: rootMetadata.MultiSig,
-// 			Nonce:    big.NewInt(rootMetadata.PreOpCount.Int64() + int64(chainIdx[tx.ChainIdentifier])),
-// 			To:       tx.To,
-// 			Data:     tx.Data,
-// 			Value:    tx.Value,
-// 		}
-
-// 		chainAgnosticOps = append(chainAgnosticOps, op)
-// 		ops[tx.ChainIdentifier][chainIdx[tx.ChainIdentifier]] = op
-// 		chainIdx[tx.ChainIdentifier]++
-// 	}
-
-// 	return ops, chainAgnosticOps
-// }
-
-// func buildMerkleTree(
-// 	chainIdentifiers []ChainIdentifier,
-// 	rootMetadatas map[ChainIdentifier]bindings.ManyChainMultiSigRootMetadata,
-// 	ops map[ChainIdentifier][]bindings.ManyChainMultiSigOp,
-// ) (*merkle.Tree, error) {
-// 	hashLeaves := make([]common.Hash, 0)
-
-// 	for _, chainID := range chainIdentifiers {
-// 		encodedRootMetadata, err := metadataEncoder(rootMetadatas[chainID])
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 		hashLeaves = append(hashLeaves, encodedRootMetadata)
-
-// 		for _, op := range ops[chainID] {
-// 			encodedOp, err := txEncoder(op)
-// 			if err != nil {
-// 				return nil, err
-// 			}
-// 			hashLeaves = append(hashLeaves, encodedOp)
-// 		}
-// 	}
-
-// 	// sort the hashes and sort the pairs
-// 	sort.Slice(hashLeaves, func(i, j int) bool {
-// 		return hashLeaves[i].String() < hashLeaves[j].String()
-// 	})
-
-// 	return merkle.NewMerkleTree(hashLeaves), nil
-// }

--- a/sdk/evm/encoder_test.go
+++ b/sdk/evm/encoder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
 	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -17,9 +18,6 @@ func TestEVMEncoder_HashOperation(t *testing.T) {
 	t.Parallel()
 
 	var (
-		evmChainID    = uint64(1)
-		chainSelector = types.ChainSelector(cselectors.EvmChainIdToChainSelector()[evmChainID])
-
 		// Static argument values to HashOperation since they don't affect the test
 		giveOpCount  = uint32(0)
 		giveMetadata = types.ChainMetadata{
@@ -37,7 +35,7 @@ func TestEVMEncoder_HashOperation(t *testing.T) {
 		{
 			name: "success: hash operation",
 			giveOp: types.Operation{
-				ChainSelector: chainSelector,
+				ChainSelector: chaintest.Chain1Selector,
 				Transaction: NewEVMOperation(
 					common.HexToAddress("0x2"),
 					[]byte("data"),
@@ -46,12 +44,12 @@ func TestEVMEncoder_HashOperation(t *testing.T) {
 					[]string{},
 				),
 			},
-			want: "0x4bd3162db447382fc6e5b2a8eb24e19e901feecb90c5071bac5deee3cb58cb97",
+			want: "0x689c68d31325bd84109a05d2319a683560f9773962d58d813915102210f571ef",
 		},
 		{
 			name: "failure: cannot unmarshal additional fields",
 			giveOp: types.Operation{
-				ChainSelector: chainSelector,
+				ChainSelector: chaintest.Chain1Selector,
 				Transaction: types.Transaction{
 					AdditionalFields: []byte("invalid"),
 				},
@@ -64,7 +62,7 @@ func TestEVMEncoder_HashOperation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			encoder := NewEVMEncoder(5, evmChainID, false)
+			encoder := NewEVMEncoder(chaintest.Chain1Selector, 5, false, false)
 			got, err := encoder.HashOperation(giveOpCount, giveMetadata, tt.giveOp)
 
 			if tt.wantErr != "" {
@@ -81,17 +79,45 @@ func TestEVMEncoder_HashOperation(t *testing.T) {
 func TestEVMEncoder_HashMetadata(t *testing.T) {
 	t.Parallel()
 
-	metadata := types.ChainMetadata{
-		StartingOpCount: 0,
-		MCMAddress:      "0x1",
+	tests := []struct {
+		name         string
+		giveSelector types.ChainSelector
+		giveMeta     types.ChainMetadata
+		want         string
+		wantErr      string
+	}{
+		{
+			name:         "success: hash metadata",
+			giveSelector: chaintest.Chain1Selector,
+			giveMeta: types.ChainMetadata{
+				StartingOpCount: 0,
+				MCMAddress:      "0x1",
+			},
+			want: "0x2402fdba934e2c405ce8e34c096eaa95a9d34291ca945c7ccede4bec8160cac0",
+		},
+		{
+			name:         "failure: could not get evm chain id",
+			giveSelector: chaintest.ChainInvalidSelector,
+			giveMeta:     types.ChainMetadata{},
+			wantErr:      "invalid chain ID: 0",
+		},
 	}
 
-	encoder := NewEVMEncoder(5, 1, false)
-	got, err := encoder.HashMetadata(metadata)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.NoError(t, err)
-	want := "0x3d030bfa3fcbbfa780ab87e0368f9487a271df7654cc2d1ba82f3be9d4933366"
-	assert.Equal(t, want, got.Hex())
+			encoder := NewEVMEncoder(tt.giveSelector, 1, false, false)
+			got, err := encoder.HashMetadata(tt.giveMeta)
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got.Hex())
+			}
+		})
+	}
 }
 
 func TestEVMEncoder_ToGethOperation(t *testing.T) {
@@ -110,13 +136,15 @@ func TestEVMEncoder_ToGethOperation(t *testing.T) {
 	)
 
 	tests := []struct {
-		name    string
-		giveOp  types.Operation
-		want    bindings.ManyChainMultiSigOp
-		wantErr string
+		name         string
+		giveSelector types.ChainSelector
+		giveOp       types.Operation
+		want         bindings.ManyChainMultiSigOp
+		wantErr      string
 	}{
 		{
-			name: "success: converts to a geth operations",
+			name:         "success: converts to a geth operations",
+			giveSelector: chaintest.Chain1Selector,
 			giveOp: types.Operation{
 				ChainSelector: chainSelector,
 				Transaction: NewEVMOperation(
@@ -128,7 +156,7 @@ func TestEVMEncoder_ToGethOperation(t *testing.T) {
 				),
 			},
 			want: bindings.ManyChainMultiSigOp{
-				ChainId:  new(big.Int).SetUint64(1),
+				ChainId:  new(big.Int).SetUint64(chaintest.Chain1EVMID),
 				MultiSig: common.HexToAddress("0x1"),
 				Nonce:    new(big.Int).SetUint64(0),
 				To:       common.HexToAddress("0x2"),
@@ -137,7 +165,14 @@ func TestEVMEncoder_ToGethOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "failure: cannot unmarshal additional fields",
+			name:         "failure: invalid chain selector",
+			giveSelector: chaintest.ChainInvalidSelector,
+			giveOp:       types.Operation{},
+			wantErr:      "invalid chain ID: 0",
+		},
+		{
+			name:         "failure: cannot unmarshal additional fields",
+			giveSelector: chaintest.Chain1Selector,
 			giveOp: types.Operation{
 				ChainSelector: chainSelector,
 				Transaction: types.Transaction{
@@ -152,7 +187,7 @@ func TestEVMEncoder_ToGethOperation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			encoder := NewEVMEncoder(5, evmChainID, false)
+			encoder := NewEVMEncoder(tt.giveSelector, 5, false, false)
 			got, err := encoder.ToGethOperation(giveOpCount, giveMetadata, tt.giveOp)
 
 			if tt.wantErr != "" {
@@ -169,21 +204,46 @@ func TestEVMEncoder_ToGethOperation(t *testing.T) {
 func TestEVMEncoder_ToGethRootMetadata(t *testing.T) {
 	t.Parallel()
 
-	metadata := types.ChainMetadata{
-		StartingOpCount: 0,
-		MCMAddress:      "0x1",
+	tests := []struct {
+		name         string
+		giveSelector types.ChainSelector
+		giveMetadata types.ChainMetadata
+		want         bindings.ManyChainMultiSigRootMetadata
+		wantErr      string
+	}{
+		{
+			name:         "success: converts to a geth root metadata",
+			giveSelector: chaintest.Chain1Selector,
+			giveMetadata: types.ChainMetadata{
+				StartingOpCount: 0,
+				MCMAddress:      "0x1",
+			},
+			want: bindings.ManyChainMultiSigRootMetadata{
+				ChainId:              new(big.Int).SetUint64(chaintest.Chain1EVMID),
+				MultiSig:             common.HexToAddress("0x1"),
+				PreOpCount:           new(big.Int).SetUint64(0),
+				PostOpCount:          new(big.Int).SetUint64(5),
+				OverridePreviousRoot: false,
+			},
+		},
+		{
+			name:         "faiure: invalid chain selector",
+			giveSelector: chaintest.ChainInvalidSelector,
+			giveMetadata: types.ChainMetadata{},
+			wantErr:      "invalid chain ID: 0",
+		},
 	}
 
-	encoder := NewEVMEncoder(5, 1, false)
-	got := encoder.ToGethRootMetadata(metadata)
+	for _, tt := range tests {
+		encoder := NewEVMEncoder(tt.giveSelector, 5, false, false)
 
-	want := bindings.ManyChainMultiSigRootMetadata{
-		ChainId:              new(big.Int).SetUint64(1),
-		MultiSig:             common.HexToAddress("0x1"),
-		PreOpCount:           new(big.Int).SetUint64(0),
-		PostOpCount:          new(big.Int).SetUint64(5),
-		OverridePreviousRoot: false,
+		got, err := encoder.ToGethRootMetadata(tt.giveMetadata)
+
+		if tt.wantErr != "" {
+			require.EqualError(t, err, tt.wantErr)
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		}
 	}
-
-	assert.Equal(t, want, got)
 }

--- a/sdk/evm/executor.go
+++ b/sdk/evm/executor.go
@@ -34,17 +34,17 @@ func (e *EVMExecutor) ExecuteOperation(
 		return "", errors.New("EVMExecutor was created without an encoder")
 	}
 
-	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(metadata.MCMAddress), e.client)
-	if err != nil {
-		return "", err
-	}
-
 	bindOp, err := e.ToGethOperation(nonce, metadata, op)
 	if err != nil {
 		return "", err
 	}
 
-	tx, err := mcmsObj.Execute(
+	mcmsC, err := bindings.NewManyChainMultiSig(common.HexToAddress(metadata.MCMAddress), e.client)
+	if err != nil {
+		return "", err
+	}
+
+	tx, err := mcmsC.Execute(
 		e.auth,
 		bindOp,
 		transformHashes(proof),
@@ -64,16 +64,21 @@ func (e *EVMExecutor) SetRoot(
 		return "", errors.New("EVMExecutor was created without an encoder")
 	}
 
-	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(metadata.MCMAddress), e.client)
+	bindMeta, err := e.ToGethRootMetadata(metadata)
 	if err != nil {
 		return "", err
 	}
 
-	tx, err := mcmsObj.SetRoot(
+	mcmsC, err := bindings.NewManyChainMultiSig(common.HexToAddress(metadata.MCMAddress), e.client)
+	if err != nil {
+		return "", err
+	}
+
+	tx, err := mcmsC.SetRoot(
 		e.auth,
 		root,
 		validUntil,
-		e.ToGethRootMetadata(metadata),
+		bindMeta,
 		transformHashes(proof),
 		transformSignatures(sortedSignatures),
 	)

--- a/signable_test.go
+++ b/signable_test.go
@@ -52,7 +52,7 @@ func Test_NewSignable(t *testing.T) {
 			giveInspectors: map[types.ChainSelector]sdk.Inspector{
 				types.ChainSelector(1): inspector,
 			},
-			wantErr: "unable to create encoder: invalid chain ID: 1",
+			wantErr: "unable to create encoder: chain family not found for selector 1",
 		},
 		{
 			name: "failure: could not generate tree from proposal (invalid additional values)",


### PR DESCRIPTION
`newEncoder` was leaking chain family specific information into the `mcms` package as we had to fetch the EVM chain id to construct an EVM encoder.

This change removes the EVM chain id argument from `newEncoder` and replaces it with the chain selector, so that the sdk itself is responsible for fetching it's chain family specific chain id.

This also allows us to remove the `isSim` override from the `mcms` into the evm sdk itself, which is a better place for it since this is evm specific.