### PR TITLE
[DPA-1421]: build(solana): pull timelock & access controller program from chainlink-ccip

### DIFF
--- a/e2e/tests/solana/compile-mcm-contracts.sh
+++ b/e2e/tests/solana/compile-mcm-contracts.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# This script builds the MCM contracts and copies the compiled binaries to the
+# This script builds the MCMS related contracts and copy the compiled binaries to the
 # destination directory. The destination directory is used by the CTF e2e tests to
-# deploy the MCM contracts on Solana.
+# deploy the programs on Solana.
 
 # Usage: ./e2e/tests/solana/compile-mcm-contracts.sh
 
@@ -11,25 +11,29 @@ set -euo pipefail
 REPO_URL="https://github.com/smartcontractkit/chainlink-ccip"
 REPO_DIR="chainlink-ccip"
 PROJECT_ROOT="$(dirname "$(realpath "$0")")/../../.."
-MCM_DIR="chains/solana/contracts/programs/mcm"
 PROGRAM_DIR="chains/solana/contracts/target/deploy"
 DEST_DIR="${PROJECT_ROOT}/e2e/artifacts/solana"
 TEMP_DIR=$(mktemp -d)
-COMMIT_HASH="a91ea5187123329c28553b884e31e5fce4f0e030" # 31 Dec 2024
+COMMIT_HASH="6d06ece7bc00c911827a5c1faefeb9f8279fc88e" # 14 Jan 2025
+
+# Programs to build
+PROGRAMS=("mcm" "timelock" "access-controller")
 
 cd "${PROJECT_ROOT}"
 
 git clone "${REPO_URL}" "${TEMP_DIR}/${REPO_DIR}"
-cd "${TEMP_DIR}/${REPO_DIR}/${MCM_DIR}"
+cd "${TEMP_DIR}/${REPO_DIR}"
 git checkout "${COMMIT_HASH}"
 
-cargo build-sbf
-
-cd -
+for program in "${PROGRAMS[@]}"; do
+  cd "chains/solana/contracts/programs/${program}"
+  cargo build-sbf
+  cd -
+done
 
 mkdir -p "${DEST_DIR}"
 cp -r "${TEMP_DIR}/${REPO_DIR}/${PROGRAM_DIR}/"* "${DEST_DIR}/"
 
 rm -rf "${TEMP_DIR}"
 
-echo "MCM contracts compiled successfully"
+echo "MCMS contracts compiled successfully"


### PR DESCRIPTION
To run e2e tests for solana timelock worker, we need to deploy the timelock worker and access controller program. This commit updates the existing script to include the timelock worker and access controller.

I have also updated the `COMMIT_HASH` since the latest chainlink-ccip now supports multiple timelock instance.

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1421
