### PR TITLE
fix(cfgtransformer): GroupSigners should be assigned in reverse order

### DIFF
--- a/.changeset/nervous-bugs-cry.md
+++ b/.changeset/nervous-bugs-cry.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+Fix assignment of `GroupSigners` in `ConfigTransformer.ToConfig()`

--- a/e2e/tests/solana/set_config.go
+++ b/e2e/tests/solana/set_config.go
@@ -45,18 +45,16 @@ func (s *SolanaTestSuite) Test_Solana_SetConfig() {
 					testEVMAccounts[6].Address,
 					testEVMAccounts[7].Address,
 				},
-				GroupSigners: []types.Config{},
-				// FIXME: needs https://github.com/smartcontractkit/mcms/pull/216
-				// GroupSigners: []types.Config{
-				// 	{
-				// 		Quorum: 1,
-				// 		Signers: []common.Address{
-				// 			testEVMAccounts[8].Address,
-				// 			testEVMAccounts[9].Address,
-				// 		},
-				// 		GroupSigners: []types.Config{},
-				// 	},
-				// },
+				GroupSigners: []types.Config{
+					{
+						Quorum: 1,
+						Signers: []common.Address{
+							testEVMAccounts[8].Address,
+							testEVMAccounts[9].Address,
+						},
+						GroupSigners: []types.Config{},
+					},
+				},
 			},
 			{
 				Quorum: 3,

--- a/sdk/evm/config_transformer.go
+++ b/sdk/evm/config_transformer.go
@@ -44,9 +44,11 @@ func (e *ConfigTransformer) ToConfig(
 		}
 	}
 
