### PR TITLE
[DPA-1421]: test(solana): e2e for get roles timelock inspection

### DIFF
--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -28,3 +28,5 @@ family = "solana"
 
 [solana_config.solana_programs]
 mcm = "6UmMZr5MEqiKWD5jqTJd1WCR5kT8oZuFYBLJFi1o6GQX"
+timelock = "LoCoNsJFuhTkSQjfdDfn3yuwqhSYoPujmviRHVCzsqn"
+access_controller = "9xi644bRR8birboDGdTiwBq3C7VEeR7VuamRYYXCubUW"

--- a/e2e/tests/solana/timelock_inspection.go
+++ b/e2e/tests/solana/timelock_inspection.go
@@ -1,0 +1,74 @@
+//go:build e2e
+// +build e2e
+
+package solanae2e
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
+
+	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+)
+
+var testPDASeedTimelockInspection = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'i', 'n', 's', 'p', 'e', 'c', 't'}
+
+func (s *SolanaTestSuite) TestGetProposers() {
+	ctx := context.Background()
+
+	inspector := solanasdk.NewTimelockInspector(s.SolanaClient)
+	proposers, err := inspector.GetProposers(ctx, solanasdk.ContractAddress(s.TimelockWorkerProgramID, testPDASeedTimelockInspection))
+	s.Require().NoError(err, "Failed to get proposers")
+	s.Require().Len(proposers, 2, "Expected 2 proposers")
+
+	var expected = make([]string, 0, len(s.Roles[timelock.Proposer_Role].Accounts))
+	for _, acc := range s.Roles[timelock.Proposer_Role].Accounts {
+		expected = append(expected, acc.PublicKey().String())
+	}
+	s.Require().ElementsMatch(expected, proposers, "Proposers don't match")
+}
+
+func (s *SolanaTestSuite) TestGetExecutors() {
+	ctx := context.Background()
+
+	inspector := solanasdk.NewTimelockInspector(s.SolanaClient)
+	executors, err := inspector.GetExecutors(ctx, solanasdk.ContractAddress(s.TimelockWorkerProgramID, testPDASeedTimelockInspection))
+	s.Require().NoError(err, "Failed to get executors")
+	s.Require().Len(executors, 2, "Expected 2 executors")
+
+	var expected = make([]string, 0, len(s.Roles[timelock.Executor_Role].Accounts))
+	for _, acc := range s.Roles[timelock.Executor_Role].Accounts {
+		expected = append(expected, acc.PublicKey().String())
+	}
+	s.Require().ElementsMatch(expected, executors, "Executors don't match")
+}
+
+func (s *SolanaTestSuite) TestGetCancellers() {
+	ctx := context.Background()
+
+	inspector := solanasdk.NewTimelockInspector(s.SolanaClient)
+	cancellers, err := inspector.GetCancellers(ctx, solanasdk.ContractAddress(s.TimelockWorkerProgramID, testPDASeedTimelockInspection))
+	s.Require().NoError(err, "Failed to get cancellers")
+	s.Require().Len(cancellers, 2, "Expected 2 cancellers")
+
+	var expected = make([]string, 0, len(s.Roles[timelock.Canceller_Role].Accounts))
+	for _, acc := range s.Roles[timelock.Canceller_Role].Accounts {
+		expected = append(expected, acc.PublicKey().String())
+	}
+	s.Require().ElementsMatch(expected, cancellers, "Cancellers don't match")
+}
+
+func (s *SolanaTestSuite) TestGetBypassers() {
+	ctx := context.Background()
+
+	inspector := solanasdk.NewTimelockInspector(s.SolanaClient)
+	bypassers, err := inspector.GetBypassers(ctx, solanasdk.ContractAddress(s.TimelockWorkerProgramID, testPDASeedTimelockInspection))
+	s.Require().NoError(err, "Failed to get bypassers")
+	s.Require().Len(bypassers, 2, "Expected 2 bypassers")
+
+	var expected = make([]string, 0, len(s.Roles[timelock.Bypasser_Role].Accounts))
+	for _, acc := range s.Roles[timelock.Bypasser_Role].Accounts {
+		expected = append(expected, acc.PublicKey().String())
+	}
+	s.Require().ElementsMatch(expected, bypassers, "Bypassers don't match")
+}


### PR DESCRIPTION
Added e2e test for get roles related operation for the solana timelock inspection.

The `isOperation` e2e will come in another PR, just wanted to get this in if Gustavo want to reuse the setupTimelockWorker

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1421