### PR TITLE
chore: extracts test selectors into a `testutils/chaintest` package

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -8,16 +8,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-playground/validator/v10"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
 	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 	"github.com/smartcontractkit/mcms/types"
 )
-
-var SepoliaSelector = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
 
 func TestProposalBuilder(t *testing.T) {
 	t.Parallel()
@@ -41,9 +39,9 @@ func TestProposalBuilder(t *testing.T) {
 					SetValidUntil(fixedValidUntilCasted).
 					SetDescription("Valid Proposal").
 					SetOverridePreviousRoot(false).
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
 					AddOperation(types.Operation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction:   types.Transaction{Data: []byte{0x01}},
 					})
 			},
@@ -55,12 +53,12 @@ func TestProposalBuilder(t *testing.T) {
 					Description:          "Valid Proposal",
 					OverridePreviousRoot: false,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						types.ChainSelector(SepoliaSelector): {StartingOpCount: 0},
+						chaintest.Chain2Selector: {StartingOpCount: 0},
 					},
 				},
 				Operations: []types.Operation{
 					{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction:   types.Transaction{Data: []byte{0x01}},
 					},
 				},
@@ -74,14 +72,14 @@ func TestProposalBuilder(t *testing.T) {
 					SetValidUntil(fixedValidUntilCasted).
 					SetDescription("Valid Proposal").
 					SetOverridePreviousRoot(false).
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
 					SetOperations([]types.Operation{
 						{
-							ChainSelector: types.ChainSelector(SepoliaSelector),
+							ChainSelector: chaintest.Chain2Selector,
 							Transaction:   types.Transaction{Data: []byte{0x01}},
 						},
 						{
-							ChainSelector: types.ChainSelector(SepoliaSelector),
+							ChainSelector: chaintest.Chain2Selector,
 							Transaction:   types.Transaction{Data: []byte{0x02}},
 						},
 					})
@@ -94,16 +92,16 @@ func TestProposalBuilder(t *testing.T) {
 					Description:          "Valid Proposal",
 					OverridePreviousRoot: false,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						types.ChainSelector(SepoliaSelector): {StartingOpCount: 0},
+						chaintest.Chain2Selector: {StartingOpCount: 0},
 					},
 				},
 				Operations: []types.Operation{
 					{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction:   types.Transaction{Data: []byte{0x01}},
 					},
 					{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction:   types.Transaction{Data: []byte{0x02}},
 					},
 				},
@@ -118,15 +116,15 @@ func TestProposalBuilder(t *testing.T) {
 					SetDescription("Valid Proposal").
 					SetOverridePreviousRoot(false).
 					SetChainMetadata(map[types.ChainSelector]types.ChainMetadata{
-						types.ChainSelector(SepoliaSelector): {StartingOpCount: 0},
+						chaintest.Chain2Selector: {StartingOpCount: 0},
 					}).
 					SetOperations([]types.Operation{
 						{
-							ChainSelector: types.ChainSelector(SepoliaSelector),
+							ChainSelector: chaintest.Chain2Selector,
 							Transaction:   types.Transaction{Data: []byte{0x01}},
 						},
 						{
-							ChainSelector: types.ChainSelector(SepoliaSelector),
+							ChainSelector: chaintest.Chain2Selector,
 							Transaction:   types.Transaction{Data: []byte{0x02}},
 						},
 					}).
@@ -149,16 +147,16 @@ func TestProposalBuilder(t *testing.T) {
 						V: 28,
 					}},
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						types.ChainSelector(SepoliaSelector): {StartingOpCount: 0},
+						chaintest.Chain2Selector: {StartingOpCount: 0},
 					},
 				},
 				Operations: []types.Operation{
 					{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction:   types.Transaction{Data: []byte{0x01}},
 					},
 					{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction:   types.Transaction{Data: []byte{0x02}},
 					},
 				},
@@ -171,9 +169,9 @@ func TestProposalBuilder(t *testing.T) {
 				b.SetValidUntil(fixedValidUntilCasted).
 					SetDescription("Missing Version").
 					SetOverridePreviousRoot(false).
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
 					AddOperation(types.Operation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction:   types.Transaction{Data: []byte{0x01}},
 					})
 			},
@@ -189,9 +187,9 @@ func TestProposalBuilder(t *testing.T) {
 					SetValidUntil(pastValidUntilCast).
 					SetDescription("ValidUntil in Past").
 					SetOverridePreviousRoot(false).
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
 					AddOperation(types.Operation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction:   types.Transaction{Data: []byte{0x01}},
 					})
 			},
@@ -207,7 +205,7 @@ func TestProposalBuilder(t *testing.T) {
 					SetValidUntil(fixedValidUntilCasted).
 					SetDescription("No Transactions").
 					SetOverridePreviousRoot(false).
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0})
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0})
 				// No transactions added
 			},
 			want: nil,
@@ -224,7 +222,7 @@ func TestProposalBuilder(t *testing.T) {
 					SetOverridePreviousRoot(false).
 					// ChainMetadata is not added
 					AddOperation(types.Operation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction:   types.Transaction{Data: []byte{0x01}},
 					})
 			},

