### PR TITLE
docs(docsify): auto scroll up on page change

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,8 @@
         name: "Many Chain Multisig System",
         repo: "https://github.com/smartcontractkit/mcms",
         homepage: "README.md",
-        loadSidebar: true
+        loadSidebar: true,
+        auto2top: true,
       };
     </script>
     <!-- Docsify v4 -->


### PR DESCRIPTION
Currently there is an annoying behaviour where if you change pages, it does not reset the scroll bar to the top. If you are viewing the bottom of a page and change to a new change, scrollbar remains at the bottom of the page and you have to scroll up manually.

Setting auto2top will reset scrollbar to the top on page change. JD has this set to true as well.