### PR TITLE
Simulate execute on solana SDK  [DPA-1418]

### DIFF
--- a/.changeset/wet-bugs-mix.md
+++ b/.changeset/wet-bugs-mix.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Adds execute operation simulation to solana sdk

--- a/e2e/tests/solana/simulation.go
+++ b/e2e/tests/solana/simulation.go
@@ -1,0 +1,57 @@
+//go:build e2e
+// +build e2e
+
+package solanae2e
+
+import (
+	"context"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
+
+	solana2 "github.com/smartcontractkit/mcms/e2e/utils/solana"
+	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+// Test_Simulator_SimulateOperation tests the operation simulation functionality.
+func (s *SolanaTestSuite) Test_Simulator_SimulateOperation() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	s.T().Cleanup(cancel)
+
+	recipientAddress, err := solana.NewRandomPrivateKey()
+	s.Require().NoError(err)
+
+	auth, err := solana.PrivateKeyFromBase58(privateKey)
+	s.Require().NoError(err)
+	solana2.FundAccounts(s.T(), ctx, []solana.PublicKey{auth.PublicKey()}, 20*solana.LAMPORTS_PER_SOL, s.SolanaClient)
+
+	// Create a new simulator
+	simulator, err := solanasdk.NewSimulator(
+		s.SolanaClient,
+		auth,
+		solanasdk.NewEncoder(s.ChainSelector, 1, false),
+	)
+	s.Require().NoError(err)
+
+	ix, err := system.NewTransferInstruction(
+		1*solana.LAMPORTS_PER_SOL,
+		auth.PublicKey(),
+		recipientAddress.PublicKey()).ValidateAndBuild()
+	s.Require().NoError(err)
+	ixData, err := ix.Data()
+	s.Require().NoError(err)
+
+	tx, err := solanasdk.NewTransaction(solana.SystemProgramID.String(), ixData, ix.Accounts(), "System", []string{})
+	s.Require().NoError(err)
+	op := types.Operation{
+		Transaction:   tx,
+		ChainSelector: s.ChainSelector,
+	}
+	metadata := types.ChainMetadata{
+		MCMAddress: s.MCMProgramID.String(),
+	}
+	err = simulator.SimulateOperation(ctx, metadata, op)
+	s.Require().NoError(err)
+}