--- a/builder_timelock_test.go
+++ b/builder_timelock_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
 	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -45,10 +46,10 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					SetOverridePreviousRoot(false).
 					SetAction(types.TimelockActionSchedule).
 					SetDelay("24h").
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
-					SetTimelockAddress(types.ChainSelector(SepoliaSelector), "0xTimelockAddress").
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
+					SetTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
 					AddOperation(types.BatchOperation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								Data:             []byte{0x01},
@@ -66,17 +67,17 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					Description:          "Valid Timelock Proposal",
 					OverridePreviousRoot: false,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						types.ChainSelector(SepoliaSelector): {StartingOpCount: 0},
+						chaintest.Chain2Selector: {StartingOpCount: 0},
 					},
 				},
 				Action: types.TimelockActionSchedule,
 				Delay:  "24h",
 				TimelockAddresses: map[types.ChainSelector]string{
-					types.ChainSelector(SepoliaSelector): "0xTimelockAddress",
+					chaintest.Chain2Selector: "0xTimelockAddress",
 				},
 				Operations: []types.BatchOperation{
 					{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								Data:             []byte{0x01},
@@ -98,10 +99,10 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					SetOverridePreviousRoot(false).
 					SetAction(types.TimelockActionSchedule).
 					SetDelay("24h").
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
-					SetTimelockAddress(types.ChainSelector(SepoliaSelector), "0xTimelockAddress").
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
+					SetTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
 					SetTransactions([]types.BatchOperation{{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								Data:             []byte{0x01},
@@ -120,17 +121,17 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					Description:          "Valid Timelock Proposal",
 					OverridePreviousRoot: false,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						types.ChainSelector(SepoliaSelector): {StartingOpCount: 0},
+						chaintest.Chain2Selector: {StartingOpCount: 0},
 					},
 				},
 				Action: types.TimelockActionSchedule,
 				Delay:  "24h",
 				TimelockAddresses: map[types.ChainSelector]string{
-					types.ChainSelector(SepoliaSelector): "0xTimelockAddress",
+					chaintest.Chain2Selector: "0xTimelockAddress",
 				},
 				Operations: []types.BatchOperation{
 					{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								Data:             []byte{0x01},
@@ -152,10 +153,10 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					SetOverridePreviousRoot(false).
 					SetAction(types.TimelockActionSchedule).
 					// Missing SetDelay
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
-					SetTimelockAddress(types.ChainSelector(SepoliaSelector), "0xTimelockAddress").
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
+					SetTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
 					AddOperation(types.BatchOperation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								Data:             []byte{0x01},
@@ -179,10 +180,10 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					SetOverridePreviousRoot(false).
 					SetAction(types.TimelockActionSchedule).
 					SetDelay("invalid_duration").
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
-					SetTimelockAddress(types.ChainSelector(SepoliaSelector), "0xTimelockAddress").
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
+					SetTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
 					AddOperation(types.BatchOperation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								Data:             []byte{0x01},
@@ -206,10 +207,10 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					SetOverridePreviousRoot(false).
 					SetAction(types.TimelockActionSchedule).
 					SetDelay("24h").
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
 					// Missing SetTimelockAddress
 					AddOperation(types.BatchOperation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								Data:             []byte{0x01},
@@ -233,8 +234,8 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					SetOverridePreviousRoot(false).
 					SetAction(types.TimelockActionSchedule).
 					SetDelay("24h").
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
-					SetTimelockAddress(types.ChainSelector(SepoliaSelector), "0xTimelockAddress")
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
+					SetTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress")
 				// No transactions added
 			},
 			want: nil,
@@ -251,10 +252,10 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					SetOverridePreviousRoot(false).
 					SetAction(types.TimelockActionSchedule).
 					SetDelay("24h").
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
-					SetTimelockAddress(types.ChainSelector(SepoliaSelector), "0xTimelockAddress").
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
+					SetTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
 					AddOperation(types.BatchOperation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								Data:             []byte{0x01},
@@ -278,10 +279,10 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					SetOverridePreviousRoot(false).
 					// Set an invalid action (not schedule, cancel, or bypass)
 					SetAction("invalid_action").
-					AddChainMetadata(types.ChainSelector(SepoliaSelector), types.ChainMetadata{StartingOpCount: 0}).
-					SetTimelockAddress(types.ChainSelector(SepoliaSelector), "0xTimelockAddress").
+					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
+					SetTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
 					AddOperation(types.BatchOperation{
-						ChainSelector: types.ChainSelector(SepoliaSelector),
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								Data: []byte{0x01},

--- a/executable_test.go
+++ b/executable_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
 	"github.com/smartcontractkit/mcms/internal/testutils/evmsim"
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm"
@@ -51,11 +52,11 @@ func Test_NewExecutable(t *testing.T) {
 			giveProposal: &Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {StartingOpCount: 5},
+						chaintest.Chain1Selector: {StartingOpCount: 5},
 					},
 				},
 				Operations: []types.Operation{
-					{ChainSelector: TestChain2},
+					{ChainSelector: chaintest.Chain2Selector},
 				},
 			},
 			giveExecutors: map[types.ChainSelector]sdk.Executor{
@@ -68,12 +69,12 @@ func Test_NewExecutable(t *testing.T) {
 			giveProposal: &Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {StartingOpCount: 5},
+						chaintest.Chain1Selector: {StartingOpCount: 5},
 					},
 				},
 				Operations: []types.Operation{
 					{
-						ChainSelector: TestChain1,
+						ChainSelector: chaintest.Chain1Selector,
 						Transaction: types.Transaction{
 							AdditionalFields: json.RawMessage([]byte(``)),
 						},
@@ -127,7 +128,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -135,7 +136,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 		},
 		Operations: []types.Operation{
 			{
-				ChainSelector: TestChain1,
+				ChainSelector: chaintest.Chain1Selector,
 				Transaction: evm.NewEVMOperation(
 					timelockC.Address(),
 					grantRoleData,
@@ -152,7 +153,9 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 	require.NoError(t, err)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{
+		chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client()),
+	}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -173,7 +176,11 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 
 	// Construct executors
 	executors := map[types.ChainSelector]sdk.Executor{
-		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim.Backend.Client(), sim.Signers[0].NewTransactOpts(t)),
+		chaintest.Chain1Selector: evm.NewEVMExecutor(
+			encoders[chaintest.Chain1Selector].(*evm.EVMEncoder),
+			sim.Backend.Client(),
+			sim.Signers[0].NewTransactOpts(t),
+		),
 	}
 
 	// Construct executable
@@ -181,7 +188,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerSingleTX_Success(t *testing.
 	require.NoError(t, err)
 
 	// SetRoot on the contract
-	txHash, err := executable.SetRoot(TestChain1)
+	txHash, err := executable.SetRoot(chaintest.Chain1Selector)
 	require.NoError(t, err)
 	require.NotEmpty(t, txHash)
 	sim.Backend.Commit()
@@ -241,7 +248,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -249,7 +256,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 		},
 		Operations: []types.Operation{
 			{
-				ChainSelector: TestChain1,
+				ChainSelector: chaintest.Chain1Selector,
 				Transaction: evm.NewEVMOperation(
 					timelockC.Address(),
 					grantRoleData,
@@ -266,7 +273,9 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 	require.NoError(t, err)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{
+		chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client()),
+	}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -290,7 +299,11 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 
 	// Construct executors
 	executors := map[types.ChainSelector]sdk.Executor{
-		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim.Backend.Client(), sim.Signers[0].NewTransactOpts(t)),
+		chaintest.Chain1Selector: evm.NewEVMExecutor(
+			encoders[chaintest.Chain1Selector].(*evm.EVMEncoder),
+			sim.Backend.Client(),
+			sim.Signers[0].NewTransactOpts(t),
+		),
 	}
 
 	// Construct executable
@@ -298,7 +311,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerSingleTX_Success(t *testin
 	require.NoError(t, err)
 
 	// SetRoot on the contract
-	txHash, err := executable.SetRoot(TestChain1)
+	txHash, err := executable.SetRoot(chaintest.Chain1Selector)
 	require.NoError(t, err)
 	require.NotEmpty(t, txHash)
 	sim.Backend.Commit()
@@ -358,7 +371,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 		require.NoError(t, perr)
 
 		operations[i] = types.Operation{
-			ChainSelector: TestChain1,
+			ChainSelector: chaintest.Chain1Selector,
 			Transaction: evm.NewEVMOperation(
 				timelockC.Address(),
 				data,
@@ -379,7 +392,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -393,7 +406,9 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 	require.NoError(t, err)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{
+		chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client()),
+	}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -414,7 +429,11 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 
 	// Construct executors
 	executors := map[types.ChainSelector]sdk.Executor{
-		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim.Backend.Client(), sim.Signers[0].NewTransactOpts(t)),
+		chaintest.Chain1Selector: evm.NewEVMExecutor(
+			encoders[chaintest.Chain1Selector].(*evm.EVMEncoder),
+			sim.Backend.Client(),
+			sim.Signers[0].NewTransactOpts(t),
+		),
 	}
 
 	// Construct executable
@@ -422,7 +441,7 @@ func TestExecutor_ExecuteE2E_SingleChainSingleSignerMultipleTX_Success(t *testin
 	require.NoError(t, err)
 
 	// SetRoot on the contract
-	txHash, err := executable.SetRoot(TestChain1)
+	txHash, err := executable.SetRoot(chaintest.Chain1Selector)
 	require.NoError(t, err)
 	require.NotEmpty(t, txHash)
 	sim.Backend.Commit()
@@ -488,7 +507,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 		data, perr := timelockAbi.Pack("grantRole", role, mcmC.Address())
 		require.NoError(t, perr)
 		operations[i] = types.Operation{
-			ChainSelector: TestChain1,
+			ChainSelector: chaintest.Chain1Selector,
 			Transaction: evm.NewEVMOperation(
 				timelockC.Address(),
 				data,
@@ -509,7 +528,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -523,7 +542,9 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 	require.NoError(t, err)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{
+		chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client()),
+	}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -547,7 +568,11 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 
 	// Construct executors
 	executors := map[types.ChainSelector]sdk.Executor{
-		TestChain1: evm.NewEVMExecutor(encoders[TestChain1].(*evm.EVMEncoder), sim.Backend.Client(), sim.Signers[0].NewTransactOpts(t)),
+		chaintest.Chain1Selector: evm.NewEVMExecutor(
+			encoders[chaintest.Chain1Selector].(*evm.EVMEncoder),
+			sim.Backend.Client(),
+			sim.Signers[0].NewTransactOpts(t),
+		),
 	}
 
 	// Construct executable
@@ -555,7 +580,7 @@ func TestExecutor_ExecuteE2E_SingleChainMultipleSignerMultipleTX_Success(t *test
 	require.NoError(t, err)
 
 	// SetRoot on the contract
-	txHash, err := executable.SetRoot(TestChain1)
+	txHash, err := executable.SetRoot(chaintest.Chain1Selector)
 	require.NoError(t, err)
 	require.NotEmpty(t, txHash)
 

--- a/factory_test.go
+++ b/factory_test.go
@@ -3,10 +3,10 @@ package mcms
 import (
 	"testing"
 
-	cselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/types"
@@ -30,17 +30,17 @@ func Test_NewEncoder(t *testing.T) {
 	}{
 		{
 			name:         "success: returns an EVM encoder (not simulated)",
-			giveSelector: types.ChainSelector(cselectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+			giveSelector: chaintest.Chain2Selector,
 			giveIsSim:    false,
 			want: &evm.EVMEncoder{
 				TxCount:              giveTxCount,
-				ChainID:              cselectors.ETHEREUM_TESTNET_SEPOLIA.EvmChainID,
+				ChainID:              chaintest.Chain2EVMID,
 				OverridePreviousRoot: false,
 			},
 		},
 		{
 			name:         "success: returns an EVM encoder (simulated)",
-			giveSelector: types.ChainSelector(cselectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
+			giveSelector: chaintest.Chain2Selector,
 			giveIsSim:    true,
 			want: &evm.EVMEncoder{
 				TxCount:              giveTxCount,
@@ -50,7 +50,7 @@ func Test_NewEncoder(t *testing.T) {
 		},
 		{
 			name:         "failure: chain not found for selector",
-			giveSelector: types.ChainSelector(0),
+			giveSelector: chaintest.TestInvalidChainSelector,
 			giveIsSim:    true,
 			wantErr:      "invalid chain ID: 0",
 		},

--- a/internal/testutils/chaintest/testchain.go
+++ b/internal/testutils/chaintest/testchain.go
@@ -1,0 +1,24 @@
+package chaintest
+
+import (
+	cselectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/mcms/types"
+)
+
+var (
+	Chain1RawSelector = cselectors.GETH_TESTNET.Selector       // 3379446385462418246
+	Chain1Selector    = types.ChainSelector(Chain1RawSelector) // 3379446385462418246
+	Chain1EVMID       = cselectors.GETH_TESTNET.EvmChainID     // 1337
+
+	Chain2RawSelector = cselectors.ETHEREUM_TESTNET_SEPOLIA.Selector   // 16015286601757825753
+	Chain2Selector    = types.ChainSelector(Chain2RawSelector)         // 16015286601757825753
+	Chain2EVMID       = cselectors.ETHEREUM_TESTNET_SEPOLIA.EvmChainID // 11155111
+
+	Chain3RawSelector = cselectors.ETHEREUM_TESTNET_SEPOLIA_BASE_1.Selector   // 10344971235874465080
+	Chain3Selector    = types.ChainSelector(Chain3RawSelector)                // 10344971235874465080
+	Chain3EVMID       = cselectors.ETHEREUM_TESTNET_SEPOLIA_BASE_1.EvmChainID // 84532
+
+	// TestInvalidChainSelector is a chain selector that doesn't exist.
+	TestInvalidChainSelector = types.ChainSelector(0)
+)

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-playground/validator/v10"
-	cselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/types"
@@ -21,9 +21,6 @@ import (
 
 var (
 	TestAddress = "0x1234567890abcdef"
-	TestChain1  = types.ChainSelector(cselectors.GETH_TESTNET.Selector)                    // 3379446385462418246
-	TestChain2  = types.ChainSelector(cselectors.ETHEREUM_TESTNET_SEPOLIA.Selector)        // 16015286601757825753
-	TestChain3  = types.ChainSelector(cselectors.ETHEREUM_TESTNET_SEPOLIA_BASE_1.Selector) // 10344971235874465080
 )
 
 func Test_BaseProposal_AppendSignature(t *testing.T) {
@@ -70,11 +67,11 @@ func Test_NewProposal(t *testing.T) {
 					Kind:       types.KindProposal,
 					ValidUntil: 2004259681,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {},
+						chaintest.Chain1Selector: {},
 					},
 				},
 				Operations: []types.Operation{
-					{ChainSelector: TestChain1},
+					{ChainSelector: chaintest.Chain1Selector},
 				},
 			},
 		},
@@ -151,11 +148,11 @@ func Test_WriteProposal(t *testing.T) {
 					Kind:       types.KindProposal,
 					ValidUntil: 2004259681,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {},
+						chaintest.Chain1Selector: {},
 					},
 				},
 				Operations: []types.Operation{
-					{ChainSelector: TestChain1},
+					{ChainSelector: chaintest.Chain1Selector},
 				},
 			},
 			want: `{
@@ -237,7 +234,7 @@ func Test_Proposal_Validate(t *testing.T) {
 					ValidUntil: 2004259681,
 					Signatures: []types.Signature{},
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {
+						chaintest.Chain1Selector: {
 							StartingOpCount: 1,
 							MCMAddress:      TestAddress,
 						},
@@ -245,7 +242,7 @@ func Test_Proposal_Validate(t *testing.T) {
 				},
 				Operations: []types.Operation{
 					{
-						ChainSelector: TestChain1,
+						ChainSelector: chaintest.Chain1Selector,
 						Transaction: types.Transaction{
 							To:               TestAddress,
 							AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
@@ -299,14 +296,14 @@ func Test_Proposal_Validate(t *testing.T) {
 					ValidUntil: 2004259681,
 					Signatures: []types.Signature{},
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {
+						chaintest.Chain1Selector: {
 							StartingOpCount: 1,
 							MCMAddress:      TestAddress,
 						},
 					},
 				},
 				Operations: []types.Operation{
-					{ChainSelector: TestChain2},
+					{ChainSelector: chaintest.Chain2Selector},
 				},
 			},
 			wantErrs: []string{
@@ -359,19 +356,19 @@ func Test_Proposal_GetEncoders(t *testing.T) {
 				BaseProposal: BaseProposal{
 					OverridePreviousRoot: false,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {},
-						TestChain2: {},
+						chaintest.Chain1Selector: {},
+						chaintest.Chain2Selector: {},
 					},
 				},
 				Operations: []types.Operation{
-					{ChainSelector: TestChain1},
-					{ChainSelector: TestChain1},
-					{ChainSelector: TestChain2},
+					{ChainSelector: chaintest.Chain1Selector},
+					{ChainSelector: chaintest.Chain1Selector},
+					{ChainSelector: chaintest.Chain2Selector},
 				},
 			},
 			want: map[types.ChainSelector]sdk.Encoder{
-				TestChain1: evm.NewEVMEncoder(2, 1337, false),
-				TestChain2: evm.NewEVMEncoder(1, 11155111, false),
+				chaintest.Chain1Selector: evm.NewEVMEncoder(2, 1337, false),
+				chaintest.Chain2Selector: evm.NewEVMEncoder(1, 11155111, false),
 			},
 		},
 		{
@@ -423,14 +420,19 @@ func Test_Proposal_ChainSelectors(t *testing.T) {
 	proposal := Proposal{
 		BaseProposal: BaseProposal{
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {},
-				TestChain2: {},
-				TestChain3: {},
+				chaintest.Chain1Selector: {},
+				chaintest.Chain2Selector: {},
+				chaintest.Chain3Selector: {},
 			},
 		},
 	}
 
-	want := []types.ChainSelector{TestChain1, TestChain3, TestChain2} // Sorted in ascending order
+	// Sorted in ascending order
+	want := []types.ChainSelector{
+		chaintest.Chain1Selector,
+		chaintest.Chain3Selector,
+		chaintest.Chain2Selector,
+	}
 	assert.Equal(t, want, proposal.ChainSelectors())
 }
 
@@ -448,13 +450,13 @@ func Test_Proposal_MerkleTree(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {StartingOpCount: 5},
-						TestChain2: {StartingOpCount: 10},
+						chaintest.Chain1Selector: {StartingOpCount: 5},
+						chaintest.Chain2Selector: {StartingOpCount: 10},
 					},
 				},
 				Operations: []types.Operation{
 					{
-						ChainSelector: TestChain1,
+						ChainSelector: chaintest.Chain1Selector,
 						Transaction: types.Transaction{
 							To:               TestAddress,
 							AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
@@ -466,7 +468,7 @@ func Test_Proposal_MerkleTree(t *testing.T) {
 						},
 					},
 					{
-						ChainSelector: TestChain2,
+						ChainSelector: chaintest.Chain2Selector,
 						Transaction: types.Transaction{
 							To:               TestAddress,
 							AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
@@ -498,11 +500,11 @@ func Test_Proposal_MerkleTree(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {StartingOpCount: 5},
+						chaintest.Chain1Selector: {StartingOpCount: 5},
 					},
 				},
 				Operations: []types.Operation{
-					{ChainSelector: TestChain2},
+					{ChainSelector: chaintest.Chain2Selector},
 				},
 			},
 			wantErr: "merkle tree generation error: missing metadata for chain 16015286601757825753",
@@ -512,11 +514,11 @@ func Test_Proposal_MerkleTree(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {StartingOpCount: uint64(math.MaxUint32 + 1)},
+						chaintest.Chain1Selector: {StartingOpCount: uint64(math.MaxUint32 + 1)},
 					},
 				},
 				Operations: []types.Operation{
-					{ChainSelector: TestChain1},
+					{ChainSelector: chaintest.Chain1Selector},
 				},
 			},
 			wantErr: "merkle tree generation error: value 4294967296 exceeds uint32 range",
@@ -526,12 +528,12 @@ func Test_Proposal_MerkleTree(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {StartingOpCount: 5},
+						chaintest.Chain1Selector: {StartingOpCount: 5},
 					},
 				},
 				Operations: []types.Operation{
 					{
-						ChainSelector: TestChain1,
+						ChainSelector: chaintest.Chain1Selector,
 						Transaction: types.Transaction{
 							AdditionalFields: json.RawMessage([]byte(``)),
 						},
@@ -562,9 +564,9 @@ func Test_Proposal_TransactionCounts(t *testing.T) {
 	t.Parallel()
 
 	ops := []types.Operation{
-		{ChainSelector: TestChain1},
-		{ChainSelector: TestChain1},
-		{ChainSelector: TestChain2},
+		{ChainSelector: chaintest.Chain1Selector},
+		{ChainSelector: chaintest.Chain1Selector},
+		{ChainSelector: chaintest.Chain2Selector},
 	}
 
 	proposal := Proposal{
@@ -574,8 +576,8 @@ func Test_Proposal_TransactionCounts(t *testing.T) {
 	got := proposal.TransactionCounts()
 
 	assert.Equal(t, map[types.ChainSelector]uint64{
-		TestChain1: 2,
-		TestChain2: 1,
+		chaintest.Chain1Selector: 2,
+		chaintest.Chain2Selector: 1,
 	}, got)
 }
 
@@ -593,17 +595,17 @@ func Test_Proposal_TransactionNonces(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {StartingOpCount: 5},
-						TestChain2: {StartingOpCount: 10},
-						TestChain3: {StartingOpCount: 15},
+						chaintest.Chain1Selector: {StartingOpCount: 5},
+						chaintest.Chain2Selector: {StartingOpCount: 10},
+						chaintest.Chain3Selector: {StartingOpCount: 15},
 					},
 				},
 				Operations: []types.Operation{
-					{ChainSelector: TestChain1},
-					{ChainSelector: TestChain2},
-					{ChainSelector: TestChain1},
-					{ChainSelector: TestChain2},
-					{ChainSelector: TestChain3},
+					{ChainSelector: chaintest.Chain1Selector},
+					{ChainSelector: chaintest.Chain2Selector},
+					{ChainSelector: chaintest.Chain1Selector},
+					{ChainSelector: chaintest.Chain2Selector},
+					{ChainSelector: chaintest.Chain3Selector},
 				},
 			},
 			want: []uint64{5, 10, 6, 11, 15},
@@ -615,7 +617,7 @@ func Test_Proposal_TransactionNonces(t *testing.T) {
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{},
 				},
 				Operations: []types.Operation{
-					{ChainSelector: TestChain1},
+					{ChainSelector: chaintest.Chain1Selector},
 				},
 			},
 			wantErr: "missing metadata for chain 3379446385462418246",

--- a/signable_test.go
+++ b/signable_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
 	"github.com/smartcontractkit/mcms/internal/testutils/evmsim"
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/sdk/evm"
@@ -58,12 +59,12 @@ func Test_NewSignable(t *testing.T) {
 			giveProposal: &Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {StartingOpCount: 5},
+						chaintest.Chain1Selector: {StartingOpCount: 5},
 					},
 				},
 				Operations: []types.Operation{
 					{
-						ChainSelector: TestChain1,
+						ChainSelector: chaintest.Chain1Selector,
 						Transaction: types.Transaction{
 							AdditionalFields: json.RawMessage([]byte(``)),
 						},
@@ -116,7 +117,7 @@ func TestSignable_SingleChainSingleSignerSingleTX_Success(t *testing.T) {
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -124,7 +125,7 @@ func TestSignable_SingleChainSingleSignerSingleTX_Success(t *testing.T) {
 		},
 		Operations: []types.Operation{
 			{
-				ChainSelector: TestChain1,
+				ChainSelector: chaintest.Chain1Selector,
 				Transaction: evm.NewEVMOperation(
 					timelockC.Address(),
 					grantRoleData,
@@ -138,7 +139,7 @@ func TestSignable_SingleChainSingleSignerSingleTX_Success(t *testing.T) {
 	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -181,7 +182,7 @@ func TestSignable_SingleChainMultipleSignerSingleTX_Success(t *testing.T) {
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -189,7 +190,7 @@ func TestSignable_SingleChainMultipleSignerSingleTX_Success(t *testing.T) {
 		},
 		Operations: []types.Operation{
 			{
-				ChainSelector: TestChain1,
+				ChainSelector: chaintest.Chain1Selector,
 				Transaction: evm.NewEVMOperation(
 					timelockC.Address(),
 					grantRoleData,
@@ -203,7 +204,7 @@ func TestSignable_SingleChainMultipleSignerSingleTX_Success(t *testing.T) {
 	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -249,7 +250,7 @@ func TestSignable_SingleChainSingleSignerMultipleTX_Success(t *testing.T) {
 		data, perr := timelockAbi.Pack("grantRole", role, mcmC.Address())
 		require.NoError(t, perr)
 		operations[i] = types.Operation{
-			ChainSelector: TestChain1,
+			ChainSelector: chaintest.Chain1Selector,
 			Transaction: evm.NewEVMOperation(
 				timelockC.Address(),
 				data,
@@ -270,7 +271,7 @@ func TestSignable_SingleChainSingleSignerMultipleTX_Success(t *testing.T) {
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -281,7 +282,7 @@ func TestSignable_SingleChainSingleSignerMultipleTX_Success(t *testing.T) {
 	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -324,7 +325,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_Success(t *testing.T) {
 		data, perr := timelockAbi.Pack("grantRole", role, mcmC.Address())
 		require.NoError(t, perr)
 		operations[i] = types.Operation{
-			ChainSelector: TestChain1,
+			ChainSelector: chaintest.Chain1Selector,
 			Transaction: evm.NewEVMOperation(
 				timelockC.Address(),
 				data,
@@ -345,7 +346,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_Success(t *testing.T) {
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -356,7 +357,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_Success(t *testing.T) {
 	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -402,7 +403,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureMissingQuorum(t *te
 		data, perr := timelockAbi.Pack("grantRole", role, mcmC.Address())
 		require.NoError(t, perr)
 		operations[i] = types.Operation{
-			ChainSelector: TestChain1,
+			ChainSelector: chaintest.Chain1Selector,
 			Transaction: evm.NewEVMOperation(
 				timelockC.Address(),
 				data,
@@ -423,7 +424,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureMissingQuorum(t *te
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -434,7 +435,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureMissingQuorum(t *te
 	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -486,7 +487,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureInvalidSigner(t *te
 		require.NoError(t, perr)
 
 		operations[i] = types.Operation{
-			ChainSelector: TestChain1,
+			ChainSelector: chaintest.Chain1Selector,
 			Transaction: evm.NewEVMOperation(
 				timelockC.Address(),
 				data,
@@ -507,7 +508,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureInvalidSigner(t *te
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      mcmC.Address().Hex(),
 				},
@@ -518,7 +519,7 @@ func TestSignable_SingleChainMultipleSignerMultipleTX_FailureInvalidSigner(t *te
 	proposal.UseSimulatedBackend(true)
 
 	// Gen caller map for easy access
-	inspectors := map[types.ChainSelector]sdk.Inspector{TestChain1: evm.NewEVMInspector(sim.Backend.Client())}
+	inspectors := map[types.ChainSelector]sdk.Inspector{chaintest.Chain1Selector: evm.NewEVMInspector(sim.Backend.Client())}
 
 	// Construct executor
 	signable, err := NewSignable(&proposal, inspectors)
@@ -558,7 +559,7 @@ func Test_Signable_Sign(t *testing.T) {
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      "0x01",
 				},
@@ -566,7 +567,7 @@ func Test_Signable_Sign(t *testing.T) {
 		},
 		Operations: []types.Operation{
 			{
-				ChainSelector: TestChain1,
+				ChainSelector: chaintest.Chain1Selector,
 				Transaction: evm.NewEVMOperation(
 					common.HexToAddress("0x02"),
 					[]byte("0x0000000"), // Use some random data since it doesn't matter
@@ -615,7 +616,7 @@ func Test_Signable_Sign(t *testing.T) {
 
 			// We need some inspectors to satisfy dependency validation, but this mock is unused.
 			inspectors := map[types.ChainSelector]sdk.Inspector{
-				TestChain1: mocks.NewInspector(t),
+				chaintest.Chain1Selector: mocks.NewInspector(t),
 			}
 
 			// Ensure that there are no signatures to being with
@@ -652,7 +653,7 @@ func Test_SignAndAppend(t *testing.T) {
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-				TestChain1: {
+				chaintest.Chain1Selector: {
 					StartingOpCount: 0,
 					MCMAddress:      "0x01",
 				},
@@ -660,7 +661,7 @@ func Test_SignAndAppend(t *testing.T) {
 		},
 		Operations: []types.Operation{
 			{
-				ChainSelector: TestChain1,
+				ChainSelector: chaintest.Chain1Selector,
 				Transaction: evm.NewEVMOperation(
 					common.HexToAddress("0x02"),
 					[]byte("0x0000000"), // Use some random data since it doesn't matter
@@ -702,7 +703,7 @@ func Test_SignAndAppend(t *testing.T) {
 
 			inspector := mocks.NewInspector(t)
 			inspectors := map[types.ChainSelector]sdk.Inspector{
-				TestChain1: inspector,
+				chaintest.Chain1Selector: inspector,
 			}
 
 			// Ensure that there are no signatures to being with
@@ -748,8 +749,8 @@ func Test_Signable_GetConfigs(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {MCMAddress: "0x01"},
-						TestChain2: {MCMAddress: "0x02"},
+						chaintest.Chain1Selector: {MCMAddress: "0x01"},
+						chaintest.Chain2Selector: {MCMAddress: "0x02"},
 					},
 				},
 			},
@@ -758,13 +759,13 @@ func Test_Signable_GetConfigs(t *testing.T) {
 				m.inspector2.EXPECT().GetConfig("0x02").Return(config2, nil)
 
 				return map[types.ChainSelector]sdk.Inspector{
-					TestChain1: m.inspector1,
-					TestChain2: m.inspector2,
+					chaintest.Chain1Selector: m.inspector1,
+					chaintest.Chain2Selector: m.inspector2,
 				}
 			},
 			want: map[types.ChainSelector]*types.Config{
-				TestChain1: config1,
-				TestChain2: config2,
+				chaintest.Chain1Selector: config1,
+				chaintest.Chain2Selector: config2,
 			},
 		},
 		{
@@ -780,7 +781,7 @@ func Test_Signable_GetConfigs(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {MCMAddress: "0x01"},
+						chaintest.Chain1Selector: {MCMAddress: "0x01"},
 					},
 				},
 			},
@@ -794,7 +795,7 @@ func Test_Signable_GetConfigs(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {MCMAddress: "0x01"},
+						chaintest.Chain1Selector: {MCMAddress: "0x01"},
 					},
 				},
 			},
@@ -802,7 +803,7 @@ func Test_Signable_GetConfigs(t *testing.T) {
 				m.inspector1.EXPECT().GetConfig("0x01").Return(nil, assert.AnError)
 
 				return map[types.ChainSelector]sdk.Inspector{
-					TestChain1: m.inspector1,
+					chaintest.Chain1Selector: m.inspector1,
 				}
 			},
 			wantErr: assert.AnError.Error(),
@@ -870,8 +871,8 @@ func Test_Signable_ValidateConfigs(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {MCMAddress: "0x01"},
-						TestChain2: {MCMAddress: "0x02"},
+						chaintest.Chain1Selector: {MCMAddress: "0x01"},
+						chaintest.Chain2Selector: {MCMAddress: "0x02"},
 					},
 				},
 			},
@@ -880,8 +881,8 @@ func Test_Signable_ValidateConfigs(t *testing.T) {
 				m.inspector2.EXPECT().GetConfig("0x02").Return(config2, nil)
 
 				return map[types.ChainSelector]sdk.Inspector{
-					TestChain1: m.inspector1,
-					TestChain2: m.inspector2,
+					chaintest.Chain1Selector: m.inspector1,
+					chaintest.Chain2Selector: m.inspector2,
 				}
 			},
 		},
@@ -898,8 +899,8 @@ func Test_Signable_ValidateConfigs(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {MCMAddress: "0x01"},
-						TestChain2: {MCMAddress: "0x02"},
+						chaintest.Chain1Selector: {MCMAddress: "0x01"},
+						chaintest.Chain2Selector: {MCMAddress: "0x02"},
 					},
 				},
 			},
@@ -908,8 +909,8 @@ func Test_Signable_ValidateConfigs(t *testing.T) {
 				m.inspector2.EXPECT().GetConfig("0x02").Return(config3, nil)
 
 				return map[types.ChainSelector]sdk.Inspector{
-					TestChain1: m.inspector1,
-					TestChain2: m.inspector2,
+					chaintest.Chain1Selector: m.inspector1,
+					chaintest.Chain2Selector: m.inspector2,
 				}
 			},
 			wantErr: "inconsistent configs for chains 16015286601757825753 and 3379446385462418246",
@@ -959,8 +960,8 @@ func Test_Signable_getCurrentOpCounts(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {MCMAddress: "0x01"},
-						TestChain2: {MCMAddress: "0x02"},
+						chaintest.Chain1Selector: {MCMAddress: "0x01"},
+						chaintest.Chain2Selector: {MCMAddress: "0x02"},
 					},
 				},
 			},
@@ -969,13 +970,13 @@ func Test_Signable_getCurrentOpCounts(t *testing.T) {
 				m.inspector2.EXPECT().GetOpCount("0x02").Return(200, nil)
 
 				return map[types.ChainSelector]sdk.Inspector{
-					TestChain1: m.inspector1,
-					TestChain2: m.inspector2,
+					chaintest.Chain1Selector: m.inspector1,
+					chaintest.Chain2Selector: m.inspector2,
 				}
 			},
 			want: map[types.ChainSelector]uint64{
-				TestChain1: 100,
-				TestChain2: 200,
+				chaintest.Chain1Selector: 100,
+				chaintest.Chain2Selector: 200,
 			},
 		},
 		{
@@ -991,7 +992,7 @@ func Test_Signable_getCurrentOpCounts(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {MCMAddress: "0x01"},
+						chaintest.Chain1Selector: {MCMAddress: "0x01"},
 					},
 				},
 			},
@@ -1005,7 +1006,7 @@ func Test_Signable_getCurrentOpCounts(t *testing.T) {
 			give: Proposal{
 				BaseProposal: BaseProposal{
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain1: {MCMAddress: "0x01"},
+						chaintest.Chain1Selector: {MCMAddress: "0x01"},
 					},
 				},
 			},
@@ -1013,7 +1014,7 @@ func Test_Signable_getCurrentOpCounts(t *testing.T) {
 				m.inspector1.EXPECT().GetOpCount("0x01").Return(0, assert.AnError)
 
 				return map[types.ChainSelector]sdk.Inspector{
-					TestChain1: m.inspector1,
+					chaintest.Chain1Selector: m.inspector1,
 				}
 			},
 			wantErr: assert.AnError.Error(),

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -11,17 +11,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
 	"github.com/smartcontractkit/mcms/types"
 )
 
 var validChainMetadata = map[types.ChainSelector]types.ChainMetadata{
-	TestChain1: {
+	chaintest.Chain1Selector: {
 		StartingOpCount: 1,
 		MCMAddress:      "0x123",
 	},
 }
 var validTimelockAddresses = map[types.ChainSelector]string{
-	TestChain1: "0x123",
+	chaintest.Chain1Selector: "0x123",
 }
 var validTx = types.Transaction{
 	To:               "0x123",
@@ -35,7 +36,7 @@ var validTx = types.Transaction{
 
 var validBatches = []types.BatchOperation{
 	{
-		ChainSelector: TestChain1,
+		ChainSelector: chaintest.Chain1Selector,
 		Transactions: []types.Transaction{
 			validTx,
 		},
@@ -90,7 +91,7 @@ func Test_NewTimelockProposal(t *testing.T) {
 					ValidUntil:  2004259681,
 					Description: "Test proposal",
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain2: {
+						chaintest.Chain2Selector: {
 							StartingOpCount: 0,
 							MCMAddress:      "0x0000000000000000000000000000000000000000",
 						},
@@ -100,11 +101,11 @@ func Test_NewTimelockProposal(t *testing.T) {
 				Action: types.TimelockActionSchedule,
 				Delay:  "1h",
 				TimelockAddresses: map[types.ChainSelector]string{
-					TestChain2: "0x01",
+					chaintest.Chain2Selector: "0x01",
 				},
 				Operations: []types.BatchOperation{
 					{
-						ChainSelector: TestChain2,
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								To:               "0x0000000000000000000000000000000000000000",
@@ -223,7 +224,7 @@ func Test_WriteTimelockProposal(t *testing.T) {
 					ValidUntil:  2004259681,
 					Description: "Test proposal",
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
-						TestChain2: {
+						chaintest.Chain2Selector: {
 							StartingOpCount: 0,
 							MCMAddress:      "0x0000000000000000000000000000000000000000",
 						},
@@ -235,7 +236,7 @@ func Test_WriteTimelockProposal(t *testing.T) {
 				TimelockAddresses: map[types.ChainSelector]string{},
 				Operations: []types.BatchOperation{
 					{
-						ChainSelector: TestChain2,
+						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
 								To:               "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
This aligns the way we need to fetch chain selector information for tests by extracting them out into a `testutils/chaintest` package. Tests can now use this common package to have the chain selector information that is consistent across all tests.