### PR TITLE
feat: changes timelock proposal delay field to a custom duration types

### DIFF
--- a/builder_timelock.go
+++ b/builder_timelock.go
@@ -35,7 +35,7 @@ func (b *TimelockProposalBuilder) SetAction(action types.TimelockAction) *Timelo
 }
 
 // SetDelay sets the delay of the timelock proposal.
-func (b *TimelockProposalBuilder) SetDelay(delay string) *TimelockProposalBuilder {
+func (b *TimelockProposalBuilder) SetDelay(delay types.Duration) *TimelockProposalBuilder {
 	b.proposal.Delay = delay
 	return b
 }
@@ -63,8 +63,8 @@ func (b *TimelockProposalBuilder) AddOperation(bop types.BatchOperation) *Timelo
 	return b
 }
 
-// SetTransactions sets all the transactions of the proposal
-func (b *TimelockProposalBuilder) SetTransactions(bops []types.BatchOperation) *TimelockProposalBuilder {
+// SetOperations sets all the operations of the proposal
+func (b *TimelockProposalBuilder) SetOperations(bops []types.BatchOperation) *TimelockProposalBuilder {
 	b.proposal.Operations = bops
 
 	return b
@@ -72,7 +72,6 @@ func (b *TimelockProposalBuilder) SetTransactions(bops []types.BatchOperation) *
 
 // Build validates and returns the constructed TimelockProposal.
 func (b *TimelockProposalBuilder) Build() (*TimelockProposal, error) {
-	// Validate the proposal
 	if err := b.proposal.Validate(); err != nil {
 		return nil, err
 	}

--- a/builder_timelock_test.go
+++ b/builder_timelock_test.go
@@ -2,18 +2,13 @@ package mcms_test
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"testing"
-	"time"
 
-	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/mcms"
 	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
-	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 	"github.com/smartcontractkit/mcms/types"
 )
 
@@ -21,36 +16,30 @@ func TestTimelockProposalBuilder(t *testing.T) {
 	t.Parallel()
 
 	// Define a fixed validUntil timestamp for consistency
-	fixedValidUntil := int64(1893456000) // January 1, 2030
-	fixedValidUntilCasted, err := safecast.Int64ToUint32(fixedValidUntil)
-	require.NoError(t, err)
-	pastValidUntil := time.Now().Add(-24 * time.Hour).Unix()
-	postValidUntilCasted, err := safecast.Int64ToUint32(pastValidUntil)
-	require.NoError(t, err)
-	futureValidUntil := time.Now().Add(24 * time.Hour).Unix()
-	futureValidUntilCasted, err := safecast.Int64ToUint32(futureValidUntil)
-	require.NoError(t, err)
+	fixedValidUntil := uint32(1893456000) // January 1, 2030
 
 	tests := []struct {
-		name     string
-		setup    func(*mcms.TimelockProposalBuilder)
-		want     *mcms.TimelockProposal
-		wantErrs []string
+		name    string
+		setup   func(*mcms.TimelockProposalBuilder)
+		want    *mcms.TimelockProposal
+		wantErr bool
 	}{
 		{
-			name: "valid timelock proposal",
+			name: "valid timelock proposal with setters",
 			setup: func(b *mcms.TimelockProposalBuilder) {
 				b.SetVersion("v1").
-					SetValidUntil(fixedValidUntilCasted).
+					SetValidUntil(fixedValidUntil).
 					SetDescription("Valid Timelock Proposal").
 					SetOverridePreviousRoot(false).
 					SetAction(types.TimelockActionSchedule).
-					SetDelay("24h").
-					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
+					SetDelay(types.MustParseDuration("24h")).
+					SetChainMetadata(map[types.ChainSelector]types.ChainMetadata{
+						chaintest.Chain2Selector: {StartingOpCount: 0},
+					}).
 					SetTimelockAddresses(map[types.ChainSelector]string{
 						chaintest.Chain2Selector: "0xTimelockAddress",
 					}).
-					AddOperation(types.BatchOperation{
+					SetOperations([]types.BatchOperation{{
 						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
@@ -59,13 +48,14 @@ func TestTimelockProposalBuilder(t *testing.T) {
 								AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
 							},
 						},
+					},
 					})
 			},
 			want: &mcms.TimelockProposal{
 				BaseProposal: mcms.BaseProposal{
 					Version:              "v1",
 					Kind:                 types.KindTimelockProposal,
-					ValidUntil:           fixedValidUntilCasted,
+					ValidUntil:           fixedValidUntil,
 					Description:          "Valid Timelock Proposal",
 					OverridePreviousRoot: false,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
@@ -73,7 +63,7 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					},
 				},
 				Action: types.TimelockActionSchedule,
-				Delay:  "24h",
+				Delay:  types.MustParseDuration("24h"),
 				TimelockAddresses: map[types.ChainSelector]string{
 					chaintest.Chain2Selector: "0xTimelockAddress",
 				},
@@ -90,20 +80,19 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					},
 				},
 			},
-			wantErrs: nil,
 		},
 		{
-			name: "valid timelock proposal with SetTransactions",
+			name: "valid timelock proposal with adders",
 			setup: func(b *mcms.TimelockProposalBuilder) {
 				b.SetVersion("v1").
-					SetValidUntil(fixedValidUntilCasted).
+					SetValidUntil(fixedValidUntil).
 					SetDescription("Valid Timelock Proposal").
 					SetOverridePreviousRoot(false).
 					SetAction(types.TimelockActionSchedule).
-					SetDelay("24h").
+					SetDelay(types.MustParseDuration("24h")).
 					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
 					AddTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
-					SetTransactions([]types.BatchOperation{{
+					AddOperation(types.BatchOperation{
 						ChainSelector: chaintest.Chain2Selector,
 						Transactions: []types.Transaction{
 							{
@@ -112,14 +101,13 @@ func TestTimelockProposalBuilder(t *testing.T) {
 								AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
 							},
 						},
-					},
 					})
 			},
 			want: &mcms.TimelockProposal{
 				BaseProposal: mcms.BaseProposal{
 					Version:              "v1",
 					Kind:                 types.KindTimelockProposal,
-					ValidUntil:           fixedValidUntilCasted,
+					ValidUntil:           fixedValidUntil,
 					Description:          "Valid Timelock Proposal",
 					OverridePreviousRoot: false,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
@@ -127,7 +115,7 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					},
 				},
 				Action: types.TimelockActionSchedule,
-				Delay:  "24h",
+				Delay:  types.MustParseDuration("24h"),
 				TimelockAddresses: map[types.ChainSelector]string{
 					chaintest.Chain2Selector: "0xTimelockAddress",
 				},
@@ -144,159 +132,11 @@ func TestTimelockProposalBuilder(t *testing.T) {
 					},
 				},
 			},
-			wantErrs: nil,
 		},
 		{
-			name: "missing delay on schedule operation",
-			setup: func(b *mcms.TimelockProposalBuilder) {
-				b.SetVersion("v1").
-					SetValidUntil(futureValidUntilCasted).
-					SetDescription("Missing Delay").
-					SetOverridePreviousRoot(false).
-					SetAction(types.TimelockActionSchedule).
-					// Missing SetDelay
-					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
-					AddTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
-					AddOperation(types.BatchOperation{
-						ChainSelector: chaintest.Chain2Selector,
-						Transactions: []types.Transaction{
-							{
-								Data:             []byte{0x01},
-								To:               "0xContractAddress",
-								AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
-							},
-						},
-					})
-			},
-			want: nil,
-			wantErrs: []string{
-				"invalid delay: ",
-			},
-		},
-		{
-			name: "invalid delay format",
-			setup: func(b *mcms.TimelockProposalBuilder) {
-				b.SetVersion("v1").
-					SetValidUntil(fixedValidUntilCasted).
-					SetDescription("Invalid Delay Format").
-					SetOverridePreviousRoot(false).
-					SetAction(types.TimelockActionSchedule).
-					SetDelay("invalid_duration").
-					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
-					AddTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
-					AddOperation(types.BatchOperation{
-						ChainSelector: chaintest.Chain2Selector,
-						Transactions: []types.Transaction{
-							{
-								Data:             []byte{0x01},
-								To:               "0xContractAddress",
-								AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
-							},
-						},
-					})
-			},
-			want: nil,
-			wantErrs: []string{
-				"invalid delay: invalid_duration",
-			},
-		},
-		{
-			name: "missing timelock address",
-			setup: func(b *mcms.TimelockProposalBuilder) {
-				b.SetVersion("v1").
-					SetValidUntil(futureValidUntilCasted).
-					SetDescription("Missing Timelock Address").
-					SetOverridePreviousRoot(false).
-					SetAction(types.TimelockActionSchedule).
-					SetDelay("24h").
-					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
-					// Missing SetTimelockAddress
-					AddOperation(types.BatchOperation{
-						ChainSelector: chaintest.Chain2Selector,
-						Transactions: []types.Transaction{
-							{
-								Data:             []byte{0x01},
-								To:               "0xContractAddress",
-								AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
-							},
-						},
-					})
-			},
-			want: nil,
-			wantErrs: []string{
-				"Key: 'TimelockProposal.TimelockAddresses' Error:Field validation for 'TimelockAddresses' failed on the 'min' tag",
-			},
-		},
-		{
-			name: "missing transactions",
-			setup: func(b *mcms.TimelockProposalBuilder) {
-				b.SetVersion("v1").
-					SetValidUntil(futureValidUntilCasted).
-					SetDescription("Missing Transactions").
-					SetOverridePreviousRoot(false).
-					SetAction(types.TimelockActionSchedule).
-					SetDelay("24h").
-					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
-					AddTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress")
-				// No transactions added
-			},
-			want: nil,
-			wantErrs: []string{
-				"Key: 'TimelockProposal.Operations' Error:Field validation for 'Operations' failed on the 'min' tag",
-			},
-		},
-		{
-			name: "validUntil in past",
-			setup: func(b *mcms.TimelockProposalBuilder) {
-				b.SetVersion("v1").
-					SetValidUntil(postValidUntilCasted).
-					SetDescription("ValidUntil in Past").
-					SetOverridePreviousRoot(false).
-					SetAction(types.TimelockActionSchedule).
-					SetDelay("24h").
-					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
-					AddTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
-					AddOperation(types.BatchOperation{
-						ChainSelector: chaintest.Chain2Selector,
-						Transactions: []types.Transaction{
-							{
-								Data:             []byte{0x01},
-								To:               "0xContractAddress",
-								AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
-							},
-						},
-					})
-			},
-			want: nil,
-			wantErrs: []string{
-				fmt.Sprintf("invalid valid until: %d", pastValidUntil),
-			},
-		},
-		{
-			name: "invalid operation",
-			setup: func(b *mcms.TimelockProposalBuilder) {
-				b.SetVersion("v1").
-					SetValidUntil(fixedValidUntilCasted).
-					SetDescription("Invalid Action").
-					SetOverridePreviousRoot(false).
-					// Set an invalid action (not schedule, cancel, or bypass)
-					SetAction("invalid_action").
-					AddChainMetadata(chaintest.Chain2Selector, types.ChainMetadata{StartingOpCount: 0}).
-					AddTimelockAddress(chaintest.Chain2Selector, "0xTimelockAddress").
-					AddOperation(types.BatchOperation{
-						ChainSelector: chaintest.Chain2Selector,
-						Transactions: []types.Transaction{
-							{
-								Data: []byte{0x01},
-								To:   "0xContractAddress",
-							},
-						},
-					})
-			},
-			want: nil,
-			wantErrs: []string{
-				"Key: 'TimelockProposal.Action' Error:Field validation for 'Action' failed on the 'oneof' tag",
-			},
+			name:    "validation fails: missing delay",
+			want:    nil,
+			wantErr: true,
 		},
 	}
 
@@ -305,32 +145,18 @@ func TestTimelockProposalBuilder(t *testing.T) {
 			t.Parallel()
 
 			builder := mcms.NewTimelockProposalBuilder()
-			tt.setup(builder)
 
-			proposal, err := builder.Build()
-			if tt.wantErrs != nil {
+			if tt.setup != nil {
+				tt.setup(builder)
+			}
+
+			got, err := builder.Build()
+			if tt.wantErr {
 				require.Error(t, err)
-				assert.Nil(t, proposal)
-
-				var errs validator.ValidationErrors
-				if errors.As(err, &errs) {
-					assert.Len(t, errs, len(tt.wantErrs))
-
-					got := []string{}
-					for _, e := range errs {
-						got = append(got, e.Error())
-					}
-
-					assert.ElementsMatch(t, tt.wantErrs, got)
-				} else {
-					assert.ElementsMatch(t, tt.wantErrs, []string{err.Error()})
-				}
+				assert.Nil(t, got)
 			} else {
 				require.NoError(t, err)
-				assert.NotNil(t, proposal)
-
-				// Compare the built proposal to the expected proposal
-				assert.Equal(t, tt.want, proposal)
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}

--- a/docs/usage/building-proposals.md
+++ b/docs/usage/building-proposals.md
@@ -154,13 +154,18 @@ func main() {
 	builder := mcms.NewTimelockProposalBuilder()
 	selector := types.ChainSelector(chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector)
 
+	delay, err := types.ParseDuration("1h")
+	if err != nil {
+		log.Fatalf("Error parsing duration: %v", err)
+	}
+
 	// Step 2: Set Proposal Details
 	builder.
 		SetVersion("v1").
 		SetValidUntil(1794610529).
 		SetDescription("Increase staking rewards").
 		SetAction(types.TimelockActionSchedule).
-		SetDelay("1h").
+		SetDelay(delay).
 		SetOverridePreviousRoot(false)
 
 	// Step 3: Set Chain Metadata

--- a/sdk/evm/timelock_converter.go
+++ b/sdk/evm/timelock_converter.go
@@ -3,7 +3,6 @@ package evm
 import (
 	"encoding/json"
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -24,7 +23,7 @@ type TimelockConverter struct{}
 func (t *TimelockConverter) ConvertBatchToChainOperation(
 	bop types.BatchOperation,
 	timelockAddress string,
-	minDelay string,
+	delay types.Duration,
 	action types.TimelockAction,
 	predecessor common.Hash,
 ) (types.Operation, common.Hash, error) {
@@ -47,7 +46,6 @@ func (t *TimelockConverter) ConvertBatchToChainOperation(
 	}
 
 	salt := ZERO_HASH
-	delay, _ := time.ParseDuration(minDelay)
 
 	abi, errAbi := bindings.RBACTimelockMetaData.GetAbi()
 	if errAbi != nil {

--- a/sdk/evm/timelock_converter_test.go
+++ b/sdk/evm/timelock_converter_test.go
@@ -22,7 +22,7 @@ func TestTimelockConverter_ConvertBatchToChainOperation(t *testing.T) {
 	testCases := []struct {
 		name           string
 		op             types.BatchOperation
-		minDelay       string
+		delay          string
 		operation      types.TimelockAction
 		predecessor    common.Hash
 		expectedError  error
@@ -42,7 +42,7 @@ func TestTimelockConverter_ConvertBatchToChainOperation(t *testing.T) {
 				},
 				ChainSelector: types.ChainSelector(cselectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 			},
-			minDelay:       "1h",
+			delay:          "1h",
 			operation:      types.TimelockActionSchedule,
 			predecessor:    zeroHash,
 			expectedError:  nil,
@@ -62,7 +62,7 @@ func TestTimelockConverter_ConvertBatchToChainOperation(t *testing.T) {
 				},
 				ChainSelector: types.ChainSelector(cselectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 			},
-			minDelay:       "1h",
+			delay:          "1h",
 			operation:      types.TimelockActionCancel,
 			predecessor:    zeroHash,
 			expectedError:  nil,
@@ -82,7 +82,7 @@ func TestTimelockConverter_ConvertBatchToChainOperation(t *testing.T) {
 				},
 				ChainSelector: types.ChainSelector(cselectors.ETHEREUM_TESTNET_SEPOLIA.Selector),
 			},
-			minDelay:       "1h",
+			delay:          "1h",
 			operation:      types.TimelockAction("invalid"),
 			predecessor:    zeroHash,
 			expectedError:  sdkerrors.NewInvalidTimelockOperationError("invalid"),
@@ -95,7 +95,9 @@ func TestTimelockConverter_ConvertBatchToChainOperation(t *testing.T) {
 			t.Parallel()
 
 			converter := &TimelockConverter{}
-			chainOperation, operationId, err := converter.ConvertBatchToChainOperation(tc.op, timelockAddress, tc.minDelay, tc.operation, tc.predecessor)
+			chainOperation, operationId, err := converter.ConvertBatchToChainOperation(
+				tc.op, timelockAddress, types.MustParseDuration(tc.delay), tc.operation, tc.predecessor,
+			)
 
 			if tc.expectedError != nil {
 				require.Error(t, err)

--- a/sdk/timelock_converter.go
+++ b/sdk/timelock_converter.go
@@ -11,7 +11,7 @@ type TimelockConverter interface {
 	ConvertBatchToChainOperation(
 		bop types.BatchOperation,
 		timelockAddress string,
-		delay string,
+		delay types.Duration,
 		action types.TimelockAction,
 		predecessor common.Hash,
 	) (types.Operation, common.Hash, error)

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -99,7 +99,7 @@ func Test_NewTimelockProposal(t *testing.T) {
 					OverridePreviousRoot: false,
 				},
 				Action: types.TimelockActionSchedule,
-				Delay:  "1h",
+				Delay:  types.MustParseDuration("1h"),
 				TimelockAddresses: map[types.ChainSelector]string{
 					chaintest.Chain2Selector: "0x01",
 				},
@@ -132,7 +132,7 @@ func Test_NewTimelockProposal(t *testing.T) {
 				"description": "Test proposal",
 				"overridePreviousRoot": false,
 				"action": "schedule",
-				"delay": "1h",
+				"delay": "1h0m0s",
 				"timelockAddresses": {
 					"16015286601757825753": "0x01"
 				},
@@ -232,7 +232,7 @@ func Test_WriteTimelockProposal(t *testing.T) {
 					OverridePreviousRoot: false,
 				},
 				Action:            types.TimelockActionSchedule,
-				Delay:             "1h",
+				Delay:             types.MustParseDuration("1h"),
 				TimelockAddresses: map[types.ChainSelector]string{},
 				Operations: []types.BatchOperation{
 					{
@@ -260,7 +260,7 @@ func Test_WriteTimelockProposal(t *testing.T) {
 				"description": "Test proposal",
 				"overridePreviousRoot": false,
 				"action": "schedule",
-				"delay": "1h",
+				"delay": "1h0m0s",
 				"signatures": null,
 				"timelockAddresses": {},
 				"operations": [
@@ -329,7 +329,7 @@ func TestTimelockProposal_Validation(t *testing.T) {
 		timelockAddr   map[types.ChainSelector]string
 		bops           []types.BatchOperation
 		timelockAction types.TimelockAction
-		timelockDelay  string
+		timelockDelay  types.Duration
 		expectedError  error
 	}{
 		{
@@ -343,7 +343,7 @@ func TestTimelockProposal_Validation(t *testing.T) {
 			timelockAddr:   validTimelockAddresses,
 			bops:           validBatches,
 			timelockAction: types.TimelockActionSchedule,
-			timelockDelay:  "1h",
+			timelockDelay:  types.MustParseDuration("1h"),
 			expectedError:  nil,
 		},
 		{
@@ -357,7 +357,7 @@ func TestTimelockProposal_Validation(t *testing.T) {
 			timelockAddr:   validTimelockAddresses,
 			bops:           validBatches,
 			timelockAction: types.TimelockActionSchedule,
-			timelockDelay:  "1h",
+			timelockDelay:  types.MustParseDuration("1h"),
 			expectedError:  errors.New("Key: 'TimelockProposal.BaseProposal.Version' Error:Field validation for 'Version' failed on the 'required' tag"),
 		},
 		{
@@ -371,7 +371,7 @@ func TestTimelockProposal_Validation(t *testing.T) {
 			timelockAddr:   validTimelockAddresses,
 			bops:           validBatches,
 			timelockAction: types.TimelockActionSchedule,
-			timelockDelay:  "1h",
+			timelockDelay:  types.MustParseDuration("1h"),
 			expectedError:  errors.New("Key: 'TimelockProposal.BaseProposal.ValidUntil' Error:Field validation for 'ValidUntil' failed on the 'required' tag"),
 		},
 		{
@@ -385,7 +385,7 @@ func TestTimelockProposal_Validation(t *testing.T) {
 			timelockAddr:   validTimelockAddresses,
 			bops:           validBatches,
 			timelockAction: types.TimelockActionSchedule,
-			timelockDelay:  "1h",
+			timelockDelay:  types.MustParseDuration("1h"),
 			expectedError:  errors.New("Key: 'TimelockProposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'required' tag"),
 		},
 		{
@@ -399,7 +399,7 @@ func TestTimelockProposal_Validation(t *testing.T) {
 			timelockAddr:   nil,
 			bops:           validBatches,
 			timelockAction: types.TimelockActionSchedule,
-			timelockDelay:  "1h",
+			timelockDelay:  types.MustParseDuration("1h"),
 			expectedError:  errors.New("Key: 'TimelockProposal.TimelockAddresses' Error:Field validation for 'TimelockAddresses' failed on the 'required' tag"),
 		},
 		{
@@ -413,7 +413,7 @@ func TestTimelockProposal_Validation(t *testing.T) {
 			timelockAddr:   validTimelockAddresses,
 			bops:           nil,
 			timelockAction: types.TimelockActionSchedule,
-			timelockDelay:  "1h",
+			timelockDelay:  types.MustParseDuration("1h"),
 			expectedError:  errors.New("Key: 'TimelockProposal.Operations' Error:Field validation for 'Operations' failed on the 'required' tag"),
 		},
 		{
@@ -427,22 +427,8 @@ func TestTimelockProposal_Validation(t *testing.T) {
 			timelockAddr:   validTimelockAddresses,
 			bops:           validBatches,
 			timelockAction: types.TimelockAction("invalid"),
-			timelockDelay:  "1h",
+			timelockDelay:  types.MustParseDuration("1h"),
 			expectedError:  errors.New("Key: 'TimelockProposal.Action' Error:Field validation for 'Action' failed on the 'oneof' tag"),
-		},
-		{
-			name:           "Invalid timelockDelay",
-			version:        "v1",
-			validUntil:     2004259681,
-			signatures:     []types.Signature{},
-			overridePrev:   false,
-			chainMetadata:  validChainMetadata,
-			description:    "description",
-			timelockAddr:   validTimelockAddresses,
-			bops:           validBatches,
-			timelockAction: types.TimelockActionSchedule,
-			timelockDelay:  "1nm",
-			expectedError:  errors.New("invalid delay: 1nm"),
 		},
 	}
 
@@ -486,7 +472,7 @@ func TestTimelockProposal_Convert(t *testing.T) {
 		validTimelockAddresses,
 		validBatches,
 		types.TimelockActionSchedule,
-		"1h",
+		types.MustParseDuration("1h"),
 	)
 	require.NoError(t, err)
 

--- a/types/duration.go
+++ b/types/duration.go
@@ -1,0 +1,71 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Duration wraps time.Duration with support for JSON encoding.
+type Duration struct {
+	time.Duration
+}
+
+// NewDuration wraps a time.Duration with a Duration.
+func NewDuration(d time.Duration) Duration {
+	return Duration{Duration: d}
+}
+
+// ParseDuration parses a duration string in the time.Duration format.
+func ParseDuration(s string) (Duration, error) {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return Duration{}, err
+	}
+
+	return NewDuration(d), nil
+}
+
+// MustParseDuration parses a duration string in the time.Duration format.
+// Panics if the string is invalid.
+//
+// Useful for tests, but should be avoided in production code.
+func MustParseDuration(s string) Duration {
+	d, err := ParseDuration(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return d
+}
+
+// String returns a string representing the duration in the form "72h3m0.5s".
+func (d Duration) String() string {
+	return d.Duration.String()
+}
+
+// MarshalJSON marshals the duration into JSON bytes and implements the json.Marshaler interface.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON unmarshals the duration from JSON bytes and implements the json.Unmarshaler
+// interface.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	switch value := v.(type) {
+	case string:
+		var err error
+		if d.Duration, err = time.ParseDuration(value); err != nil {
+			return err
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("invalid duration type: %T", v)
+	}
+}

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -1,0 +1,158 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewDuration(t *testing.T) {
+	t.Parallel()
+
+	d, err := time.ParseDuration("1h")
+	require.NoError(t, err)
+
+	assert.Equal(t, Duration{Duration: d}, NewDuration(d))
+}
+
+func Test_ParseDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    string
+		want    Duration
+		wantErr string
+	}{
+		{
+			name: "success",
+			give: "1h",
+			want: MustParseDuration("1h"),
+		},
+		{
+			name:    "invalid duration string",
+			give:    "a",
+			wantErr: "time: invalid duration \"a\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := ParseDuration(tt.give)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, actual)
+			}
+		})
+	}
+}
+
+func Test_MustParseDuration(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		d, err := time.ParseDuration("1h")
+		require.NoError(t, err)
+
+		got := MustParseDuration("1h")
+		assert.Equal(t, Duration{Duration: d}, got)
+	})
+
+	assert.Panics(t, func() {
+		MustParseDuration("a")
+	})
+}
+
+func Test_Duration_String(t *testing.T) {
+	t.Parallel()
+
+	d, err := time.ParseDuration("1h")
+	require.NoError(t, err)
+
+	assert.Equal(t, "1h0m0s", NewDuration(d).String())
+}
+
+func Test_Duration_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    Duration
+		want    []byte
+		wantErr string
+	}{
+		{
+			name: "success",
+			give: MustParseDuration("1h"),
+			want: []byte(`"1h0m0s"`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.give.MarshalJSON()
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_Duration_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    []byte
+		want    Duration
+		wantErr string
+	}{
+		{
+			name: "valid string",
+			give: []byte(`"1h"`),
+			want: MustParseDuration("1h"),
+		},
+		{
+			name:    "invalid float64",
+			give:    []byte(`1`),
+			wantErr: "invalid duration type: float64",
+		},
+		{
+			name:    "invalid time string",
+			give:    []byte(`"a"`),
+			wantErr: "time: invalid duration \"a\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got Duration
+			err := got.UnmarshalJSON(tt.give)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -14,7 +14,7 @@ import (
 func BatchToChainOperation(
 	bops types.BatchOperation,
 	timelockAddr string,
-	delay string,
+	delay types.Duration,
 	action types.TimelockAction,
 	predecessor common.Hash,
 ) (types.Operation, common.Hash, error) {


### PR DESCRIPTION
This adds a new `Duration` type which is a wrapper around `time.Duration` to allow for custom JSON marshalling and unmarshalling. The `Delay` field in the `TimelockProposal` has been updated to use this new type. This allows us to validate the duration format more easily.