### PR TITLE
fix(solana): fetch full history

### DIFF
--- a/e2e/tests/compile-mcm-solana.sh
+++ b/e2e/tests/compile-mcm-solana.sh
@@ -15,7 +15,7 @@ DEST_DIR="../artifacts/solana"
 TEMP_DIR=$(mktemp -d)
 COMMIT_HASH="a91ea5187123329c28553b884e31e5fce4f0e030" # 31 Dec 2024
 
-git clone --depth 1 $REPO_URL $TEMP_DIR/$REPO_DIR
+git clone $REPO_URL $TEMP_DIR/$REPO_DIR
 cd $TEMP_DIR/$REPO_DIR/$MCM_DIR
 git checkout $COMMIT_HASH
 


### PR DESCRIPTION
Instead of using `--depth 1` which only clone the recent history, we needed to clone the full history so we can fetch a hardcoded version of the repo `a91ea5187123329c28553b884e31e5fce4f0e030`.

error:
```
 fatal: unable to read tree (a91ea5187123329c28553b884e31e5fce4f0e030)
 ```
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4o-2024-08-06). Be mindful of hallucinations and verify accuracy.**

## Why

The changes remove the shallow clone option in the Solana compilation script to ensure the full history is fetched. This is necessary for operations that require access to the complete commit history.

## What

- **compile-mcm-solana.sh**
  - Removed shallow clone option from git clone command.
