### PR TITLE
[DPA-1421]: fix(solana): add finders for timelock PDAs

### DIFF
--- a/sdk/solana/common.go
+++ b/sdk/solana/common.go
@@ -57,6 +57,24 @@ func FindSeenSignedHashesPDA(
 	return findPDA(programID, seeds)
 }
 
+func FindTimelockConfigPDA(
+	programID solana.PublicKey, pdaSeed PDASeed) (solana.PublicKey, error) {
+	seeds := [][]byte{[]byte("timelock_config"), pdaSeed[:]}
+	return findPDA(programID, seeds)
+}
+
+func FindTimelockOperationPDA(
+	programID solana.PublicKey, pdaSeed PDASeed) (solana.PublicKey, error) {
+	seeds := [][]byte{[]byte("timelock_operation"), pdaSeed[:]}
+	return findPDA(programID, seeds)
+}
+
+func FindTimelockSignerPDA(
+	programID solana.PublicKey, pdaSeed PDASeed) (solana.PublicKey, error) {
+	seeds := [][]byte{[]byte("timelock_signer"), pdaSeed[:]}
+	return findPDA(programID, seeds)
+}
+
 func findPDA(programID solana.PublicKey, seeds [][]byte) (solana.PublicKey, error) {
 	pda, _, err := solana.FindProgramAddress(seeds, programID)
 	if err != nil {

--- a/sdk/solana/common_test.go
+++ b/sdk/solana/common_test.go
@@ -70,6 +70,27 @@ func Test_FindSeenSignedHashesPDA(t *testing.T) {
 	require.Empty(t, cmp.Diff(pda, solana.MustPublicKeyFromBase58("FxPYSHG9tm35T43zpAuVDdNY8uMPQfaaVBftxVrLyXVq")))
 }
 
+func Test_FindTimelockConfigPDA(t *testing.T) {
+	t.Parallel()
+	pda, err := FindTimelockConfigPDA(testProgramID, testPDASeed)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(pda, solana.MustPublicKeyFromBase58("27X4nnwKaRk93RamRXQSfNyuB1pBSSK1hf2ULUeL1VCp")))
+}
+
+func Test_FindTimelockOperationPDA(t *testing.T) {
+	t.Parallel()
+	pda, err := FindTimelockOperationPDA(testProgramID, testPDASeed)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(pda, solana.MustPublicKeyFromBase58("8TL4xwjpntLQXeFbADMPnooDofGUwocc4ikHAJb41Fcm")))
+}
+
+func Test_FindTimelockSignerPDA(t *testing.T) {
+	t.Parallel()
+	pda, err := FindTimelockSignerPDA(testProgramID, testPDASeed)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(pda, solana.MustPublicKeyFromBase58("HAQoFdsmxUFgAfBb6u9AXvg9q1nJthWb7xMYWpvzFJfg")))
+}
+
 func Test_sendAndConfirm(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
In preparation for the timelock inspector work, adding a few PDA finders method.

Based from:
![Screenshot 2025-01-09 at 3 37 36 pm](https://github.com/user-attachments/assets/cec7d0ab-ee42-4e6d-b088-8495e431e358)

The table above shows that we dont need an extra seed for timelock signer and config.
However from this [slack conversation](https://chainlink-core.slack.com/archives/C07NVBK16KS/p1736283177487899), we plan to introduce a timelock worker name as an extra seed.

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1421
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4o-2024-08-06). Be mindful of hallucinations and verify accuracy.**

## Why
Enhances the Solana SDK by adding functions to find Program Derived Addresses (PDAs) for timelock configurations, operations, and signers. This improves the ability to manage and interact with timelock-related functionalities within the Solana blockchain.

## What
- **common.go**
  - Add FindTimelockConfigPDA function
  - Add FindTimelockOperationPDA function
  - Add FindTimelockSignerPDA function
- **common_test.go**
  - Add Test_FindTimelockConfigPDA function
  - Add Test_FindTimelockOperationPDA function
  - Add Test_FindTimelockSignerPDA function
