### PR TITLE
[DRAFT] fix: update inspector api 

### DIFF
--- a/sdk/evm/inspector.go
+++ b/sdk/evm/inspector.go
@@ -1,6 +1,8 @@
 package evm
 
 import (
+	"context"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
@@ -25,8 +27,8 @@ func NewInspector(client ContractDeployBackend) *Inspector {
 	}
 }
 
-func (e *Inspector) GetConfig(mcmAddress string) (*types.Config, error) {
-	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(mcmAddress), e.client)
+func (e *Inspector) GetConfig(_ context.Context, addr sdk.AddrMetadata) (*types.Config, error) {
+	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(addr.MCMAddress), e.client)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +41,8 @@ func (e *Inspector) GetConfig(mcmAddress string) (*types.Config, error) {
 	return e.ToConfig(onchainConfig)
 }
 
-func (e *Inspector) GetOpCount(mcmAddress string) (uint64, error) {
-	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(mcmAddress), e.client)
+func (e *Inspector) GetOpCount(_ context.Context, addr sdk.AddrMetadata) (uint64, error) {
+	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(addr.MCMAddress), e.client)
 	if err != nil {
 		return 0, err
 	}
@@ -53,8 +55,8 @@ func (e *Inspector) GetOpCount(mcmAddress string) (uint64, error) {
 	return opCount.Uint64(), nil
 }
 
-func (e *Inspector) GetRoot(mcmAddress string) (common.Hash, uint32, error) {
-	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(mcmAddress), e.client)
+func (e *Inspector) GetRoot(_ context.Context, addr sdk.AddrMetadata) (common.Hash, uint32, error) {
+	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(addr.MCMAddress), e.client)
 	if err != nil {
 		return common.Hash{}, 0, err
 	}
@@ -67,8 +69,8 @@ func (e *Inspector) GetRoot(mcmAddress string) (common.Hash, uint32, error) {
 	return root.Root, root.ValidUntil, nil
 }
 