--- a/e2e/utils/solana/testutils.go
+++ b/e2e/utils/solana/testutils.go
@@ -23,7 +23,7 @@ func FundAccounts(
 
 	var sigs = make([]solana.Signature, 0, len(accounts))
 	for _, v := range accounts {
-		sig, err := solanaGoClient.RequestAirdrop(ctx, v, solAmount*solana.LAMPORTS_PER_SOL, rpc.CommitmentFinalized)
+		sig, err := solanaGoClient.RequestAirdrop(ctx, v, solAmount*solana.LAMPORTS_PER_SOL, rpc.CommitmentConfirmed)
 		require.NoError(t, err)
 		sigs = append(sigs, sig)
 	}
@@ -47,7 +47,7 @@ func FundAccounts(
 
 			unconfirmedTxCount := 0
 			for _, res := range statusRes.Value {
-				if res == nil || res.ConfirmationStatus == rpc.ConfirmationStatusProcessed || res.ConfirmationStatus == rpc.ConfirmationStatusConfirmed {
+				if res == nil || res.ConfirmationStatus == rpc.ConfirmationStatusProcessed {
 					unconfirmedTxCount++
 				}
 			}

--- a/sdk/solana/simulator.go
+++ b/sdk/solana/simulator.go
@@ -20,7 +20,7 @@ type Simulator struct {
 }
 
 // NewSimulator creates a new Solana Simulator
-func NewSimulator(client *rpc.Client, encoder *Encoder, auth solana.PrivateKey) (*Simulator, error) {
+func NewSimulator(client *rpc.Client, auth solana.PrivateKey, encoder *Encoder) (*Simulator, error) {
 	if client == nil {
 		return nil, errors.New("Simulator was created without a Solana RPC client")
 	}

--- a/sdk/solana/simulator.go
+++ b/sdk/solana/simulator.go
@@ -1,0 +1,101 @@
+package solana
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+
+	"github.com/smartcontractkit/mcms/types"
+)
+
+type Simulator struct {
+	client    *rpc.Client
+	encoder   *Encoder
+	inspector *Inspector
+	auth      solana.PrivateKey
+}
+
+// NewSimulator creates a new Solana Simulator
+func NewSimulator(client *rpc.Client, encoder *Encoder, auth solana.PrivateKey) (*Simulator, error) {
+	if client == nil {
+		return nil, errors.New("Simulator was created without a Solana RPC client")
+	}
+
+	if encoder == nil {
+		return nil, errors.New("Simulator was created without an encoder")
+	}
+
+	return &Simulator{
+		client:    client,
+		encoder:   encoder,
+		auth:      auth,
+		inspector: NewInspector(client),
+	}, nil
+}
+
+func (s *Simulator) SimulateSetRoot(
+	ctx context.Context,
+	originCaller solana.PublicKey,
+	metadata types.ChainMetadata,
+	proof [][]byte,
+	root [32]byte,
+	validUntil uint32,
+	sortedSignatures []types.Signature,
+) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *Simulator) SimulateOperation(
+	ctx context.Context,
+	metadata types.ChainMetadata,
+	op types.Operation,
+) error {
+	// Parse the inner instruction from the operation
+	var additionalFields AdditionalFields
+	if err := json.Unmarshal(op.Transaction.AdditionalFields, &additionalFields); err != nil {
+		return fmt.Errorf("unable to unmarshal additional fields: %w", err)
+	}
+
+	toProgramID, _, err := ParseContractAddress(op.Transaction.To)
+	if errors.Is(err, ErrInvalidContractAddressFormat) {
+		var pkerr error
+		toProgramID, pkerr = solana.PublicKeyFromBase58(op.Transaction.To)
+		if pkerr != nil {
+			return fmt.Errorf("unable to parse the 'To' address: %w", err)
+		}
+	}
+
+	// Build the inner instruction
+	accounts := additionalFields.Accounts
+	accounts = append(accounts, solana.Meta(s.auth.PublicKey()).SIGNER())
+	innerInstruction := solana.NewInstruction(
+		toProgramID,
+		accounts,
+		op.Transaction.Data,
+	)
+	recentBlockHash, err := s.client.GetRecentBlockhash(ctx, rpc.CommitmentConfirmed)
+	if err != nil {
+		return fmt.Errorf("unable to get recent blockhash: %w", err)
+	}
+
+	// Build the transaction with the inner instruction
+	tx, err := solana.NewTransaction(
+		[]solana.Instruction{innerInstruction},
+		recentBlockHash.Value.Blockhash,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create transaction: %w", err)
+	}
+
+	// Simulate the transaction
+	_, err = s.client.SimulateTransaction(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("unable to simulate transaction: %w", err)
+	}
+
+	return nil
+}

--- a/sdk/solana/simulator_test.go
+++ b/sdk/solana/simulator_test.go
@@ -43,7 +43,6 @@ func TestSimulator_SimulateOperation(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		ctx      context.Context
 		metadata types.ChainMetadata
 		op       types.Operation
 	}
@@ -61,6 +60,7 @@ func TestSimulator_SimulateOperation(t *testing.T) {
 	data, err := ix.Data()
 	require.NoError(t, err)
 	tx, err := NewTransaction(solana.SystemProgramID.String(), data, ix.Accounts(), "solana-testing", []string{})
+	require.NoError(t, err)
 	tests := []struct {
 		name string
 		args args
@@ -75,7 +75,6 @@ func TestSimulator_SimulateOperation(t *testing.T) {
 				metadata: types.ChainMetadata{
 					MCMAddress: contractID,
 				},
-				ctx: ctx,
 				op: types.Operation{
 					Transaction:   tx,
 					ChainSelector: types.ChainSelector(selector),
@@ -93,7 +92,7 @@ func TestSimulator_SimulateOperation(t *testing.T) {
 				metadata: types.ChainMetadata{
 					MCMAddress: contractID,
 				},
-				ctx: ctx,
+
 				op: types.Operation{
 					Transaction: types.Transaction{
 						AdditionalFields: []byte("invalid"),
@@ -103,7 +102,7 @@ func TestSimulator_SimulateOperation(t *testing.T) {
 			},
 			mockSetup: func(m *mocks.JSONRPCClient) {},
 			wantErr:   fmt.Errorf("unable to unmarshal additional fields: invalid character 'i' looking for beginning of value"),
-			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assertion: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.EqualError(t, err, "unable to unmarshal additional fields: invalid character 'i' looking for beginning of value")
 			},
 		},
@@ -113,7 +112,7 @@ func TestSimulator_SimulateOperation(t *testing.T) {
 				metadata: types.ChainMetadata{
 					MCMAddress: contractID,
 				},
-				ctx: ctx,
+
 				op: types.Operation{
 					Transaction:   tx,
 					ChainSelector: types.ChainSelector(selector),
@@ -123,7 +122,7 @@ func TestSimulator_SimulateOperation(t *testing.T) {
 				mockSolanaSimulation(t, m, 20, 5, "2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6", errors.New("failed to simulate"))
 			},
 			wantErr: errors.New("failed to simulate"),
-			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assertion: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.EqualError(t, err, "unable to get recent blockhash: failed to simulate")
 			},
 		},
@@ -143,7 +142,6 @@ func TestSimulator_SimulateOperation(t *testing.T) {
 				tt.assertion(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
-
 			}
 		})
 	}

--- a/sdk/solana/simulator_test.go
+++ b/sdk/solana/simulator_test.go
@@ -1,0 +1,101 @@
+package solana
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/gagliardetto/solana-go/rpc"
+	cselectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/sdk/solana/mocks"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+func TestNewSimulator(t *testing.T) {
+	t.Parallel()
+
+	client := &rpc.Client{}
+	auth := solana.MustPrivateKeyFromBase58("DmPfeHBC8Brf8s5qQXi25bmJ996v6BHRtaLc6AH51yFGSqQpUMy1oHkbbXobPNBdgGH2F29PAmoq9ZZua4K9vCc")
+	chainSelector := types.ChainSelector(cselectors.SOLANA_DEVNET.Selector)
+	encoder := NewEncoder(chainSelector, 1, false)
+
+	simulator, err := NewSimulator(client, auth, encoder)
+	require.NoError(t, err)
+	require.NotNil(t, simulator)
+}
+
+func TestSimulator_SimulateOperation(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		ctx      context.Context
+		metadata types.ChainMetadata
+		op       types.Operation
+	}
+	selector := cselectors.SOLANA_DEVNET.Selector
+	auth, err := solana.PrivateKeyFromBase58(dummyPrivateKey)
+	require.NoError(t, err)
+	contractID := fmt.Sprintf("%s.%s", testMCMProgramID.String(), testPDASeed)
+
+	ctx := context.Background()
+
+	require.NoError(t, err)
+	testWallet := solana.NewWallet()
+	ix, err := system.NewTransferInstruction(20*solana.LAMPORTS_PER_SOL, auth.PublicKey(), testWallet.PublicKey()).ValidateAndBuild()
+	require.NoError(t, err)
+	data, err := ix.Data()
+	require.NoError(t, err)
+	tx, err := NewTransaction(solana.SystemProgramID.String(), data, ix.Accounts(), "solana-testing", []string{})
+	tests := []struct {
+		name string
+		args args
+
+		mockSetup func(*mocks.JSONRPCClient)
+		assertion assert.ErrorAssertionFunc
+		wantErr   error
+	}{
+		{
+			name: "success: SimulateOperation",
+			args: args{
+				metadata: types.ChainMetadata{
+					MCMAddress: contractID,
+				},
+				ctx: ctx,
+				op: types.Operation{
+					Transaction:   tx,
+					ChainSelector: types.ChainSelector(selector),
+				},
+			},
+			mockSetup: func(m *mocks.JSONRPCClient) {
+				mockSolanaSimulation(t, m, 20, 5, "2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6", nil)
+			},
+
+			assertion: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			jsonRPCClient := mocks.NewJSONRPCClient(t)
+			encoder := NewEncoder(types.ChainSelector(selector), 0, false)
+			client := rpc.NewWithCustomRPCClient(jsonRPCClient)
+			tt.mockSetup(jsonRPCClient)
+			sim, err := NewSimulator(client, auth, encoder)
+			require.NoError(t, err)
+			err = sim.SimulateOperation(ctx, tt.args.metadata, tt.args.op)
+			require.NoError(t, err)
+			if tt.wantErr != nil {
+				tt.assertion(t, err, fmt.Sprintf("%q. Simulator.SimulateOperation()", tt.name))
+			} else {
+				require.NoError(t, err)
+
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the simulate operation functionality for the solana SDK

## Summary 
This pull request introduces a new `Simulator` class for the Solana SDK, along with corresponding tests. The most important changes include the implementation of the `Simulator` class, a new test suite for the `Simulator`, and a helper function for mocking Solana transactions.

New `Simulator` class implementation:

* [`sdk/solana/simulator.go`](diffhunk://#diff-819ef823068a2dda743cca46f5aa3881fb329dbe720413f5bbe77159069dfcadR1-R101): Added a new `Simulator` class with methods for simulating operations and setting roots. This includes the `NewSimulator` constructor and methods `SimulateSetRoot` and `SimulateOperation`.

Testing:

* [`sdk/solana/simulator_test.go`](diffhunk://#diff-c235e4dcf18f3d08d41ea03fc63a97e8417a4de95aa692992fe7f1948f1c26e1R1-R101): Added tests for the `Simulator` class, including `TestNewSimulator` to test the constructor and `TestSimulator_SimulateOperation` to test the `SimulateOperation` method.

Helper function for mocking:

* [`sdk/solana/utils_test.go`](diffhunk://#diff-8096af585d3c4fec6947d289f0200e6e905bc40f87c14541e540bafe2e743e24R156-R197): Added a new helper function `mockSolanaSimulation` to mock Solana transaction simulations in tests.