### PR TITLE
[DPA-1421]: fix(timelock): use string for inspector return type

### DIFF
--- a/.changeset/healthy-stingrays-notice.md
+++ b/.changeset/healthy-stingrays-notice.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Use string for inspector return type

--- a/e2e/tests/evm/timelock_inspection.go
+++ b/e2e/tests/evm/timelock_inspection.go
@@ -107,7 +107,7 @@ func (s *TimelockInspectionTestSuite) TestGetProposers() {
 	proposers, err := inspector.GetProposers(ctx, s.timelockContract.Address().Hex())
 	s.Require().NoError(err)
 	s.Require().Len(proposers, 1)
-	s.Require().Equal(s.signerAddresses[0], proposers[0])
+	s.Require().Equal(s.signerAddresses[0].Hex(), proposers[0])
 }
 
 // TestGetExecutors gets the list of executors
@@ -118,8 +118,8 @@ func (s *TimelockInspectionTestSuite) TestGetExecutors() {
 	executors, err := inspector.GetExecutors(ctx, s.timelockContract.Address().Hex())
 	s.Require().NoError(err)
 	s.Require().Len(executors, 2)
-	s.Require().Equal(s.signerAddresses[0], executors[0])
-	s.Require().Equal(s.signerAddresses[1], executors[1])
+	s.Require().Equal(s.signerAddresses[0].Hex(), executors[0])
+	s.Require().Equal(s.signerAddresses[1].Hex(), executors[1])
 }
 
 // TestGetBypassers gets the list of bypassers
@@ -131,7 +131,7 @@ func (s *TimelockInspectionTestSuite) TestGetBypassers() {
 	s.Require().NoError(err)
 	s.Require().Len(bypassers, 1) // Ensure lengths match
 	// Check that all elements of signerAddresses are in proposers
-	s.Require().Contains(bypassers, s.signerAddresses[1])
+	s.Require().Contains(bypassers, s.signerAddresses[1].Hex())
 }
 
 // TestGetCancellers gets the list of cancellers
@@ -142,8 +142,8 @@ func (s *TimelockInspectionTestSuite) TestGetCancellers() {
 	cancellers, err := inspector.GetCancellers(ctx, s.timelockContract.Address().Hex())
 	s.Require().NoError(err)
 	s.Require().Len(cancellers, 2)
-	s.Require().Equal(s.signerAddresses[0], cancellers[0])
-	s.Require().Equal(s.signerAddresses[1], cancellers[1])
+	s.Require().Equal(s.signerAddresses[0].Hex(), cancellers[0])
+	s.Require().Equal(s.signerAddresses[1].Hex(), cancellers[1])
 }
 
 // TestIsOperation tests the IsOperation method

