### PR TITLE
refactor: updates the unorderedArrayEquals method for efficiency

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -70,10 +70,6 @@ func (c *Config) Equals(other *Config) bool {
 		return false
 	}
 
-	if len(c.Signers) != len(other.Signers) {
-		return false
-	}
-
 	// Compare signers (order doesn't matter)
 	if !unorderedArrayEquals(c.Signers, other.Signers) {
 		return false
@@ -155,28 +151,21 @@ func unorderedArrayEquals[T comparable](a, b []T) bool {
 		return false
 	}
 
-	aMap := make(map[T]struct{})
-	bMap := make(map[T]struct{})
+	countMap := make(map[T]int)
 
-	for _, i := range a {
-		aMap[i] = struct{}{}
+	// Count occurrences in the first slice
+	for _, elem := range a {
+		countMap[elem]++
 	}
 
-	for _, i := range b {
-		bMap[i] = struct{}{}
-	}
-
-	for _, i := range a {
-		if _, ok := bMap[i]; !ok {
+	// Subtract occurrences using the second slice
+	for _, elem := range b {
+		if countMap[elem] == 0 {
 			return false
 		}
+		countMap[elem]--
 	}
 
-	for _, i := range b {
-		if _, ok := aMap[i]; !ok {
-			return false
-		}
-	}
-
+	// If slices are equal, all counts should be zero
 	return true
 }

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -347,3 +347,59 @@ func Test_Config_CanSetRoot(t *testing.T) {
 		})
 	}
 }
+
+func Test_unorderedArrayEquals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a, b []common.Address
+		want bool
+	}{
+		{
+			name: "success: equal arrays in same order",
+			a:    []common.Address{signer1, signer2, signer3},
+			b:    []common.Address{signer1, signer2, signer3},
+			want: true,
+		},
+		{
+			name: "success: equal arrays in different order",
+			a:    []common.Address{signer1, signer2, signer3},
+			b:    []common.Address{signer3, signer1, signer2},
+			want: true,
+		},
+		{
+			name: "failure: different lengths",
+			a:    []common.Address{signer1, signer2},
+			b:    []common.Address{signer1, signer2, signer3},
+			want: false,
+		},
+		{
+			name: "failure: different elements",
+			a:    []common.Address{signer1, signer2, signer3},
+			b:    []common.Address{signer1, signer2, signer4},
+			want: false,
+		},
+		{
+			name: "success: both empty arrays",
+			a:    []common.Address{},
+			b:    []common.Address{},
+			want: true,
+		},
+		{
+			name: "failure: one empty array",
+			a:    []common.Address{signer1},
+			b:    []common.Address{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := unorderedArrayEquals(tt.a, tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Updates the `unorderedArrayEquals` method to improve readability and space efficiency gain as we no longer initialize 2 maps

Adds tests to ensure the method works as expected.