-func (e *Inspector) GetRootMetadata(mcmAddress string) (types.ChainMetadata, error) {
-	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(mcmAddress), e.client)
+func (e *Inspector) GetRootMetadata(_ context.Context, addr sdk.AddrMetadata) (types.ChainMetadata, error) {
+	mcmsObj, err := bindings.NewManyChainMultiSig(common.HexToAddress(addr.MCMAddress), e.client)
 	if err != nil {
 		return types.ChainMetadata{}, err
 	}
@@ -80,6 +82,6 @@ func (e *Inspector) GetRootMetadata(mcmAddress string) (types.ChainMetadata, err
 
 	return types.ChainMetadata{
 		StartingOpCount: metadata.PreOpCount.Uint64(),
-		MCMAddress:      mcmAddress,
+		MCMAddress:      addr.MCMAddress,
 	}, nil
 }

--- a/sdk/inspector.go
+++ b/sdk/inspector.go
@@ -1,15 +1,29 @@
 package sdk
 
 import (
+	"context"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/mcms/types"
 )
 
+type SolanaAdditionalFields struct {
+	// MSIGName is a differentiator/seed for supporting
+	// multiple multisigs with a single deployed program
+	// only applicable to Solana
+	MSIGName []byte
+}
+
+type AddrMetadata struct {
+	MCMAddress             string
+	SolanaAdditionalFields SolanaAdditionalFields
+}
+
 // Inspector is an interface for inspecting on chain state of MCMS contracts.
 type Inspector interface {
-	GetConfig(mcmAddress string) (*types.Config, error)
-	GetOpCount(mcmAddress string) (uint64, error)
-	GetRoot(mcmAddress string) (common.Hash, uint32, error)
-	GetRootMetadata(mcmAddress string) (types.ChainMetadata, error)
+	GetConfig(ctx context.Context, addr AddrMetadata) (*types.Config, error)
+	GetOpCount(ctx context.Context, addr AddrMetadata) (uint64, error)
+	GetRoot(ctx context.Context, addr AddrMetadata) (common.Hash, uint32, error)
+	GetRootMetadata(ctx context.Context, addr AddrMetadata) (types.ChainMetadata, error)
 }

--- a/sdk/mocks/executor.go
+++ b/sdk/mocks/executor.go
@@ -3,8 +3,13 @@
 package mocks
 
 import (
+	context "context"
+
 	common "github.com/ethereum/go-ethereum/common"
+
 	mock "github.com/stretchr/testify/mock"
+
+	sdk "github.com/smartcontractkit/mcms/sdk"
 
 	types "github.com/smartcontractkit/mcms/types"
 )
@@ -81,9 +86,9 @@ func (_c *Executor_ExecuteOperation_Call) RunAndReturn(run func(types.ChainMetad
 	return _c
 }
 
-// GetConfig provides a mock function with given fields: mcmAddress
-func (_m *Executor) GetConfig(mcmAddress string) (*types.Config, error) {
-	ret := _m.Called(mcmAddress)
+// GetConfig provides a mock function with given fields: ctx, addr
+func (_m *Executor) GetConfig(ctx context.Context, addr sdk.AddrMetadata) (*types.Config, error) {
+	ret := _m.Called(ctx, addr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConfig")
@@ -91,19 +96,19 @@ func (_m *Executor) GetConfig(mcmAddress string) (*types.Config, error) {
 
 	var r0 *types.Config
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*types.Config, error)); ok {
-		return rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) (*types.Config, error)); ok {
+		return rf(ctx, addr)
 	}
-	if rf, ok := ret.Get(0).(func(string) *types.Config); ok {
-		r0 = rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) *types.Config); ok {
+		r0 = rf(ctx, addr)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.Config)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(mcmAddress)
+	if rf, ok := ret.Get(1).(func(context.Context, sdk.AddrMetadata) error); ok {
+		r1 = rf(ctx, addr)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -117,14 +122,15 @@ type Executor_GetConfig_Call struct {
 }
 
 // GetConfig is a helper method to define mock.On call
-//   - mcmAddress string
-func (_e *Executor_Expecter) GetConfig(mcmAddress interface{}) *Executor_GetConfig_Call {
-	return &Executor_GetConfig_Call{Call: _e.mock.On("GetConfig", mcmAddress)}
+//   - ctx context.Context
+//   - addr sdk.AddrMetadata
+func (_e *Executor_Expecter) GetConfig(ctx interface{}, addr interface{}) *Executor_GetConfig_Call {
+	return &Executor_GetConfig_Call{Call: _e.mock.On("GetConfig", ctx, addr)}
 }
 
-func (_c *Executor_GetConfig_Call) Run(run func(mcmAddress string)) *Executor_GetConfig_Call {
+func (_c *Executor_GetConfig_Call) Run(run func(ctx context.Context, addr sdk.AddrMetadata)) *Executor_GetConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(sdk.AddrMetadata))
 	})
 	return _c
 }
@@ -134,14 +140,14 @@ func (_c *Executor_GetConfig_Call) Return(_a0 *types.Config, _a1 error) *Executo
 	return _c
 }
 