-	for i, parent := range bindConfig.GroupParents {
+	// link the group signers; this assumes a group's parent always has a lower index
+	for i := 31; i >= 0; i-- {
+		parent := bindConfig.GroupParents[i]
 		if i > 0 && groups[i].Quorum > 0 {
-			groups[parent].GroupSigners = append(groups[parent].GroupSigners, groups[i])
+			groups[parent].GroupSigners = append([]types.Config{groups[i]}, groups[parent].GroupSigners...)
 		}
 	}
 

--- a/sdk/evm/config_transformer_test.go
+++ b/sdk/evm/config_transformer_test.go
@@ -49,6 +49,87 @@ func Test_ConfigTransformer_ToConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "success: nested configs",
+			give: bindings.ManyChainMultiSigConfig{
+				GroupQuorums: [32]uint8{2, 4, 1, 1, 3, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				GroupParents: [32]uint8{0, 0, 1, 2, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Signers: []bindings.ManyChainMultiSigSigner{
+					{Addr: common.HexToAddress("0x156a4DB782D04911FFd880885e04Fdb3611084cf"), Index: 0, Group: 0},
+					{Addr: common.HexToAddress("0x16e1Ff31F5890C75E737703883b6696966d40bef"), Index: 1, Group: 0},
+					{Addr: common.HexToAddress("0x34eDf371A1489Fc463579De16af39502eeF0D58C"), Index: 2, Group: 0},
+					{Addr: common.HexToAddress("0x3A7942bB5A8597769a7D32698fe58483f6D983c9"), Index: 3, Group: 1},
+					{Addr: common.HexToAddress("0x3e87E9D6fbe4660e55150228E600b2f3bfd25463"), Index: 4, Group: 1},
+					{Addr: common.HexToAddress("0x5262971Ba093A8ce9D739A3Cbe860319EA181eAF"), Index: 5, Group: 1},
+					{Addr: common.HexToAddress("0x63c49Cc2075cE6050E2413De66181dE456A99982"), Index: 6, Group: 1},
+					{Addr: common.HexToAddress("0x666bC8eD0Ac152f60e2A8EBEE68528940af3370F"), Index: 7, Group: 1},
+					{Addr: common.HexToAddress("0x67530Eb5B40a4279a21AAcace0192417c1040956"), Index: 8, Group: 2},
+					{Addr: common.HexToAddress("0x9ACc926BbD7fd76Ac9f19295D4cb0769e3f0bD43"), Index: 9, Group: 2},
+					{Addr: common.HexToAddress("0xAC3cd4fE42fEd3CeBad0D8B1164D048FeF46376f"), Index: 10, Group: 3},
+					{Addr: common.HexToAddress("0xc6E315d96A4dD15F3B844fEA41cc00E37aF0830d"), Index: 11, Group: 4},
+					{Addr: common.HexToAddress("0xd30dDc8cD88e4B4843BAC08B9551c2c91DCD44d6"), Index: 12, Group: 4},
+					{Addr: common.HexToAddress("0xE0b8e2CCe74082197423C4d6f4232c4316133A35"), Index: 13, Group: 4},
+					{Addr: common.HexToAddress("0xEcB7cd3f3FDb405e1Dfa24Ba1565F19fe65Bc460"), Index: 14, Group: 4},
+					{Addr: common.HexToAddress("0xFCc93a2f3d4511Db830b079A3c8B7c96594b232B"), Index: 15, Group: 5},
+				},
+			},
+			want: &types.Config{
+				Quorum: 2,
+				Signers: []common.Address{
+					common.HexToAddress("0x156a4DB782D04911FFd880885e04Fdb3611084cf"),
+					common.HexToAddress("0x16e1Ff31F5890C75E737703883b6696966d40bef"),
+					common.HexToAddress("0x34eDf371A1489Fc463579De16af39502eeF0D58C"),
+				},
+				GroupSigners: []types.Config{
+					{
+						Quorum: 4,
+						Signers: []common.Address{
+							common.HexToAddress("0x3A7942bB5A8597769a7D32698fe58483f6D983c9"),
+							common.HexToAddress("0x3e87E9D6fbe4660e55150228E600b2f3bfd25463"),
+							common.HexToAddress("0x5262971Ba093A8ce9D739A3Cbe860319EA181eAF"),
+							common.HexToAddress("0x63c49Cc2075cE6050E2413De66181dE456A99982"),
+							common.HexToAddress("0x666bC8eD0Ac152f60e2A8EBEE68528940af3370F"),
+						},
+						GroupSigners: []types.Config{
+							{
+								Quorum: 1,
+								Signers: []common.Address{
+									common.HexToAddress("0x67530Eb5B40a4279a21AAcace0192417c1040956"),
+									common.HexToAddress("0x9ACc926BbD7fd76Ac9f19295D4cb0769e3f0bD43"),
+								},
+								GroupSigners: []types.Config{
+									{
+										Quorum: 1,
+										Signers: []common.Address{
+											common.HexToAddress("0xAC3cd4fE42fEd3CeBad0D8B1164D048FeF46376f"),
+										},
+										GroupSigners: []types.Config{},
+									},
+								},
+							},
+						},
+					},
+					{
+						Quorum: 3,
+						Signers: []common.Address{
+							common.HexToAddress("0xc6E315d96A4dD15F3B844fEA41cc00E37aF0830d"),
+							common.HexToAddress("0xd30dDc8cD88e4B4843BAC08B9551c2c91DCD44d6"),
+							common.HexToAddress("0xE0b8e2CCe74082197423C4d6f4232c4316133A35"),
+							common.HexToAddress("0xEcB7cd3f3FDb405e1Dfa24Ba1565F19fe65Bc460"),
+						},
+						GroupSigners: []types.Config{
+							{
+								Quorum: 1,
+								Signers: []common.Address{
+									common.HexToAddress("0xFCc93a2f3d4511Db830b079A3c8B7c96594b232B"),
+								},
+								GroupSigners: []types.Config{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "failure: validation error on resulting config",
 			give: bindings.ManyChainMultiSigConfig{
 				GroupQuorums: [32]uint8{0, 1}, // A zero quorum makes this invalid

--- a/sdk/solana/config_transformer.go
+++ b/sdk/solana/config_transformer.go
@@ -38,9 +38,11 @@ func (e *ConfigTransformer) ToConfig(
 		}
 	}
 
-	for i, parent := range bindConfig.GroupParents {
+	// link the group signers; this assumes a group's parent always has a lower index
+	for i := 31; i >= 0; i-- {
+		parent := bindConfig.GroupParents[i]
 		if i > 0 && groups[i].Quorum > 0 {
-			groups[parent].GroupSigners = append(groups[parent].GroupSigners, groups[i])
+			groups[parent].GroupSigners = append([]types.Config{groups[i]}, groups[parent].GroupSigners...)
 		}
 	}
 

--- a/sdk/solana/config_transformer_test.go
+++ b/sdk/solana/config_transformer_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/go-cmp/cmp"
 	bindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/mcms/types"
@@ -48,6 +48,87 @@ func Test_ConfigTransformer_ToConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "success: nested configs",
+			give: bindings.MultisigConfig{
+				GroupQuorums: [32]uint8{2, 4, 1, 1, 3, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				GroupParents: [32]uint8{0, 0, 1, 2, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Signers: []bindings.McmSigner{
+					{EvmAddress: common.HexToAddress("0x156a4DB782D04911FFd880885e04Fdb3611084cf"), Index: 0, Group: 0},
+					{EvmAddress: common.HexToAddress("0x16e1Ff31F5890C75E737703883b6696966d40bef"), Index: 1, Group: 0},
+					{EvmAddress: common.HexToAddress("0x34eDf371A1489Fc463579De16af39502eeF0D58C"), Index: 2, Group: 0},
+					{EvmAddress: common.HexToAddress("0x3A7942bB5A8597769a7D32698fe58483f6D983c9"), Index: 3, Group: 1},
+					{EvmAddress: common.HexToAddress("0x3e87E9D6fbe4660e55150228E600b2f3bfd25463"), Index: 4, Group: 1},
+					{EvmAddress: common.HexToAddress("0x5262971Ba093A8ce9D739A3Cbe860319EA181eAF"), Index: 5, Group: 1},
+					{EvmAddress: common.HexToAddress("0x63c49Cc2075cE6050E2413De66181dE456A99982"), Index: 6, Group: 1},
+					{EvmAddress: common.HexToAddress("0x666bC8eD0Ac152f60e2A8EBEE68528940af3370F"), Index: 7, Group: 1},
+					{EvmAddress: common.HexToAddress("0x67530Eb5B40a4279a21AAcace0192417c1040956"), Index: 8, Group: 2},
+					{EvmAddress: common.HexToAddress("0x9ACc926BbD7fd76Ac9f19295D4cb0769e3f0bD43"), Index: 9, Group: 2},
+					{EvmAddress: common.HexToAddress("0xAC3cd4fE42fEd3CeBad0D8B1164D048FeF46376f"), Index: 10, Group: 3},
+					{EvmAddress: common.HexToAddress("0xc6E315d96A4dD15F3B844fEA41cc00E37aF0830d"), Index: 11, Group: 4},
+					{EvmAddress: common.HexToAddress("0xd30dDc8cD88e4B4843BAC08B9551c2c91DCD44d6"), Index: 12, Group: 4},
+					{EvmAddress: common.HexToAddress("0xE0b8e2CCe74082197423C4d6f4232c4316133A35"), Index: 13, Group: 4},
+					{EvmAddress: common.HexToAddress("0xEcB7cd3f3FDb405e1Dfa24Ba1565F19fe65Bc460"), Index: 14, Group: 4},
+					{EvmAddress: common.HexToAddress("0xFCc93a2f3d4511Db830b079A3c8B7c96594b232B"), Index: 15, Group: 5},
+				},
+			},
+			want: &types.Config{
+				Quorum: 2,
+				Signers: []common.Address{
+					common.HexToAddress("0x156a4DB782D04911FFd880885e04Fdb3611084cf"),
+					common.HexToAddress("0x16e1Ff31F5890C75E737703883b6696966d40bef"),
+					common.HexToAddress("0x34eDf371A1489Fc463579De16af39502eeF0D58C"),
+				},
+				GroupSigners: []types.Config{
+					{
+						Quorum: 4,
+						Signers: []common.Address{
+							common.HexToAddress("0x3A7942bB5A8597769a7D32698fe58483f6D983c9"),
+							common.HexToAddress("0x3e87E9D6fbe4660e55150228E600b2f3bfd25463"),
+							common.HexToAddress("0x5262971Ba093A8ce9D739A3Cbe860319EA181eAF"),
+							common.HexToAddress("0x63c49Cc2075cE6050E2413De66181dE456A99982"),
+							common.HexToAddress("0x666bC8eD0Ac152f60e2A8EBEE68528940af3370F"),
+						},
+						GroupSigners: []types.Config{
+							{
+								Quorum: 1,
+								Signers: []common.Address{
+									common.HexToAddress("0x67530Eb5B40a4279a21AAcace0192417c1040956"),
+									common.HexToAddress("0x9ACc926BbD7fd76Ac9f19295D4cb0769e3f0bD43"),
+								},
+								GroupSigners: []types.Config{
+									{
+										Quorum: 1,
+										Signers: []common.Address{
+											common.HexToAddress("0xAC3cd4fE42fEd3CeBad0D8B1164D048FeF46376f"),
+										},
+										GroupSigners: []types.Config{},
+									},
+								},
+							},
+						},
+					},
+					{
+						Quorum: 3,
+						Signers: []common.Address{
+							common.HexToAddress("0xc6E315d96A4dD15F3B844fEA41cc00E37aF0830d"),
+							common.HexToAddress("0xd30dDc8cD88e4B4843BAC08B9551c2c91DCD44d6"),
+							common.HexToAddress("0xE0b8e2CCe74082197423C4d6f4232c4316133A35"),
+							common.HexToAddress("0xEcB7cd3f3FDb405e1Dfa24Ba1565F19fe65Bc460"),
+						},
+						GroupSigners: []types.Config{
+							{
+								Quorum: 1,
+								Signers: []common.Address{
+									common.HexToAddress("0xFCc93a2f3d4511Db830b079A3c8B7c96594b232B"),
+								},
+								GroupSigners: []types.Config{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "failure: validation error on resulting config",
 			give: bindings.MultisigConfig{
 				GroupQuorums: [32]uint8{0, 1}, // A zero quorum makes this invalid
@@ -72,7 +153,7 @@ func Test_ConfigTransformer_ToConfig(t *testing.T) {
 				require.EqualError(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tt.want, got)
+				require.Empty(t, cmp.Diff(tt.want, got))
 			}
 		})
 	}


### PR DESCRIPTION
The current ConfigTransformer.ToConfig implementation does not properly set nested `GroupSigner` attributes because it copies the group's reference before the attribute is assigned:

```
1. group1.GroupSigners = append(group1.GroupSigners, group2)  // appends copy of group2
2. group2.GroupSigners = ...                                  // modifies original
```

This patch fixes the issue by processing groups in the reverse order:

```
1. group2.GroupSigners = ...                                  // modifies original
2. group1.GroupSigners = append(group1.GroupSigners, group2)  // appends (modified)copy of group2
```
<!-- DON'T DELETE. add your comments above llm generated contents -->