--- a/sdk/evm/timelock_inspector.go
+++ b/sdk/evm/timelock_inspector.go
@@ -29,13 +29,13 @@ func NewTimelockInspector(client ContractDeployBackend) *TimelockInspector {
 // getAddressesWithRole returns the list of addresses with the given role
 func (tm TimelockInspector) getAddressesWithRole(
 	ctx context.Context, timelock *bindings.RBACTimelock, role [32]byte,
-) ([]common.Address, error) {
+) ([]string, error) {
 	numAddresses, err := timelock.GetRoleMemberCount(&bind.CallOpts{Context: ctx}, role)
 	if err != nil {
 		return nil, err
 	}
 	// For each address index in the roles count, get the address
-	addresses := make([]common.Address, 0, numAddresses.Uint64())
+	addresses := make([]string, 0, numAddresses.Uint64())
 	for i := range numAddresses.Uint64() {
 		idx, err := safecast.Uint64ToInt64(i)
 		if err != nil {
@@ -45,14 +45,14 @@ func (tm TimelockInspector) getAddressesWithRole(
 		if err != nil {
 			return nil, err
 		}
-		addresses = append(addresses, address)
+		addresses = append(addresses, address.String())
 	}
 
 	return addresses, nil
 }
 
 // GetProposers returns the list of addresses with the proposer role
-func (tm TimelockInspector) GetProposers(ctx context.Context, address string) ([]common.Address, error) {
+func (tm TimelockInspector) GetProposers(ctx context.Context, address string) ([]string, error) {
 	timelock, err := bindings.NewRBACTimelock(common.HexToAddress(address), tm.client)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (tm TimelockInspector) GetProposers(ctx context.Context, address string) ([
 }
 
 // GetExecutors returns the list of addresses with the executor role
-func (tm TimelockInspector) GetExecutors(ctx context.Context, address string) ([]common.Address, error) {
+func (tm TimelockInspector) GetExecutors(ctx context.Context, address string) ([]string, error) {
 	timelock, err := bindings.NewRBACTimelock(common.HexToAddress(address), tm.client)
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ func (tm TimelockInspector) GetExecutors(ctx context.Context, address string) ([
 }
 
 // GetBypassers returns the list of addresses with the bypasser role
-func (tm TimelockInspector) GetBypassers(ctx context.Context, address string) ([]common.Address, error) {
+func (tm TimelockInspector) GetBypassers(ctx context.Context, address string) ([]string, error) {
 	timelock, err := bindings.NewRBACTimelock(common.HexToAddress(address), tm.client)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (tm TimelockInspector) GetBypassers(ctx context.Context, address string) ([
 }
 
 // GetCancellers returns the list of addresses with the canceller role
-func (tm TimelockInspector) GetCancellers(ctx context.Context, address string) ([]common.Address, error) {
+func (tm TimelockInspector) GetCancellers(ctx context.Context, address string) ([]string, error) {
 	timelock, err := bindings.NewRBACTimelock(common.HexToAddress(address), tm.client)
 	if err != nil {
 		return nil, err

--- a/sdk/evm/timelock_inspector_test.go
+++ b/sdk/evm/timelock_inspector_test.go
@@ -23,7 +23,7 @@ type roleFetchTest struct {
 	roleMembers     []common.Address
 	proposerRole    [32]byte
 	mockError       error
-	want            []common.Address
+	want            []string
 	wantErr         error
 	roleFetchType   string // Specify the role type (proposers, executors, etc.)
 }
@@ -66,10 +66,10 @@ func TestTimelockInspector_GetRolesTests(t *testing.T) {
 				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
 			},
 			proposerRole: [32]byte{0x01},
-			want: []common.Address{
-				common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdef"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
+			want: []string{
+				"0x0000AbCDeFabcdEfaBcDeFabCDEFAbCDEfABcDeF",
+				"0x1234567890AbcdEF1234567890aBcdef12345678",
+				"0x1234567890aBcdef1234567890Abcdef56785678",
 			},
 			roleFetchType: "proposers",
 		},
@@ -91,10 +91,10 @@ func TestTimelockInspector_GetRolesTests(t *testing.T) {
 				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
 			},
 			proposerRole: [32]byte{0x01},
-			want: []common.Address{
-				common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdef"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
+			want: []string{
+				"0x0000AbCDeFabcdEfaBcDeFabCDEFAbCDEfABcDeF",
+				"0x1234567890AbcdEF1234567890aBcdef12345678",
+				"0x1234567890aBcdef1234567890Abcdef56785678",
 			},
 			roleFetchType: "executors",
 		},
@@ -116,10 +116,10 @@ func TestTimelockInspector_GetRolesTests(t *testing.T) {
 				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
 			},
 			proposerRole: [32]byte{0x01},
-			want: []common.Address{
-				common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdef"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
+			want: []string{
+				"0x0000AbCDeFabcdEfaBcDeFabCDEFAbCDEfABcDeF",
+				"0x1234567890AbcdEF1234567890aBcdef12345678",
+				"0x1234567890aBcdef1234567890Abcdef56785678",
 			},
 			roleFetchType: "executors",
 		},
@@ -141,10 +141,10 @@ func TestTimelockInspector_GetRolesTests(t *testing.T) {
 				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
 			},
 			proposerRole: [32]byte{0x01},
-			want: []common.Address{
-				common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdef"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
+			want: []string{
+				"0x0000AbCDeFabcdEfaBcDeFabCDEFAbCDEfABcDeF",
+				"0x1234567890AbcdEF1234567890aBcdef12345678",
+				"0x1234567890aBcdef1234567890Abcdef56785678",
 			},
 			roleFetchType: "bypassers",
 		},
@@ -166,10 +166,10 @@ func TestTimelockInspector_GetRolesTests(t *testing.T) {
 				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
 			},
 			proposerRole: [32]byte{0x01},
-			want: []common.Address{
-				common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdef"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
-				common.HexToAddress("0x1234567890abcdef1234567890abcdef56785678"),
+			want: []string{
+				"0x0000AbCDeFabcdEfaBcDeFabCDEFAbCDEfABcDeF",
+				"0x1234567890AbcdEF1234567890aBcdef12345678",
+				"0x1234567890aBcdef1234567890Abcdef56785678",
 			},
 			roleFetchType: "bypassers",
 		},
@@ -205,7 +205,7 @@ func TestTimelockInspector_GetRolesTests(t *testing.T) {
 			}
 
 			// Select and call the appropriate role-fetching function
-			var got []common.Address
+			var got []string
 			switch tt.roleFetchType {
 			case "proposers":
 				got, err = inspector.GetProposers(ctx, tt.address)

--- a/sdk/mocks/timelock_executor.go
+++ b/sdk/mocks/timelock_executor.go
@@ -86,23 +86,23 @@ func (_c *TimelockExecutor_Execute_Call) RunAndReturn(run func(context.Context, 
 }
 
 // GetBypassers provides a mock function with given fields: ctx, address
-func (_m *TimelockExecutor) GetBypassers(ctx context.Context, address string) ([]common.Address, error) {
+func (_m *TimelockExecutor) GetBypassers(ctx context.Context, address string) ([]string, error) {
 	ret := _m.Called(ctx, address)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBypassers")
 	}
 
-	var r0 []common.Address
+	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]common.Address, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
 		return rf(ctx, address)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []common.Address); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
 		r0 = rf(ctx, address)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 
@@ -134,34 +134,34 @@ func (_c *TimelockExecutor_GetBypassers_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *TimelockExecutor_GetBypassers_Call) Return(_a0 []common.Address, _a1 error) *TimelockExecutor_GetBypassers_Call {
+func (_c *TimelockExecutor_GetBypassers_Call) Return(_a0 []string, _a1 error) *TimelockExecutor_GetBypassers_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *TimelockExecutor_GetBypassers_Call) RunAndReturn(run func(context.Context, string) ([]common.Address, error)) *TimelockExecutor_GetBypassers_Call {
+func (_c *TimelockExecutor_GetBypassers_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *TimelockExecutor_GetBypassers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCancellers provides a mock function with given fields: ctx, address
-func (_m *TimelockExecutor) GetCancellers(ctx context.Context, address string) ([]common.Address, error) {
+func (_m *TimelockExecutor) GetCancellers(ctx context.Context, address string) ([]string, error) {
 	ret := _m.Called(ctx, address)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCancellers")
 	}
 
-	var r0 []common.Address
+	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]common.Address, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
 		return rf(ctx, address)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []common.Address); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
 		r0 = rf(ctx, address)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 
@@ -193,34 +193,34 @@ func (_c *TimelockExecutor_GetCancellers_Call) Run(run func(ctx context.Context,
 	return _c
 }
 
-func (_c *TimelockExecutor_GetCancellers_Call) Return(_a0 []common.Address, _a1 error) *TimelockExecutor_GetCancellers_Call {
+func (_c *TimelockExecutor_GetCancellers_Call) Return(_a0 []string, _a1 error) *TimelockExecutor_GetCancellers_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *TimelockExecutor_GetCancellers_Call) RunAndReturn(run func(context.Context, string) ([]common.Address, error)) *TimelockExecutor_GetCancellers_Call {
+func (_c *TimelockExecutor_GetCancellers_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *TimelockExecutor_GetCancellers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetExecutors provides a mock function with given fields: ctx, address
-func (_m *TimelockExecutor) GetExecutors(ctx context.Context, address string) ([]common.Address, error) {
+func (_m *TimelockExecutor) GetExecutors(ctx context.Context, address string) ([]string, error) {
 	ret := _m.Called(ctx, address)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetExecutors")
 	}
 
-	var r0 []common.Address
+	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]common.Address, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
 		return rf(ctx, address)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []common.Address); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
 		r0 = rf(ctx, address)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 
@@ -252,34 +252,34 @@ func (_c *TimelockExecutor_GetExecutors_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *TimelockExecutor_GetExecutors_Call) Return(_a0 []common.Address, _a1 error) *TimelockExecutor_GetExecutors_Call {
+func (_c *TimelockExecutor_GetExecutors_Call) Return(_a0 []string, _a1 error) *TimelockExecutor_GetExecutors_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *TimelockExecutor_GetExecutors_Call) RunAndReturn(run func(context.Context, string) ([]common.Address, error)) *TimelockExecutor_GetExecutors_Call {
+func (_c *TimelockExecutor_GetExecutors_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *TimelockExecutor_GetExecutors_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetProposers provides a mock function with given fields: ctx, address
-func (_m *TimelockExecutor) GetProposers(ctx context.Context, address string) ([]common.Address, error) {
+func (_m *TimelockExecutor) GetProposers(ctx context.Context, address string) ([]string, error) {
 	ret := _m.Called(ctx, address)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetProposers")
 	}
 
-	var r0 []common.Address
+	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]common.Address, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
 		return rf(ctx, address)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []common.Address); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
 		r0 = rf(ctx, address)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 
@@ -311,12 +311,12 @@ func (_c *TimelockExecutor_GetProposers_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *TimelockExecutor_GetProposers_Call) Return(_a0 []common.Address, _a1 error) *TimelockExecutor_GetProposers_Call {
+func (_c *TimelockExecutor_GetProposers_Call) Return(_a0 []string, _a1 error) *TimelockExecutor_GetProposers_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *TimelockExecutor_GetProposers_Call) RunAndReturn(run func(context.Context, string) ([]common.Address, error)) *TimelockExecutor_GetProposers_Call {
+func (_c *TimelockExecutor_GetProposers_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *TimelockExecutor_GetProposers_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sdk/mocks/timelock_inspector.go
+++ b/sdk/mocks/timelock_inspector.go
@@ -5,8 +5,6 @@ package mocks
 import (
 	context "context"
 
-	common "github.com/ethereum/go-ethereum/common"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -24,23 +22,23 @@ func (_m *TimelockInspector) EXPECT() *TimelockInspector_Expecter {
 }
 
 // GetBypassers provides a mock function with given fields: ctx, address
-func (_m *TimelockInspector) GetBypassers(ctx context.Context, address string) ([]common.Address, error) {
+func (_m *TimelockInspector) GetBypassers(ctx context.Context, address string) ([]string, error) {
 	ret := _m.Called(ctx, address)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBypassers")
 	}
 
-	var r0 []common.Address
+	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]common.Address, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
 		return rf(ctx, address)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []common.Address); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
 		r0 = rf(ctx, address)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 
@@ -72,34 +70,34 @@ func (_c *TimelockInspector_GetBypassers_Call) Run(run func(ctx context.Context,
 	return _c
 }
 
-func (_c *TimelockInspector_GetBypassers_Call) Return(_a0 []common.Address, _a1 error) *TimelockInspector_GetBypassers_Call {
+func (_c *TimelockInspector_GetBypassers_Call) Return(_a0 []string, _a1 error) *TimelockInspector_GetBypassers_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *TimelockInspector_GetBypassers_Call) RunAndReturn(run func(context.Context, string) ([]common.Address, error)) *TimelockInspector_GetBypassers_Call {
+func (_c *TimelockInspector_GetBypassers_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *TimelockInspector_GetBypassers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCancellers provides a mock function with given fields: ctx, address
-func (_m *TimelockInspector) GetCancellers(ctx context.Context, address string) ([]common.Address, error) {
+func (_m *TimelockInspector) GetCancellers(ctx context.Context, address string) ([]string, error) {
 	ret := _m.Called(ctx, address)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCancellers")
 	}
 
-	var r0 []common.Address
+	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]common.Address, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
 		return rf(ctx, address)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []common.Address); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
 		r0 = rf(ctx, address)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 
@@ -131,34 +129,34 @@ func (_c *TimelockInspector_GetCancellers_Call) Run(run func(ctx context.Context
 	return _c
 }
 
-func (_c *TimelockInspector_GetCancellers_Call) Return(_a0 []common.Address, _a1 error) *TimelockInspector_GetCancellers_Call {
+func (_c *TimelockInspector_GetCancellers_Call) Return(_a0 []string, _a1 error) *TimelockInspector_GetCancellers_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *TimelockInspector_GetCancellers_Call) RunAndReturn(run func(context.Context, string) ([]common.Address, error)) *TimelockInspector_GetCancellers_Call {
+func (_c *TimelockInspector_GetCancellers_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *TimelockInspector_GetCancellers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetExecutors provides a mock function with given fields: ctx, address
-func (_m *TimelockInspector) GetExecutors(ctx context.Context, address string) ([]common.Address, error) {
+func (_m *TimelockInspector) GetExecutors(ctx context.Context, address string) ([]string, error) {
 	ret := _m.Called(ctx, address)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetExecutors")
 	}
 
-	var r0 []common.Address
+	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]common.Address, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
 		return rf(ctx, address)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []common.Address); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
 		r0 = rf(ctx, address)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 
@@ -190,34 +188,34 @@ func (_c *TimelockInspector_GetExecutors_Call) Run(run func(ctx context.Context,
 	return _c
 }
 
-func (_c *TimelockInspector_GetExecutors_Call) Return(_a0 []common.Address, _a1 error) *TimelockInspector_GetExecutors_Call {
+func (_c *TimelockInspector_GetExecutors_Call) Return(_a0 []string, _a1 error) *TimelockInspector_GetExecutors_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *TimelockInspector_GetExecutors_Call) RunAndReturn(run func(context.Context, string) ([]common.Address, error)) *TimelockInspector_GetExecutors_Call {
+func (_c *TimelockInspector_GetExecutors_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *TimelockInspector_GetExecutors_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetProposers provides a mock function with given fields: ctx, address
-func (_m *TimelockInspector) GetProposers(ctx context.Context, address string) ([]common.Address, error) {
+func (_m *TimelockInspector) GetProposers(ctx context.Context, address string) ([]string, error) {
 	ret := _m.Called(ctx, address)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetProposers")
 	}
 
-	var r0 []common.Address
+	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]common.Address, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
 		return rf(ctx, address)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []common.Address); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
 		r0 = rf(ctx, address)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 
@@ -249,12 +247,12 @@ func (_c *TimelockInspector_GetProposers_Call) Run(run func(ctx context.Context,
 	return _c
 }
 
-func (_c *TimelockInspector_GetProposers_Call) Return(_a0 []common.Address, _a1 error) *TimelockInspector_GetProposers_Call {
+func (_c *TimelockInspector_GetProposers_Call) Return(_a0 []string, _a1 error) *TimelockInspector_GetProposers_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *TimelockInspector_GetProposers_Call) RunAndReturn(run func(context.Context, string) ([]common.Address, error)) *TimelockInspector_GetProposers_Call {
+func (_c *TimelockInspector_GetProposers_Call) RunAndReturn(run func(context.Context, string) ([]string, error)) *TimelockInspector_GetProposers_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sdk/solana/timelock_inspector.go
+++ b/sdk/solana/timelock_inspector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
@@ -27,19 +26,19 @@ func NewTimelockInspector(client *rpc.Client) *TimelockInspector {
 	return &TimelockInspector{client: client}
 }
 
-func (t TimelockInspector) GetProposers(ctx context.Context, address string) ([]common.Address, error) {
+func (t TimelockInspector) GetProposers(ctx context.Context, address string) ([]string, error) {
 	panic("implement me")
 }
 
-func (t TimelockInspector) GetExecutors(ctx context.Context, address string) ([]common.Address, error) {
+func (t TimelockInspector) GetExecutors(ctx context.Context, address string) ([]string, error) {
 	panic("implement me")
 }
 
-func (t TimelockInspector) GetBypassers(ctx context.Context, address string) ([]common.Address, error) {
+func (t TimelockInspector) GetBypassers(ctx context.Context, address string) ([]string, error) {
 	panic("implement me")
 }
 
-func (t TimelockInspector) GetCancellers(ctx context.Context, address string) ([]common.Address, error) {
+func (t TimelockInspector) GetCancellers(ctx context.Context, address string) ([]string, error) {
 	panic("implement me")
 }
 

--- a/sdk/timelock_inspector.go
+++ b/sdk/timelock_inspector.go
@@ -2,15 +2,13 @@ package sdk
 
 import (
 	"context"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type TimelockInspector interface {
-	GetProposers(ctx context.Context, address string) ([]common.Address, error)
-	GetExecutors(ctx context.Context, address string) ([]common.Address, error)
-	GetBypassers(ctx context.Context, address string) ([]common.Address, error)
-	GetCancellers(ctx context.Context, address string) ([]common.Address, error)
+	GetProposers(ctx context.Context, address string) ([]string, error)
+	GetExecutors(ctx context.Context, address string) ([]string, error)
+	GetBypassers(ctx context.Context, address string) ([]string, error)
+	GetCancellers(ctx context.Context, address string) ([]string, error)
 	IsOperation(ctx context.Context, address string, opID [32]byte) (bool, error)
 	IsOperationPending(ctx context.Context, address string, opID [32]byte) (bool, error)
 	IsOperationReady(ctx context.Context, address string, opID [32]byte) (bool, error)


### PR DESCRIPTION
Currently for evm , it returns []common.address for get roles methods in timelock inspector. This does not work for solana as we want to return solana.publickey.

Changing the return type allow us to return both types.

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1421