-func (_c *Executor_GetConfig_Call) RunAndReturn(run func(string) (*types.Config, error)) *Executor_GetConfig_Call {
+func (_c *Executor_GetConfig_Call) RunAndReturn(run func(context.Context, sdk.AddrMetadata) (*types.Config, error)) *Executor_GetConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetOpCount provides a mock function with given fields: mcmAddress
-func (_m *Executor) GetOpCount(mcmAddress string) (uint64, error) {
-	ret := _m.Called(mcmAddress)
+// GetOpCount provides a mock function with given fields: ctx, addr
+func (_m *Executor) GetOpCount(ctx context.Context, addr sdk.AddrMetadata) (uint64, error) {
+	ret := _m.Called(ctx, addr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOpCount")
@@ -149,17 +155,17 @@ func (_m *Executor) GetOpCount(mcmAddress string) (uint64, error) {
 
 	var r0 uint64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (uint64, error)); ok {
-		return rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) (uint64, error)); ok {
+		return rf(ctx, addr)
 	}
-	if rf, ok := ret.Get(0).(func(string) uint64); ok {
-		r0 = rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) uint64); ok {
+		r0 = rf(ctx, addr)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(mcmAddress)
+	if rf, ok := ret.Get(1).(func(context.Context, sdk.AddrMetadata) error); ok {
+		r1 = rf(ctx, addr)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -173,14 +179,15 @@ type Executor_GetOpCount_Call struct {
 }
 
 // GetOpCount is a helper method to define mock.On call
-//   - mcmAddress string
-func (_e *Executor_Expecter) GetOpCount(mcmAddress interface{}) *Executor_GetOpCount_Call {
-	return &Executor_GetOpCount_Call{Call: _e.mock.On("GetOpCount", mcmAddress)}
+//   - ctx context.Context
+//   - addr sdk.AddrMetadata
+func (_e *Executor_Expecter) GetOpCount(ctx interface{}, addr interface{}) *Executor_GetOpCount_Call {
+	return &Executor_GetOpCount_Call{Call: _e.mock.On("GetOpCount", ctx, addr)}
 }
 
-func (_c *Executor_GetOpCount_Call) Run(run func(mcmAddress string)) *Executor_GetOpCount_Call {
+func (_c *Executor_GetOpCount_Call) Run(run func(ctx context.Context, addr sdk.AddrMetadata)) *Executor_GetOpCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(sdk.AddrMetadata))
 	})
 	return _c
 }
@@ -190,14 +197,14 @@ func (_c *Executor_GetOpCount_Call) Return(_a0 uint64, _a1 error) *Executor_GetO
 	return _c
 }
 
-func (_c *Executor_GetOpCount_Call) RunAndReturn(run func(string) (uint64, error)) *Executor_GetOpCount_Call {
+func (_c *Executor_GetOpCount_Call) RunAndReturn(run func(context.Context, sdk.AddrMetadata) (uint64, error)) *Executor_GetOpCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetRoot provides a mock function with given fields: mcmAddress
-func (_m *Executor) GetRoot(mcmAddress string) (common.Hash, uint32, error) {
-	ret := _m.Called(mcmAddress)
+// GetRoot provides a mock function with given fields: ctx, addr
+func (_m *Executor) GetRoot(ctx context.Context, addr sdk.AddrMetadata) (common.Hash, uint32, error) {
+	ret := _m.Called(ctx, addr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRoot")
@@ -206,25 +213,25 @@ func (_m *Executor) GetRoot(mcmAddress string) (common.Hash, uint32, error) {
 	var r0 common.Hash
 	var r1 uint32
 	var r2 error
-	if rf, ok := ret.Get(0).(func(string) (common.Hash, uint32, error)); ok {
-		return rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) (common.Hash, uint32, error)); ok {
+		return rf(ctx, addr)
 	}
-	if rf, ok := ret.Get(0).(func(string) common.Hash); ok {
-		r0 = rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) common.Hash); ok {
+		r0 = rf(ctx, addr)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Hash)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) uint32); ok {
-		r1 = rf(mcmAddress)
+	if rf, ok := ret.Get(1).(func(context.Context, sdk.AddrMetadata) uint32); ok {
+		r1 = rf(ctx, addr)
 	} else {
 		r1 = ret.Get(1).(uint32)
 	}
 
-	if rf, ok := ret.Get(2).(func(string) error); ok {
-		r2 = rf(mcmAddress)
+	if rf, ok := ret.Get(2).(func(context.Context, sdk.AddrMetadata) error); ok {
+		r2 = rf(ctx, addr)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -238,14 +245,15 @@ type Executor_GetRoot_Call struct {
 }
 
 // GetRoot is a helper method to define mock.On call
-//   - mcmAddress string
-func (_e *Executor_Expecter) GetRoot(mcmAddress interface{}) *Executor_GetRoot_Call {
-	return &Executor_GetRoot_Call{Call: _e.mock.On("GetRoot", mcmAddress)}
+//   - ctx context.Context
+//   - addr sdk.AddrMetadata
+func (_e *Executor_Expecter) GetRoot(ctx interface{}, addr interface{}) *Executor_GetRoot_Call {
+	return &Executor_GetRoot_Call{Call: _e.mock.On("GetRoot", ctx, addr)}
 }
 
-func (_c *Executor_GetRoot_Call) Run(run func(mcmAddress string)) *Executor_GetRoot_Call {
+func (_c *Executor_GetRoot_Call) Run(run func(ctx context.Context, addr sdk.AddrMetadata)) *Executor_GetRoot_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(sdk.AddrMetadata))
 	})
 	return _c
 }
@@ -255,14 +263,14 @@ func (_c *Executor_GetRoot_Call) Return(_a0 common.Hash, _a1 uint32, _a2 error) 
 	return _c
 }
 
-func (_c *Executor_GetRoot_Call) RunAndReturn(run func(string) (common.Hash, uint32, error)) *Executor_GetRoot_Call {
+func (_c *Executor_GetRoot_Call) RunAndReturn(run func(context.Context, sdk.AddrMetadata) (common.Hash, uint32, error)) *Executor_GetRoot_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetRootMetadata provides a mock function with given fields: mcmAddress
-func (_m *Executor) GetRootMetadata(mcmAddress string) (types.ChainMetadata, error) {
-	ret := _m.Called(mcmAddress)
+// GetRootMetadata provides a mock function with given fields: ctx, addr
+func (_m *Executor) GetRootMetadata(ctx context.Context, addr sdk.AddrMetadata) (types.ChainMetadata, error) {
+	ret := _m.Called(ctx, addr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRootMetadata")
@@ -270,17 +278,17 @@ func (_m *Executor) GetRootMetadata(mcmAddress string) (types.ChainMetadata, err
 
 	var r0 types.ChainMetadata
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (types.ChainMetadata, error)); ok {
-		return rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) (types.ChainMetadata, error)); ok {
+		return rf(ctx, addr)
 	}
-	if rf, ok := ret.Get(0).(func(string) types.ChainMetadata); ok {
-		r0 = rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) types.ChainMetadata); ok {
+		r0 = rf(ctx, addr)
 	} else {
 		r0 = ret.Get(0).(types.ChainMetadata)
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(mcmAddress)
+	if rf, ok := ret.Get(1).(func(context.Context, sdk.AddrMetadata) error); ok {
+		r1 = rf(ctx, addr)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -294,14 +302,15 @@ type Executor_GetRootMetadata_Call struct {
 }
 
 // GetRootMetadata is a helper method to define mock.On call
-//   - mcmAddress string
-func (_e *Executor_Expecter) GetRootMetadata(mcmAddress interface{}) *Executor_GetRootMetadata_Call {
-	return &Executor_GetRootMetadata_Call{Call: _e.mock.On("GetRootMetadata", mcmAddress)}
+//   - ctx context.Context
+//   - addr sdk.AddrMetadata
+func (_e *Executor_Expecter) GetRootMetadata(ctx interface{}, addr interface{}) *Executor_GetRootMetadata_Call {
+	return &Executor_GetRootMetadata_Call{Call: _e.mock.On("GetRootMetadata", ctx, addr)}
 }
 
-func (_c *Executor_GetRootMetadata_Call) Run(run func(mcmAddress string)) *Executor_GetRootMetadata_Call {
+func (_c *Executor_GetRootMetadata_Call) Run(run func(ctx context.Context, addr sdk.AddrMetadata)) *Executor_GetRootMetadata_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(sdk.AddrMetadata))
 	})
 	return _c
 }
@@ -311,7 +320,7 @@ func (_c *Executor_GetRootMetadata_Call) Return(_a0 types.ChainMetadata, _a1 err
 	return _c
 }
 
-func (_c *Executor_GetRootMetadata_Call) RunAndReturn(run func(string) (types.ChainMetadata, error)) *Executor_GetRootMetadata_Call {
+func (_c *Executor_GetRootMetadata_Call) RunAndReturn(run func(context.Context, sdk.AddrMetadata) (types.ChainMetadata, error)) *Executor_GetRootMetadata_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sdk/mocks/inspector.go
+++ b/sdk/mocks/inspector.go
@@ -3,8 +3,13 @@
 package mocks
 
 import (
+	context "context"
+
 	common "github.com/ethereum/go-ethereum/common"
+
 	mock "github.com/stretchr/testify/mock"
+
+	sdk "github.com/smartcontractkit/mcms/sdk"
 
 	types "github.com/smartcontractkit/mcms/types"
 )
@@ -22,9 +27,9 @@ func (_m *Inspector) EXPECT() *Inspector_Expecter {
 	return &Inspector_Expecter{mock: &_m.Mock}
 }
 
-// GetConfig provides a mock function with given fields: mcmAddress
-func (_m *Inspector) GetConfig(mcmAddress string) (*types.Config, error) {
-	ret := _m.Called(mcmAddress)
+// GetConfig provides a mock function with given fields: ctx, addr
+func (_m *Inspector) GetConfig(ctx context.Context, addr sdk.AddrMetadata) (*types.Config, error) {
+	ret := _m.Called(ctx, addr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConfig")
@@ -32,19 +37,19 @@ func (_m *Inspector) GetConfig(mcmAddress string) (*types.Config, error) {
 
 	var r0 *types.Config
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*types.Config, error)); ok {
-		return rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) (*types.Config, error)); ok {
+		return rf(ctx, addr)
 	}
-	if rf, ok := ret.Get(0).(func(string) *types.Config); ok {
-		r0 = rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) *types.Config); ok {
+		r0 = rf(ctx, addr)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.Config)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(mcmAddress)
+	if rf, ok := ret.Get(1).(func(context.Context, sdk.AddrMetadata) error); ok {
+		r1 = rf(ctx, addr)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -58,14 +63,15 @@ type Inspector_GetConfig_Call struct {
 }
 
 // GetConfig is a helper method to define mock.On call
-//   - mcmAddress string
-func (_e *Inspector_Expecter) GetConfig(mcmAddress interface{}) *Inspector_GetConfig_Call {
-	return &Inspector_GetConfig_Call{Call: _e.mock.On("GetConfig", mcmAddress)}
+//   - ctx context.Context
+//   - addr sdk.AddrMetadata
+func (_e *Inspector_Expecter) GetConfig(ctx interface{}, addr interface{}) *Inspector_GetConfig_Call {
+	return &Inspector_GetConfig_Call{Call: _e.mock.On("GetConfig", ctx, addr)}
 }
 
-func (_c *Inspector_GetConfig_Call) Run(run func(mcmAddress string)) *Inspector_GetConfig_Call {
+func (_c *Inspector_GetConfig_Call) Run(run func(ctx context.Context, addr sdk.AddrMetadata)) *Inspector_GetConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(sdk.AddrMetadata))
 	})
 	return _c
 }
@@ -75,14 +81,14 @@ func (_c *Inspector_GetConfig_Call) Return(_a0 *types.Config, _a1 error) *Inspec
 	return _c
 }
 
-func (_c *Inspector_GetConfig_Call) RunAndReturn(run func(string) (*types.Config, error)) *Inspector_GetConfig_Call {
+func (_c *Inspector_GetConfig_Call) RunAndReturn(run func(context.Context, sdk.AddrMetadata) (*types.Config, error)) *Inspector_GetConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetOpCount provides a mock function with given fields: mcmAddress
-func (_m *Inspector) GetOpCount(mcmAddress string) (uint64, error) {
-	ret := _m.Called(mcmAddress)
+// GetOpCount provides a mock function with given fields: ctx, addr
+func (_m *Inspector) GetOpCount(ctx context.Context, addr sdk.AddrMetadata) (uint64, error) {
+	ret := _m.Called(ctx, addr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOpCount")
@@ -90,17 +96,17 @@ func (_m *Inspector) GetOpCount(mcmAddress string) (uint64, error) {
 
 	var r0 uint64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (uint64, error)); ok {
-		return rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) (uint64, error)); ok {
+		return rf(ctx, addr)
 	}
-	if rf, ok := ret.Get(0).(func(string) uint64); ok {
-		r0 = rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) uint64); ok {
+		r0 = rf(ctx, addr)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(mcmAddress)
+	if rf, ok := ret.Get(1).(func(context.Context, sdk.AddrMetadata) error); ok {
+		r1 = rf(ctx, addr)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -114,14 +120,15 @@ type Inspector_GetOpCount_Call struct {
 }
 
 // GetOpCount is a helper method to define mock.On call
-//   - mcmAddress string
-func (_e *Inspector_Expecter) GetOpCount(mcmAddress interface{}) *Inspector_GetOpCount_Call {
-	return &Inspector_GetOpCount_Call{Call: _e.mock.On("GetOpCount", mcmAddress)}
+//   - ctx context.Context
+//   - addr sdk.AddrMetadata
+func (_e *Inspector_Expecter) GetOpCount(ctx interface{}, addr interface{}) *Inspector_GetOpCount_Call {
+	return &Inspector_GetOpCount_Call{Call: _e.mock.On("GetOpCount", ctx, addr)}
 }
 
-func (_c *Inspector_GetOpCount_Call) Run(run func(mcmAddress string)) *Inspector_GetOpCount_Call {
+func (_c *Inspector_GetOpCount_Call) Run(run func(ctx context.Context, addr sdk.AddrMetadata)) *Inspector_GetOpCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(sdk.AddrMetadata))
 	})
 	return _c
 }
@@ -131,14 +138,14 @@ func (_c *Inspector_GetOpCount_Call) Return(_a0 uint64, _a1 error) *Inspector_Ge
 	return _c
 }
 
-func (_c *Inspector_GetOpCount_Call) RunAndReturn(run func(string) (uint64, error)) *Inspector_GetOpCount_Call {
+func (_c *Inspector_GetOpCount_Call) RunAndReturn(run func(context.Context, sdk.AddrMetadata) (uint64, error)) *Inspector_GetOpCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetRoot provides a mock function with given fields: mcmAddress
-func (_m *Inspector) GetRoot(mcmAddress string) (common.Hash, uint32, error) {
-	ret := _m.Called(mcmAddress)
+// GetRoot provides a mock function with given fields: ctx, addr
+func (_m *Inspector) GetRoot(ctx context.Context, addr sdk.AddrMetadata) (common.Hash, uint32, error) {
+	ret := _m.Called(ctx, addr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRoot")
@@ -147,25 +154,25 @@ func (_m *Inspector) GetRoot(mcmAddress string) (common.Hash, uint32, error) {
 	var r0 common.Hash
 	var r1 uint32
 	var r2 error
-	if rf, ok := ret.Get(0).(func(string) (common.Hash, uint32, error)); ok {
-		return rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) (common.Hash, uint32, error)); ok {
+		return rf(ctx, addr)
 	}
-	if rf, ok := ret.Get(0).(func(string) common.Hash); ok {
-		r0 = rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) common.Hash); ok {
+		r0 = rf(ctx, addr)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Hash)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) uint32); ok {
-		r1 = rf(mcmAddress)
+	if rf, ok := ret.Get(1).(func(context.Context, sdk.AddrMetadata) uint32); ok {
+		r1 = rf(ctx, addr)
 	} else {
 		r1 = ret.Get(1).(uint32)
 	}
 
-	if rf, ok := ret.Get(2).(func(string) error); ok {
-		r2 = rf(mcmAddress)
+	if rf, ok := ret.Get(2).(func(context.Context, sdk.AddrMetadata) error); ok {
+		r2 = rf(ctx, addr)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -179,14 +186,15 @@ type Inspector_GetRoot_Call struct {
 }
 
 // GetRoot is a helper method to define mock.On call
-//   - mcmAddress string
-func (_e *Inspector_Expecter) GetRoot(mcmAddress interface{}) *Inspector_GetRoot_Call {
-	return &Inspector_GetRoot_Call{Call: _e.mock.On("GetRoot", mcmAddress)}
+//   - ctx context.Context
+//   - addr sdk.AddrMetadata
+func (_e *Inspector_Expecter) GetRoot(ctx interface{}, addr interface{}) *Inspector_GetRoot_Call {
+	return &Inspector_GetRoot_Call{Call: _e.mock.On("GetRoot", ctx, addr)}
 }
 
-func (_c *Inspector_GetRoot_Call) Run(run func(mcmAddress string)) *Inspector_GetRoot_Call {
+func (_c *Inspector_GetRoot_Call) Run(run func(ctx context.Context, addr sdk.AddrMetadata)) *Inspector_GetRoot_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(sdk.AddrMetadata))
 	})
 	return _c
 }
@@ -196,14 +204,14 @@ func (_c *Inspector_GetRoot_Call) Return(_a0 common.Hash, _a1 uint32, _a2 error)
 	return _c
 }
 
-func (_c *Inspector_GetRoot_Call) RunAndReturn(run func(string) (common.Hash, uint32, error)) *Inspector_GetRoot_Call {
+func (_c *Inspector_GetRoot_Call) RunAndReturn(run func(context.Context, sdk.AddrMetadata) (common.Hash, uint32, error)) *Inspector_GetRoot_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetRootMetadata provides a mock function with given fields: mcmAddress
-func (_m *Inspector) GetRootMetadata(mcmAddress string) (types.ChainMetadata, error) {
-	ret := _m.Called(mcmAddress)
+// GetRootMetadata provides a mock function with given fields: ctx, addr
+func (_m *Inspector) GetRootMetadata(ctx context.Context, addr sdk.AddrMetadata) (types.ChainMetadata, error) {
+	ret := _m.Called(ctx, addr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRootMetadata")
@@ -211,17 +219,17 @@ func (_m *Inspector) GetRootMetadata(mcmAddress string) (types.ChainMetadata, er
 
 	var r0 types.ChainMetadata
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (types.ChainMetadata, error)); ok {
-		return rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) (types.ChainMetadata, error)); ok {
+		return rf(ctx, addr)
 	}
-	if rf, ok := ret.Get(0).(func(string) types.ChainMetadata); ok {
-		r0 = rf(mcmAddress)
+	if rf, ok := ret.Get(0).(func(context.Context, sdk.AddrMetadata) types.ChainMetadata); ok {
+		r0 = rf(ctx, addr)
 	} else {
 		r0 = ret.Get(0).(types.ChainMetadata)
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(mcmAddress)
+	if rf, ok := ret.Get(1).(func(context.Context, sdk.AddrMetadata) error); ok {
+		r1 = rf(ctx, addr)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -235,14 +243,15 @@ type Inspector_GetRootMetadata_Call struct {
 }
 
 // GetRootMetadata is a helper method to define mock.On call
-//   - mcmAddress string
-func (_e *Inspector_Expecter) GetRootMetadata(mcmAddress interface{}) *Inspector_GetRootMetadata_Call {
-	return &Inspector_GetRootMetadata_Call{Call: _e.mock.On("GetRootMetadata", mcmAddress)}
+//   - ctx context.Context
+//   - addr sdk.AddrMetadata
+func (_e *Inspector_Expecter) GetRootMetadata(ctx interface{}, addr interface{}) *Inspector_GetRootMetadata_Call {
+	return &Inspector_GetRootMetadata_Call{Call: _e.mock.On("GetRootMetadata", ctx, addr)}
 }
 
-func (_c *Inspector_GetRootMetadata_Call) Run(run func(mcmAddress string)) *Inspector_GetRootMetadata_Call {
+func (_c *Inspector_GetRootMetadata_Call) Run(run func(ctx context.Context, addr sdk.AddrMetadata)) *Inspector_GetRootMetadata_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(sdk.AddrMetadata))
 	})
 	return _c
 }
@@ -252,7 +261,7 @@ func (_c *Inspector_GetRootMetadata_Call) Return(_a0 types.ChainMetadata, _a1 er
 	return _c
 }
 
-func (_c *Inspector_GetRootMetadata_Call) RunAndReturn(run func(string) (types.ChainMetadata, error)) *Inspector_GetRootMetadata_Call {
+func (_c *Inspector_GetRootMetadata_Call) RunAndReturn(run func(context.Context, sdk.AddrMetadata) (types.ChainMetadata, error)) *Inspector_GetRootMetadata_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/signable.go
+++ b/signable.go
@@ -136,7 +136,7 @@ func (s *Signable) GetConfigs() (map[types.ChainSelector]*types.Config, error) {
 			return nil, fmt.Errorf("inspector not found for chain %d", chain)
 		}
 
-		configuration, err := inspector.GetConfig(metadata.MCMAddress)
+		configuration, err := inspector.GetConfig(context.Background(), toAddrMetadata(metadata))
 		if err != nil {
 			return nil, err
 		}
@@ -175,7 +175,7 @@ func (s *Signable) CheckQuorum(chain types.ChainSelector) (bool, error) {
 		recoveredSigners[i] = recoveredAddr
 	}
 
-	configuration, err := inspector.GetConfig(s.proposal.ChainMetadata[chain].MCMAddress)
+	configuration, err := inspector.GetConfig(context.Background(), toAddrMetadata(s.proposal.ChainMetadata[chain]))
 	if err != nil {
 		return false, err
 	}
@@ -243,7 +243,7 @@ func (s *Signable) getCurrentOpCounts() (map[types.ChainSelector]uint64, error) 
 			return nil, fmt.Errorf("inspector not found for chain %d", sel)
 		}
 
-		opCount, err := inspector.GetOpCount(metadata.MCMAddress)
+		opCount, err := inspector.GetOpCount(context.Background(), toAddrMetadata(metadata))
 		if err != nil {
 			return nil, err
 		}
@@ -252,4 +252,11 @@ func (s *Signable) getCurrentOpCounts() (map[types.ChainSelector]uint64, error) 
 	}
 
 	return opCounts, nil
+}
+
+func toAddrMetadata(metadata types.ChainMetadata) sdk.AddrMetadata {
+	return sdk.AddrMetadata{
+		MCMAddress:             metadata.MCMAddress,
+		SolanaAdditionalFields: sdk.SolanaAdditionalFields{MSIGName: []byte(metadata.MSIGName)},
+	}
 }

--- a/types/chain.go
+++ b/types/chain.go
@@ -4,4 +4,8 @@ package types
 type ChainMetadata struct {
 	StartingOpCount uint64 `json:"startingOpCount"`
 	MCMAddress      string `json:"mcmAddress"`
+	// msigName is a differentiator/seed for supporting
+	// multiple multisigs with a single deployed program
+	// only applicable to solana
+	MSIGName string `json:"msigName"`
 }


### PR DESCRIPTION
To add context and seed parameter to the inspector interface in order to support what we need for solana.

Just getting people thoughts on this approach before i go and fix all the tests.

i opted to not use generic since it introduces more complexity on the consumer side and decided just to use a simple struct as a container. If everyone is happy with this approach, then i will continue to update the tests (
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4o-2024-08-06). Be mindful of hallucinations and verify accuracy.**

## Why

The update to the inspector API introduces a more flexible and context-aware approach to interacting with the blockchain. By incorporating context and address metadata, the changes aim to enhance the functionality and scalability of the inspector, particularly for supporting multiple multisigs on Solana.

## What

- **inspector.go**
  - Added context and address metadata to GetConfig, GetOpCount, GetRoot, GetRootMetadata functions.
  - Introduced AddrMetadata struct with MCMAddress and MSIGName fields.
  
- **evm/inspector.go**
  - Added context and address metadata to GetConfig, GetOpCount, GetRoot, GetRootMetadata functions.
  - Replaced mcmAddress string with addr.MCMAddress.
  
- **mocks/executor.go**
  - Updated mock functions to use context and address metadata.
  - Modified GetConfig, GetOpCount, GetRoot, GetRootMetadata functions to accept context and address metadata.
  
- **mocks/inspector.go**
  - Updated mock functions to use context and address metadata.
  - Modified GetConfig, GetOpCount, GetRoot, GetRootMetadata functions to accept context and address metadata.
  
- **solana/inspector.go**
  - Removed context from NewInspector function.
  - Added context and address metadata to GetConfig, GetOpCount, GetRoot, GetRootMetadata functions.
  - Implemented expiringRootAndOpCountAddress function.
  
- **signable.go**
  - Updated GetConfigs, CheckQuorum, getCurrentOpCounts functions to use context and address metadata.
  - Added toAddrMetadata helper function.
  
- **types/chain.go**
  - Added MSIGName field to ChainMetadata struct.
