### PR TITLE
docs: typo NewEVMInspector

### DIFF
--- a/docs/usage/signing-proposals.md
+++ b/docs/usage/signing-proposals.md
@@ -37,7 +37,7 @@ func main() {
 	selector := chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
 	backend := backends.SimulatedBackend{}
 	inspectorsMap := make(map[types.ChainSelector]sdk.Inspector)
-	inspectorsMap[types.ChainSelector(selector)] = evm.NewEVMInspector(backend)
+	inspectorsMap[types.ChainSelector(selector)] = evm.NewInspector(backend)
 	signable, err := mcms.NewSignable(proposal, inspectorsMap)
 
 	// 3. Sign the proposal bytes

--- a/docs/usage/timelock-proposal-flow.md
+++ b/docs/usage/timelock-proposal-flow.md
@@ -57,7 +57,7 @@ func main() {
 	selector := chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
 	backend := backends.SimulatedBackend{}
 	inspectorsMap := make(map[types.ChainSelector]sdk.Inspector)
-	inspectorsMap[types.ChainSelector(selector)] = evm.NewEVMInspector(backend)
+	inspectorsMap[types.ChainSelector(selector)] = evm.NewInspector(backend)
 	signable, err := mcms.NewSignable(&mcmsProposal, inspectorsMap)
 	if err != nil {
 		log.Fatalf("failed to open file: %v", err)


### PR DESCRIPTION
`NewEVMInspector` -> `NewInspector`

Looks like a typo
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4o-2024-08-06). Be mindful of hallucinations and verify accuracy.**

## Why
Corrects a typo in the documentation by replacing `NewEVMInspector` with `NewInspector` to ensure consistency and accuracy in the code examples provided.

## What
- **signing-proposals.md**
  - Replace `NewEVMInspector` with `NewInspector` in code example
- **timelock-proposal-flow.md**
  - Replace `NewEVMInspector` with `NewInspector` in code example
