### PR TITLE
feat(solana): simulation for set root

### DIFF
--- a/.changeset/smooth-bags-burn.md
+++ b/.changeset/smooth-bags-burn.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+feat(solana): add setRoot simulator

--- a/e2e/tests/solana/simulator.go
+++ b/e2e/tests/solana/simulator.go
@@ -1,0 +1,102 @@
+//go:build e2e
+// +build e2e
+
+package solanae2e
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go"
+
+	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/sdk"
+	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+var testPDASeedSetRootSimulateTest = [32]byte{'t', 'e', 's', 't', '-', 's', 'e', 't', 'r', 'o', 'o', 't', '-', 's', 'i', 'm', 'u', 'l', 'a', 't', 'e'}
+
+func (s *SolanaTestSuite) TestSimulator_SimulateSetRoot() {
+	s.SetupMCM(testPDASeedSetRootSimulateTest)
+	ctx := context.Background()
+
+	mcmAddress := solanasdk.ContractAddress(s.MCMProgramID, testPDASeedSetRootSimulateTest)
+
+	signerEVMAccount := NewEVMTestAccount(s.T())
+	mcmConfig := types.Config{Quorum: 1, Signers: []common.Address{signerEVMAccount.Address}}
+
+	auth, err := solana.PrivateKeyFromBase58(privateKey)
+	s.Require().NoError(err)
+
+	validUntil := time.Now().Add(10 * time.Hour).Unix()
+	solanaTx, err := solanasdk.NewTransaction(
+		auth.PublicKey().String(),
+		[]byte("test data"),
+		[]*solana.AccountMeta{{PublicKey: auth.PublicKey(), IsSigner: true, IsWritable: false}},
+		"unit-tests",
+		[]string{"test"},
+	)
+	s.Require().NoError(err)
+
+	proposal, err := mcms.NewProposalBuilder().
+		SetVersion("v1").
+		SetValidUntil(uint32(validUntil)).
+		SetDescription("proposal to test SetRoot").
+		SetOverridePreviousRoot(true).
+		AddChainMetadata(s.ChainSelector, types.ChainMetadata{MCMAddress: mcmAddress}).
+		AddOperation(types.Operation{
+			ChainSelector: s.ChainSelector,
+			Transaction:   solanaTx,
+		}).
+		Build()
+	s.Require().NoError(err)
+
+	encoders, err := proposal.GetEncoders()
+	s.Require().NoError(err)
+	encoder := encoders[s.ChainSelector].(*solanasdk.Encoder)
+	executor := solanasdk.NewExecutor(s.SolanaClient, auth, encoder)
+	inspectors := map[types.ChainSelector]sdk.Inspector{s.ChainSelector: solanasdk.NewInspector(s.SolanaClient)}
+
+	// sign proposal
+	signable, err := mcms.NewSignable(proposal, inspectors)
+	s.Require().NoError(err)
+	s.Require().NotNil(signable)
+	_, err = signable.SignAndAppend(mcms.NewPrivateKeySigner(signerEVMAccount.PrivateKey))
+	s.Require().NoError(err)
+
+	// set config
+	configurer := solanasdk.NewConfigurer(s.SolanaClient, auth, s.ChainSelector)
+	_, err = configurer.SetConfig(ctx, mcmAddress, &mcmConfig, true)
+	s.Require().NoError(err)
+
+	// simulate set root
+	metadata := proposal.ChainMetadata[s.ChainSelector]
+	metadataHash, err := encoder.HashMetadata(metadata)
+	s.Require().NoError(err)
+
+	tree, err := proposal.MerkleTree()
+	s.Require().NoError(err)
+
+	proof, err := tree.GetProof(metadataHash)
+	s.Require().NoError(err)
+
+	hash, err := proposal.SigningHash()
+	s.Require().NoError(err)
+
+	// Sort signatures by recovered address
+	sortedSignatures := slices.Clone(proposal.Signatures) // Clone so we don't modify the original
+	slices.SortFunc(sortedSignatures, func(a, b types.Signature) int {
+		recoveredSignerA, _ := a.Recover(hash)
+		recoveredSignerB, _ := b.Recover(hash)
+
+		return recoveredSignerA.Cmp(recoveredSignerB)
+	})
+
+	simulator := solanasdk.NewSimulator(executor)
+
+	err = simulator.SimulateSetRoot(ctx, "", metadata, proof, [32]byte(tree.Root.Bytes()), proposal.ValidUntil, sortedSignatures)
+	s.Require().NoError(err)
+}

