### PR TITLE
[DPA-1413]: fix(solana): set program id in inspection

### DIFF
--- a/.changeset/sweet-chefs-remember.md
+++ b/.changeset/sweet-chefs-remember.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix(solana): setProgramID on inspection methods

--- a/sdk/solana/inspector.go
+++ b/sdk/solana/inspector.go
@@ -36,6 +36,8 @@ func (e *Inspector) GetConfig(ctx context.Context, address string) (*types.Confi
 		return nil, err
 	}
 
+	bindings.SetProgramID(programID)
+
 	configPDA, err := FindConfigPDA(programID, instanceID)
 	if err != nil {
 		return nil, err
@@ -60,6 +62,9 @@ func (e *Inspector) GetOpCount(ctx context.Context, mcmAddress string) (uint64, 
 	if err != nil {
 		return 0, err
 	}
+
+	bindings.SetProgramID(programID)
+
 	pda, err := FindExpiringRootAndOpCountPDA(programID, seed)
 	if err != nil {
 		return 0, err
@@ -78,6 +83,9 @@ func (e *Inspector) GetRoot(ctx context.Context, mcmAddress string) (common.Hash
 	if err != nil {
 		return common.Hash{}, 0, err
 	}
+
+	bindings.SetProgramID(programID)
+
 	pda, err := FindExpiringRootAndOpCountPDA(programID, seed)
 	if err != nil {
 		return common.Hash{}, 0, err
@@ -96,6 +104,9 @@ func (e *Inspector) GetRootMetadata(ctx context.Context, mcmAddress string) (typ
 	if err != nil {
 		return types.ChainMetadata{}, err
 	}
+
+	bindings.SetProgramID(programID)
+
 	pda, err := FindRootMetadataPDA(programID, seed)
 	if err != nil {
 		return types.ChainMetadata{}, err


### PR DESCRIPTION
Per discussion [here](https://github.com/smartcontractkit/mcms/pull/209#discussion_r1907993479), looks like we need to setProgramId on every public api that we have.

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1413
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4o-2024-08-06). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that the program ID is set correctly in the Solana inspector functions. This is crucial for accurate contract address parsing and subsequent operations, enhancing the reliability of the Solana SDK.

## What
- **inspector.go**
  - Add `mcm.SetProgramID(programID)` in `GetOpCount`
  - Add `mcm.SetProgramID(programID)` in `GetRoot`
  - Add `mcm.SetProgramID(programID)` in `GetRootMetadata`
