### PR TITLE
tests(e2e/timelock): re-enable skipped test

### DIFF
--- a/e2e/tests/timelock_inspection_test.go
+++ b/e2e/tests/timelock_inspection_test.go
@@ -237,7 +237,6 @@ func (s *TimelockInspectionTestSuite) TestIsOperationReady() {
 }
 
 func (s *TimelockInspectionTestSuite) TestIsOperationDone() {
-	s.T().Skip("fails after addition of context parameters")
 	ctx := context.Background()
 
 	// Deploy a new timelock for this test
@@ -310,7 +309,7 @@ func (s *TimelockInspectionTestSuite) TestIsOperationDone() {
 		opID, err := evm.HashOperationBatch(calls, pred, salt)
 		s.Require().NoError(err, "Failed to compute operation ID")
 
-		isOpDone, err := inspector.IsOperationDone(ctx, s.timelockContract.Address().Hex(), opID)
+		isOpDone, err := inspector.IsOperationDone(ctx, timelockContract.Address().Hex(), opID)
 		s.Require().NoError(err, "Failed to check if operation is done")
 
 		return isOpDone


### PR DESCRIPTION
The e2e test for `IsOperationDone` was skipped after the context was introduced due to failing. This was due to using the wrong timelock contract from the test suite instead of the newly created one in that particular test.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4o-2024-08-06). Be mindful of hallucinations and verify accuracy.**

## Why
Re-enabling the previously skipped `TestIsOperationDone` test in the `TimelockInspectionTestSuite` ensures comprehensive end-to-end testing of the timelock functionality, improving test coverage and reliability.

## What
- **timelock_inspection_test.go**
  - Re-enable `TestIsOperationDone` by removing `Skip` call
  - Fix variable reference for `timelockContract.Address()`