--- a/sdk/solana/simulatable.go
+++ b/sdk/solana/simulatable.go
@@ -1,0 +1,80 @@
+package solana
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
+	solanaCommon "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+)
+
+type Simulatable struct {
+	simulate     bool
+	instructions []instructionBuilder[*mcm.Instruction]
+}
+
+func (s *Simulatable) EnableSimulation(
+	ctx context.Context, client *rpc.Client, auth solana.PrivateKey, opts rpc.SimulateTransactionOpts, action func() error,
+) error {
+	s.simulate = true
+
+	err := action()
+	if err != nil {
+		return err
+	}
+
+	err = simulateInstructionWithOpts(ctx, client, auth, s.instructions, opts)
+	s.simulate = false
+	s.instructions = nil
+	if err != nil {
+		return fmt.Errorf("simulation failed: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Simulatable) sendAndConfirmOrSimulate(
+	ctx context.Context,
+	client *rpc.Client,
+	auth solana.PrivateKey,
+	instructionBuilder instructionBuilder[*mcm.Instruction],
+	commitmentType rpc.CommitmentType,
+) (string, error) {
+	if s.simulate {
+		s.instructions = append(s.instructions, instructionBuilder)
+		return "", nil
+	}
+
+	signature, err := sendAndConfirm(ctx, client, auth, instructionBuilder, commitmentType)
+
+	return signature, err
+}
+
+func simulateInstructionWithOpts(
+	ctx context.Context,
+	client *rpc.Client,
+	auth solana.PrivateKey,
+	instructionBuilders []instructionBuilder[*mcm.Instruction],
+	opts rpc.SimulateTransactionOpts,
+) error {
+	insts := make([]solana.Instruction, 0, len(instructionBuilders))
+	for _, inst := range instructionBuilders {
+		builtInstruction, err := inst.ValidateAndBuild()
+		if err != nil {
+			return fmt.Errorf("unable to validate and build instruction: %w", err)
+		}
+		insts = append(insts, builtInstruction)
+	}
+
+	result, err := solanaCommon.SimulateTransactionWithOpts(ctx, client, insts, auth, opts)
+	if err != nil {
+		return fmt.Errorf("unable to simulate instruction: %w", err)
+	}
+	if result.Value.Err != nil {
+		return fmt.Errorf("unable to simulate instruction: %s", result.Value.Err)
+	}
+
+	return nil
+}

--- a/sdk/solana/simulatable_test.go
+++ b/sdk/solana/simulatable_test.go
@@ -1,0 +1,144 @@
+package solana
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/mcm"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/sdk/solana/mocks"
+)
+
+func TestSimulatable_SimulationOn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	pk, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+
+	pubKey := pk.PublicKey()
+
+	someError := errors.New("some error")
+	tests := []struct {
+		name          string
+		expectedError string
+		actionToRun   func(client *rpc.Client, s *Simulatable) error
+		setupMock     func(t *testing.T, client *mocks.JSONRPCClient)
+	}{
+		{
+			name: "Successful Simulation",
+			setupMock: func(t *testing.T, client *mocks.JSONRPCClient) {
+				t.Helper()
+				mockSolanaSimulateTransaction(t, client, 50, nil, nil)
+			},
+			actionToRun: func(client *rpc.Client, s *Simulatable) error {
+				instruction := mcm.NewClearSignersInstruction(testPDASeed, pubKey, pubKey, pubKey)
+				_, err = s.sendAndConfirmOrSimulate(ctx, client, pk, instruction, rpc.CommitmentFinalized)
+
+				return err
+			},
+			expectedError: "",
+		},
+		{
+			name: "Simulated Action Error",
+			actionToRun: func(_ *rpc.Client, _ *Simulatable) error {
+				return someError
+			},
+			expectedError: "some error",
+		},
+		{
+			name: "Instruction Validation Error",
+			actionToRun: func(client *rpc.Client, s *Simulatable) error {
+				instruction := mcm.NewClearSignersInstruction(testPDASeed, pubKey, pubKey, pubKey)
+				// setting MultisigId to nil will trigger validation error later when building the instruction
+				instruction.MultisigId = nil
+				_, err = s.sendAndConfirmOrSimulate(ctx, client, pk, instruction, rpc.CommitmentConfirmed)
+
+				return err
+			},
+			expectedError: "simulation failed: unable to validate and build instruction: MultisigId parameter is not set",
+		},
+		{
+			name: "SimulateTransaction RPC Communication Error",
+			setupMock: func(t *testing.T, client *mocks.JSONRPCClient) {
+				t.Helper()
+				mockSolanaSimulateTransaction(t, client, 50, someError, nil)
+			},
+			actionToRun: func(client *rpc.Client, s *Simulatable) error {
+				instruction := mcm.NewClearSignersInstruction(testPDASeed, pubKey, pubKey, pubKey)
+				_, err = s.sendAndConfirmOrSimulate(ctx, client, pk, instruction, rpc.CommitmentConfirmed)
+
+				return err
+			},
+			expectedError: "some error",
+		},
+		{
+			name: "SimulateTransaction RPC Response Error",
+			setupMock: func(t *testing.T, client *mocks.JSONRPCClient) {
+				t.Helper()
+				mockSolanaSimulateTransaction(t, client, 50, nil, someError)
+			},
+			actionToRun: func(client *rpc.Client, s *Simulatable) error {
+				instruction := mcm.NewClearSignersInstruction(testPDASeed, pubKey, pubKey, pubKey)
+				_, err = s.sendAndConfirmOrSimulate(ctx, client, pk, instruction, rpc.CommitmentConfirmed)
+
+				return err
+			},
+			expectedError: "some error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Simulatable{}
+
+			mockJSONRPCClient := mocks.NewJSONRPCClient(t)
+			client := rpc.NewWithCustomRPCClient(mockJSONRPCClient)
+
+			if tt.setupMock != nil {
+				tt.setupMock(t, mockJSONRPCClient)
+			}
+
+			action := func() error {
+				return tt.actionToRun(client, s)
+			}
+
+			err = s.EnableSimulation(ctx, client, pk, rpc.SimulateTransactionOpts{}, action)
+
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSimulatable_SimulationOff(t *testing.T) {
+	t.Parallel()
+
+	s := &Simulatable{}
+	mockJSONRPCClient := mocks.NewJSONRPCClient(t)
+	client := rpc.NewWithCustomRPCClient(mockJSONRPCClient)
+	ctx := context.Background()
+
+	pk, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+
+	pubKey := pk.PublicKey()
+
+	// expect actual transaction to be sent
+	mockSolanaTransaction(t, mockJSONRPCClient, 12, 22,
+		"2iEeniu3QUgXNsjau8r7fZ7XLb2g1F3q9VJJKvRyyFz4hHgVvhGkLgSUdmRumfXKWv8spJ9ihudGFyPZsPGdp4Ya", nil)
+
+	instruction := mcm.NewClearSignersInstruction(testPDASeed, pubKey, pubKey, pubKey)
+
+	_, err = s.sendAndConfirmOrSimulate(ctx, client, pk, instruction, rpc.CommitmentConfirmed)
+
+	require.NoError(t, err)
+}

--- a/sdk/solana/simulator.go
+++ b/sdk/solana/simulator.go
@@ -1,0 +1,45 @@
+package solana
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go/rpc"
+
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+var _ sdk.Simulator = &Simulator{}
+
+type Simulator struct {
+	*Executor
+}
+
+func NewSimulator(executor *Executor) *Simulator {
+	return &Simulator{
+		executor,
+	}
+}
+
+func (s Simulator) SimulateSetRoot(
+	ctx context.Context, _ string,
+	metadata types.ChainMetadata, proof []common.Hash, root [32]byte,
+	validUntil uint32, sortedSignatures []types.Signature,
+) error {
+	err := s.EnableSimulation(ctx, s.client, s.auth,
+		rpc.SimulateTransactionOpts{
+			Commitment: rpc.CommitmentConfirmed,
+		},
+		func() error {
+			_, err := s.SetRoot(ctx, metadata, proof, root, validUntil, sortedSignatures)
+			return err
+		})
+
+	return err
+}
+
+func (s Simulator) SimulateOperation(
+	ctx context.Context, metadata types.ChainMetadata, operation types.Operation) error {
+	panic("implement me")
+}

--- a/sdk/solana/simulator_test.go
+++ b/sdk/solana/simulator_test.go
@@ -1,0 +1,72 @@
+package solana
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/sdk/solana/mocks"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+func TestSimulator_SimulateSetRoot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	auth, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+
+	metadata := types.ChainMetadata{StartingOpCount: 100, MCMAddress: ContractAddress(testMCMProgramID, testPDASeed)}
+	proof := []common.Hash{common.HexToHash("0x1"), common.HexToHash("0x2")}
+	root := common.HexToHash("0x1234")
+	validUntil := uint32(2082758400)
+	signatures := []types.Signature{
+		{R: common.HexToHash("0x3"), S: common.HexToHash("0x4"), V: 27},
+		{R: common.HexToHash("0x5"), S: common.HexToHash("0x6"), V: 27},
+	}
+
+	tests := []struct {
+		name          string
+		setupMocks    func(t *testing.T, client *mocks.JSONRPCClient)
+		expectedError string
+	}{
+		{
+			name: "success",
+			setupMocks: func(t *testing.T, client *mocks.JSONRPCClient) {
+				t.Helper()
+				mockSolanaSimulateTransaction(t, client, 50, nil, nil)
+			},
+		},
+		{
+			name: "set root error",
+			setupMocks: func(t *testing.T, client *mocks.JSONRPCClient) {
+				t.Helper()
+				mockSolanaSimulateTransaction(t, client, 50, errors.New("some error"), nil)
+			},
+			expectedError: "some error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			executor, client := newTestExecutor(t, auth, testChainSelector)
+			simulator := NewSimulator(executor)
+
+			tt.setupMocks(t, client)
+
+			err = simulator.SimulateSetRoot(ctx, "", metadata, proof, root, validUntil, signatures)
+
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/sdk/solana/utils_test.go
+++ b/sdk/solana/utils_test.go
@@ -153,6 +153,46 @@ func mockSolanaTransaction(
 	}).Once()
 }
 
+func mockSolanaSimulateTransaction(
+	t *testing.T, client *mocks.JSONRPCClient, lastBlockHeight uint64, mockBlockHashRPCError error,
+	mockSimulateTransactionError error,
+) {
+	t.Helper()
+
+	client.EXPECT().CallForInto(
+		anyContext, mock.Anything, "getLatestBlockhash", []any{rpc.M{"commitment": rpc.CommitmentFinalized}},
+	).RunAndReturn(func(_ context.Context, output any, _ string, _ []any) error {
+		result, ok := output.(**rpc.GetLatestBlockhashResult)
+		require.True(t, ok)
+
+		*result = &rpc.GetLatestBlockhashResult{Value: &rpc.LatestBlockhashResult{
+			Blockhash:            solana.MustHashFromBase58(randomPublicKey(t).String()),
+			LastValidBlockHeight: lastBlockHeight,
+		}}
+
+		return mockBlockHashRPCError
+	}).Once()
+	if mockBlockHashRPCError != nil {
+		return
+	}
+
+	client.EXPECT().CallForInto(
+		anyContext, mock.Anything, "simulateTransaction", mock.Anything,
+	).RunAndReturn(func(_ context.Context, output any, _ string, _ []any) error {
+		result, ok := output.(**rpc.SimulateTransactionResponse)
+		require.True(t, ok)
+
+		*result = &rpc.SimulateTransactionResponse{
+			Value: &rpc.SimulateTransactionResult{
+				Err:  mockSimulateTransactionError,
+				Logs: []string{"Transaction simulation successful"},
+			},
+		}
+
+		return nil
+	})
+}
+
 var sendTransactionParams = func(t *testing.T) any {
 	t.Helper()
 


### PR DESCRIPTION
An attempt at simulating the set root operation using the simulate transaction api of the rpc client.

**Focus on simulator.go and executor.go, that where the core changes are**

Trying to get some feedback on this approach.

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1417