### PR TITLE
[DPA-1477]: fix(executor): callproxy as config & missing test

### DIFF
--- a/.changeset/honest-jobs-prove.md
+++ b/.changeset/honest-jobs-prove.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix(executor): callproxy as config

--- a/e2e/tests/solana/timelock_converter.go
+++ b/e2e/tests/solana/timelock_converter.go
@@ -416,12 +416,12 @@ func (s *SolanaTestSuite) executeTimelockProposal(
 	timelockExecutable, err := mcms.NewTimelockExecutable(timelockProposal, timelockExecutors)
 	s.Require().NoError(err)
 
-	signature, err := timelockExecutable.Execute(ctx, 0, "")
+	signature, err := timelockExecutable.Execute(ctx, 0)
 	s.Require().NoError(err)
 	s.Require().Contains(getTransactionLogs(s.T(), ctx, s.SolanaClient, signature), "Called `empty`")
 	s.Require().Contains(getTransactionLogs(s.T(), ctx, s.SolanaClient, signature), "Called `u8_instruction_data`")
 
-	signature, err = timelockExecutable.Execute(ctx, 1, "")
+	signature, err = timelockExecutable.Execute(ctx, 1)
 	s.Require().NoError(err)
 	s.Require().Contains(getTransactionLogs(s.T(), ctx, s.SolanaClient, signature), "Called `account_mut`")
 }


### PR DESCRIPTION
From the [original PR](https://github.com/smartcontractkit/mcms/pull/256) by Akhil

I thought it would fit better for the call proxy config to be configured via the [option pattern](https://golang.cafe/blog/golang-functional-options-pattern.html) as the call proxy is optional so we dont have to provide empty string. Thoughts?

Also it was missing a unit test for the call proxy.

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1477