### PR TITLE
feat: return GetTransactionResult type as Solana transactions

### DIFF
--- a/.changeset/old-adults-swim.md
+++ b/.changeset/old-adults-swim.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+Return the solana.rpc.GetTransactionResult struct as the raw transaction of the Solana SDK.

--- a/sdk/solana/common.go
+++ b/sdk/solana/common.go
@@ -107,26 +107,26 @@ func sendAndConfirm[I solana.Instruction](
 	auth solana.PrivateKey,
 	builder instructionBuilder[I],
 	commitmentType rpc.CommitmentType,
-) (string, error) {
+) (string, *rpc.GetTransactionResult, error) {
 	builtInstruction, err := builder.ValidateAndBuild()
 	if err != nil {
-		return "", fmt.Errorf("unable to validate and build instruction: %w", err)
+		return "", nil, fmt.Errorf("unable to validate and build instruction: %w", err)
 	}
 
 	result, err := solanaCommon.SendAndConfirm(ctx, client, []solana.Instruction{builtInstruction}, auth, commitmentType)
 	if err != nil {
-		return "", fmt.Errorf("unable to send instruction: %w", err)
+		return "", nil, fmt.Errorf("unable to send instruction: %w", err)
 	}
 	if result.Transaction == nil {
-		return "", fmt.Errorf("nil transaction in instruction result")
+		return "", nil, fmt.Errorf("nil transaction in instruction result")
 	}
 
 	transaction, err := result.Transaction.GetTransaction()
 	if err != nil {
-		return "", fmt.Errorf("unable to get transaction from instruction result: %w", err)
+		return "", nil, fmt.Errorf("unable to get transaction from instruction result: %w", err)
 	}
 
-	return transaction.Signatures[0].String(), nil
+	return transaction.Signatures[0].String(), result, nil
 }
 
 func chunkIndexes(numItems int, chunkSize int) [][2]int {

--- a/sdk/solana/common_test.go
+++ b/sdk/solana/common_test.go
@@ -116,20 +116,29 @@ func Test_sendAndConfirm(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		name    string
-		setup   func(*mocks.JSONRPCClient)
-		builder instructionBuilder[*bindings.Instruction]
-		want    string
-		wantErr string
+		name            string
+		setup           func(*mocks.JSONRPCClient)
+		builder         instructionBuilder[*bindings.Instruction]
+		wantSignature   string
+		wantTransaction *rpc.GetTransactionResult
+		wantErr         string
 	}{
 		{
 			name:    "success",
 			builder: bindings.NewAcceptOwnershipInstruction(testPDASeed, configPDA, auth.PublicKey()),
 			setup: func(mockJSONRPCClient *mocks.JSONRPCClient) {
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
-					"KCXrjxMUkZ8mYmYB8uTKyCzHuAEHFwgRy7McRsrSPA9MndPjkPtsc2zA82ZKh9mBxB41REzghVMCTGLuNqWkzhp", nil)
+					"KCXrjxMUkZ8mYmYB8uTKyCzHuAEHFwgRy7McRsrSPA9MndPjkPtsc2zA82ZKh9mBxB41REzghVMCTGLuNqWkzhp",
+					ptrTo(solana.UnixTimeSeconds(1735689600)), nil)
 			},
-			want: "KCXrjxMUkZ8mYmYB8uTKyCzHuAEHFwgRy7McRsrSPA9MndPjkPtsc2zA82ZKh9mBxB41REzghVMCTGLuNqWkzhp",
+			wantSignature: "KCXrjxMUkZ8mYmYB8uTKyCzHuAEHFwgRy7McRsrSPA9MndPjkPtsc2zA82ZKh9mBxB41REzghVMCTGLuNqWkzhp",
+			wantTransaction: &rpc.GetTransactionResult{
+				Slot:        20,
+				BlockTime:   ptrTo(solana.UnixTimeSeconds(1735689600)),
+				Transaction: buildTransactionEnvelope(t, "KCXrjxMUkZ8mYmYB8uTKyCzHuAEHFwgRy7McRsrSPA9MndPjkPtsc2zA82ZKh9mBxB41REzghVMCTGLuNqWkzhp"),
+				Meta:        &rpc.TransactionMeta{},
+				Version:     1,
+			},
 		},
 		{
 			name:    "failure: ValidateAndBuild error ",
@@ -143,7 +152,7 @@ func Test_sendAndConfirm(t *testing.T) {
 			setup: func(mockJSONRPCClient *mocks.JSONRPCClient) {
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
 					"NyH6sKKEbAMjxzG9qLTcwd1yEmv46Z94XmH5Pp9AXJps8EofvpPdUn5bp7rzKnztWmxskBiVRnp4DwaHujhHvFh",
-					fmt.Errorf("send and confirm error"))
+					nil, fmt.Errorf("send and confirm error"))
 			},
 			wantErr: "unable to send instruction: send and confirm error",
 		},
@@ -156,12 +165,15 @@ func Test_sendAndConfirm(t *testing.T) {
 			client := rpc.NewWithCustomRPCClient(mockJSONRPCClient)
 			tt.setup(mockJSONRPCClient)
 
-			got, err := sendAndConfirm(ctx, client, auth, tt.builder, commitmentType)
+			gotSignature, gotTransaction, err := sendAndConfirm(ctx, client, auth, tt.builder, commitmentType)
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)
-				require.Equal(t, tt.want, got)
+				require.Equal(t, tt.wantSignature, gotSignature)
+				require.Equal(t, tt.wantTransaction, gotTransaction)
 			} else {
+				require.Empty(t, gotSignature)
+				require.Nil(t, gotTransaction)
 				require.ErrorContains(t, err, tt.wantErr)
 			}
 		})
@@ -174,4 +186,17 @@ type invalidTestInstruction struct{}
 
 func (*invalidTestInstruction) ValidateAndBuild() (*bindings.Instruction, error) {
 	return nil, fmt.Errorf("validate and build error ")
+}
+
+func buildTransactionEnvelope(t *testing.T, signature string) *rpc.TransactionResultEnvelope {
+	t.Helper()
+
+	var transactionEnvelope rpc.TransactionResultEnvelope
+	err := transactionEnvelope.UnmarshalJSON([]byte(`{
+		"signatures": ["` + signature + `"],
+		"message": {}
+	}`))
+	require.NoError(t, err)
+
+	return &transactionEnvelope
 }

--- a/sdk/solana/configurer_test.go
+++ b/sdk/solana/configurer_test.go
@@ -54,13 +54,13 @@ func TestConfigurer_SetConfig(t *testing.T) {
 				// TODO: extract/decode payload in transaction data and test values
 				// 4 transactions: init-signers, append-signers, finalize-signers, set-config
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
-					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr", nil)
+					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 11, 21,
-					"7D9XEYRnCn1D5JFrrYMPUaHfog7Vnj5rbPdj7kbULa4hKq7GsnA7Q8KNQfLEgfCawBsW4dcH2MQAp4km1dnjr6V", nil)
+					"7D9XEYRnCn1D5JFrrYMPUaHfog7Vnj5rbPdj7kbULa4hKq7GsnA7Q8KNQfLEgfCawBsW4dcH2MQAp4km1dnjr6V", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 12, 22,
-					"2iEeniu3QUgXNsjau8r7fZ7XLb2g1F3q9VJJKvRyyFz4hHgVvhGkLgSUdmRumfXKWv8spJ9ihudGFyPZsPGdp4Ya", nil)
+					"2iEeniu3QUgXNsjau8r7fZ7XLb2g1F3q9VJJKvRyyFz4hHgVvhGkLgSUdmRumfXKWv8spJ9ihudGFyPZsPGdp4Ya", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 13, 23,
-					"52f3VmvW7m9uTQu3PtyibgxnAvEuXDmm9umuHherGjS4pzRR7QXRDKnZhh6b95P7pQxzTgvE1muMNKYEY7YWsS3G", nil)
+					"52f3VmvW7m9uTQu3PtyibgxnAvEuXDmm9umuHherGjS4pzRR7QXRDKnZhh6b95P7pQxzTgvE1muMNKYEY7YWsS3G", nil, nil)
 			},
 			want: "52f3VmvW7m9uTQu3PtyibgxnAvEuXDmm9umuHherGjS4pzRR7QXRDKnZhh6b95P7pQxzTgvE1muMNKYEY7YWsS3G",
 		},
@@ -78,7 +78,7 @@ func TestConfigurer_SetConfig(t *testing.T) {
 
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
 					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr",
-					fmt.Errorf("initialize signers error"))
+					nil, fmt.Errorf("initialize signers error"))
 			},
 			wantErr: "unable to initialize signers: unable to send instruction: initialize signers error",
 		},
@@ -90,12 +90,12 @@ func TestConfigurer_SetConfig(t *testing.T) {
 
 				// initialize signers
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
-					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr", nil)
+					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr", nil, nil)
 
 				// append signers
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
 					"7D9XEYRnCn1D5JFrrYMPUaHfog7Vnj5rbPdj7kbULa4hKq7GsnA7Q8KNQfLEgfCawBsW4dcH2MQAp4km1dnjr6V",
-					fmt.Errorf("append signers error"))
+					nil, fmt.Errorf("append signers error"))
 			},
 			wantErr: "unable to append signers (0): unable to send instruction: append signers error",
 		},
@@ -107,14 +107,14 @@ func TestConfigurer_SetConfig(t *testing.T) {
 
 				// initialize signers + append signers
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
-					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr", nil)
+					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
-					"7D9XEYRnCn1D5JFrrYMPUaHfog7Vnj5rbPdj7kbULa4hKq7GsnA7Q8KNQfLEgfCawBsW4dcH2MQAp4km1dnjr6V", nil)
+					"7D9XEYRnCn1D5JFrrYMPUaHfog7Vnj5rbPdj7kbULa4hKq7GsnA7Q8KNQfLEgfCawBsW4dcH2MQAp4km1dnjr6V", nil, nil)
 
 				// finalize signers
 				mockSolanaTransaction(t, mockJSONRPCClient, 12, 22,
 					"2iEeniu3QUgXNsjau8r7fZ7XLb2g1F3q9VJJKvRyyFz4hHgVvhGkLgSUdmRumfXKWv8spJ9ihudGFyPZsPGdp4Ya",
-					fmt.Errorf("finalize signers error"))
+					nil, fmt.Errorf("finalize signers error"))
 			},
 			wantErr: "unable to finalize signers: unable to send instruction: finalize signers error",
 		},
@@ -126,16 +126,16 @@ func TestConfigurer_SetConfig(t *testing.T) {
 
 				// initialize signers + append signers + finalize signers
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
-					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr", nil)
+					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
-					"7D9XEYRnCn1D5JFrrYMPUaHfog7Vnj5rbPdj7kbULa4hKq7GsnA7Q8KNQfLEgfCawBsW4dcH2MQAp4km1dnjr6V", nil)
+					"7D9XEYRnCn1D5JFrrYMPUaHfog7Vnj5rbPdj7kbULa4hKq7GsnA7Q8KNQfLEgfCawBsW4dcH2MQAp4km1dnjr6V", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 12, 22,
-					"2iEeniu3QUgXNsjau8r7fZ7XLb2g1F3q9VJJKvRyyFz4hHgVvhGkLgSUdmRumfXKWv8spJ9ihudGFyPZsPGdp4Ya", nil)
+					"2iEeniu3QUgXNsjau8r7fZ7XLb2g1F3q9VJJKvRyyFz4hHgVvhGkLgSUdmRumfXKWv8spJ9ihudGFyPZsPGdp4Ya", nil, nil)
 
 				// set config
 				mockSolanaTransaction(t, mockJSONRPCClient, 13, 23,
 					"52f3VmvW7m9uTQu3PtyibgxnAvEuXDmm9umuHherGjS4pzRR7QXRDKnZhh6b95P7pQxzTgvE1muMNKYEY7YWsS3G",
-					fmt.Errorf("set config error"))
+					nil, fmt.Errorf("set config error"))
 			},
 			wantErr: "unable to set config: unable to send instruction: set config error",
 		},

--- a/sdk/solana/executor_test.go
+++ b/sdk/solana/executor_test.go
@@ -77,7 +77,8 @@ func TestExecutor_ExecuteOperation(t *testing.T) {
 				},
 			},
 			mockSetup: func(m *mocks.JSONRPCClient) {
-				mockSolanaTransaction(t, m, 20, 5, "2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6", nil)
+				mockSolanaTransaction(t, m, 20, 5,
+					"2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6", nil, nil)
 			},
 			want:      "2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6",
 			assertion: assert.NoError,
@@ -127,6 +128,7 @@ func TestExecutor_ExecuteOperation(t *testing.T) {
 					20,
 					5,
 					"2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6",
+					nil,
 					errors.New("ix send failure"))
 			},
 			want:    "",
@@ -226,13 +228,13 @@ func TestExecutor_SetRoot(t *testing.T) {
 				// TODO: extract/decode payload in transaction data and test values
 				// 4 transactions: init-signatures, append-signatures, finalize-signatures, set-root
 				mockSolanaTransaction(t, mockJSONRPCClient, 50, 60,
-					"AxzwxQ2DLR4zEFxEPGaafR4z3MY4CP1CAdSs1ZZhArtgS3G4F9oYSy3Nx1HyA1Macb4bYEi4jU6F1CL4SRrZz1v", nil)
+					"AxzwxQ2DLR4zEFxEPGaafR4z3MY4CP1CAdSs1ZZhArtgS3G4F9oYSy3Nx1HyA1Macb4bYEi4jU6F1CL4SRrZz1v", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 51, 61,
-					"3DqeyZzb7PJmQ31M1qdXfP7iACr5AiEXcKeLUNmVvDoYM23JJK5ZvermxsDy8eiQKzpagc69MKRtrpzK7tRcLGgr", nil)
+					"3DqeyZzb7PJmQ31M1qdXfP7iACr5AiEXcKeLUNmVvDoYM23JJK5ZvermxsDy8eiQKzpagc69MKRtrpzK7tRcLGgr", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 52, 62,
-					"GHR9z23oUJnS2aV5HZ9zEpUpEe4qoBLFMzuBjNA3xJcQuc6JjDmuUq2VVmxqwPeFzfs8V7nfjqc1wRviEb82bRu", nil)
+					"GHR9z23oUJnS2aV5HZ9zEpUpEe4qoBLFMzuBjNA3xJcQuc6JjDmuUq2VVmxqwPeFzfs8V7nfjqc1wRviEb82bRu", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 53, 63,
-					"oaV9FKKPDVneUANQ9hJqEuhgwfUgbxucUC4TmzpgGJhuSxBueapWc9HJ4cJQMqT2PPQX6rhTbKnXkebsaravnLo", nil)
+					"oaV9FKKPDVneUANQ9hJqEuhgwfUgbxucUC4TmzpgGJhuSxBueapWc9HJ4cJQMqT2PPQX6rhTbKnXkebsaravnLo", nil, nil)
 			},
 			want: "oaV9FKKPDVneUANQ9hJqEuhgwfUgbxucUC4TmzpgGJhuSxBueapWc9HJ4cJQMqT2PPQX6rhTbKnXkebsaravnLo",
 		},
@@ -269,7 +271,7 @@ func TestExecutor_SetRoot(t *testing.T) {
 				// init-signatures
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
 					"AxzwxQ2DLR4zEFxEPGaafR4z3MY4CP1CAdSs1ZZhArtgS3G4F9oYSy3Nx1HyA1Macb4bYEi4jU6F1CL4SRrZz1v",
-					fmt.Errorf("initialize signatures error"))
+					nil, fmt.Errorf("initialize signatures error"))
 			},
 			wantErr: "unable to initialize signatures: unable to send instruction: initialize signatures error",
 		},
@@ -285,12 +287,12 @@ func TestExecutor_SetRoot(t *testing.T) {
 
 				// init-signatures
 				mockSolanaTransaction(t, mockJSONRPCClient, 50, 60,
-					"AxzwxQ2DLR4zEFxEPGaafR4z3MY4CP1CAdSs1ZZhArtgS3G4F9oYSy3Nx1HyA1Macb4bYEi4jU6F1CL4SRrZz1v", nil)
+					"AxzwxQ2DLR4zEFxEPGaafR4z3MY4CP1CAdSs1ZZhArtgS3G4F9oYSy3Nx1HyA1Macb4bYEi4jU6F1CL4SRrZz1v", nil, nil)
 
 				// append-signatures
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
 					"3DqeyZzb7PJmQ31M1qdXfP7iACr5AiEXcKeLUNmVvDoYM23JJK5ZvermxsDy8eiQKzpagc69MKRtrpzK7tRcLGgr",
-					fmt.Errorf("append signatures error"))
+					nil, fmt.Errorf("append signatures error"))
 			},
 			wantErr: "unable to append signatures (0): unable to send instruction: append signatures error",
 		},
@@ -306,14 +308,14 @@ func TestExecutor_SetRoot(t *testing.T) {
 
 				// init-signatures + append-signatures
 				mockSolanaTransaction(t, mockJSONRPCClient, 50, 60,
-					"AxzwxQ2DLR4zEFxEPGaafR4z3MY4CP1CAdSs1ZZhArtgS3G4F9oYSy3Nx1HyA1Macb4bYEi4jU6F1CL4SRrZz1v", nil)
+					"AxzwxQ2DLR4zEFxEPGaafR4z3MY4CP1CAdSs1ZZhArtgS3G4F9oYSy3Nx1HyA1Macb4bYEi4jU6F1CL4SRrZz1v", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
-					"3DqeyZzb7PJmQ31M1qdXfP7iACr5AiEXcKeLUNmVvDoYM23JJK5ZvermxsDy8eiQKzpagc69MKRtrpzK7tRcLGgr", nil)
+					"3DqeyZzb7PJmQ31M1qdXfP7iACr5AiEXcKeLUNmVvDoYM23JJK5ZvermxsDy8eiQKzpagc69MKRtrpzK7tRcLGgr", nil, nil)
 
 				// finalize-signatures
 				mockSolanaTransaction(t, mockJSONRPCClient, 52, 62,
 					"GHR9z23oUJnS2aV5HZ9zEpUpEe4qoBLFMzuBjNA3xJcQuc6JjDmuUq2VVmxqwPeFzfs8V7nfjqc1wRviEb82bRu",
-					fmt.Errorf("finalize signatures error"))
+					nil, fmt.Errorf("finalize signatures error"))
 			},
 			wantErr: "unable to finalize signatures: unable to send instruction: finalize signatures error",
 		},
@@ -329,16 +331,16 @@ func TestExecutor_SetRoot(t *testing.T) {
 
 				// init-signatures + append-signatures + finalize-signatures
 				mockSolanaTransaction(t, mockJSONRPCClient, 50, 60,
-					"AxzwxQ2DLR4zEFxEPGaafR4z3MY4CP1CAdSs1ZZhArtgS3G4F9oYSy3Nx1HyA1Macb4bYEi4jU6F1CL4SRrZz1v", nil)
+					"AxzwxQ2DLR4zEFxEPGaafR4z3MY4CP1CAdSs1ZZhArtgS3G4F9oYSy3Nx1HyA1Macb4bYEi4jU6F1CL4SRrZz1v", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
-					"3DqeyZzb7PJmQ31M1qdXfP7iACr5AiEXcKeLUNmVvDoYM23JJK5ZvermxsDy8eiQKzpagc69MKRtrpzK7tRcLGgr", nil)
+					"3DqeyZzb7PJmQ31M1qdXfP7iACr5AiEXcKeLUNmVvDoYM23JJK5ZvermxsDy8eiQKzpagc69MKRtrpzK7tRcLGgr", nil, nil)
 				mockSolanaTransaction(t, mockJSONRPCClient, 52, 62,
-					"GHR9z23oUJnS2aV5HZ9zEpUpEe4qoBLFMzuBjNA3xJcQuc6JjDmuUq2VVmxqwPeFzfs8V7nfjqc1wRviEb82bRu", nil)
+					"GHR9z23oUJnS2aV5HZ9zEpUpEe4qoBLFMzuBjNA3xJcQuc6JjDmuUq2VVmxqwPeFzfs8V7nfjqc1wRviEb82bRu", nil, nil)
 
 				// set-root
 				mockSolanaTransaction(t, mockJSONRPCClient, 53, 63,
 					"oaV9FKKPDVneUANQ9hJqEuhgwfUgbxucUC4TmzpgGJhuSxBueapWc9HJ4cJQMqT2PPQX6rhTbKnXkebsaravnLo",
-					fmt.Errorf("set root error"))
+					nil, fmt.Errorf("set root error"))
 			},
 			wantErr: "unable to set root: unable to send instruction: set root error",
 		},

--- a/sdk/solana/timelock_executor.go
+++ b/sdk/solana/timelock_executor.go
@@ -89,7 +89,7 @@ func (e *TimelockExecutor) Execute(
 		predecessorOperationPDA, configPDA, signerPDA, config.ExecutorRoleAccessController, e.auth.PublicKey())
 	instruction.AccountMetaSlice = append(instruction.AccountMetaSlice, accounts...)
 
-	signature, err := sendAndConfirm(ctx, e.client, e.auth, instruction, rpc.CommitmentConfirmed)
+	signature, tx, err := sendAndConfirm(ctx, e.client, e.auth, instruction, rpc.CommitmentConfirmed)
 	if err != nil {
 		return types.TransactionResult{}, fmt.Errorf("unable to call execute operation instruction: %w", err)
 	}
@@ -97,6 +97,6 @@ func (e *TimelockExecutor) Execute(
 	return types.TransactionResult{
 		Hash:           signature,
 		ChainFamily:    chain_selectors.FamilySolana,
-		RawTransaction: instruction,
+		RawTransaction: tx,
 	}, nil
 }

--- a/sdk/solana/timelock_executor_test.go
+++ b/sdk/solana/timelock_executor_test.go
@@ -79,7 +79,8 @@ func Test_TimelockExecutor_Execute(t *testing.T) {
 			},
 			mockSetup: func(m *mocks.JSONRPCClient) {
 				mockGetAccountInfo(t, m, configPDA, config, nil)
-				mockSolanaTransaction(t, m, 20, 5, "2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6", nil)
+				mockSolanaTransaction(t, m, 20, 5,
+					"2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6", nil, nil)
 			},
 			want:      "2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6",
 			assertion: assert.NoError,
@@ -159,7 +160,9 @@ func Test_TimelockExecutor_Execute(t *testing.T) {
 			},
 			mockSetup: func(m *mocks.JSONRPCClient) {
 				mockGetAccountInfo(t, m, configPDA, config, nil)
-				mockSolanaTransaction(t, m, 20, 5, "2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6", fmt.Errorf("invalid tx"))
+				mockSolanaTransaction(t, m, 20, 5,
+					"2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6",
+					nil, fmt.Errorf("invalid tx"))
 			},
 			assertion: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.EqualError(t, err, "unable to call execute operation instruction: unable to send instruction: invalid tx")

--- a/sdk/solana/utils_test.go
+++ b/sdk/solana/utils_test.go
@@ -81,7 +81,8 @@ func mockGetBlockTime(
 }
 
 func mockSolanaTransaction(
-	t *testing.T, client *mocks.JSONRPCClient, lastBlockHeight uint64, slot uint64, signature string, mockError error,
+	t *testing.T, client *mocks.JSONRPCClient, lastBlockHeight uint64, slot uint64, signature string,
+	blockTime *solana.UnixTimeSeconds, mockError error,
 ) {
 	t.Helper()
 
@@ -141,10 +142,14 @@ func mockSolanaTransaction(
 		}`))
 		require.NoError(t, err)
 
+		if blockTime == nil {
+			blockTime = ptrTo(solana.UnixTimeSeconds(time.Now().Unix()))
+		}
+
 		*result = &rpc.GetTransactionResult{
 			Version:     1,
 			Slot:        slot,
-			BlockTime:   ptrTo(solana.UnixTimeSeconds(time.Now().Unix())),
+			BlockTime:   blockTime,
 			Transaction: &transactionEnvelope,
 			Meta:        &rpc.TransactionMeta{},
 		}


### PR DESCRIPTION
This PR is a follow up to PR #257.

It changes the transaction type returned by the Solana SDK. We now return the `rpc.GetTransactionResult` struct, which is defined as follows:

```go
type GetTransactionResult struct {
	Slot        uint64                     `json:"slot"`
	BlockTime   *solana.UnixTimeSeconds    `json:"blockTime" bin:"optional"`
	Transaction *TransactionResultEnvelope `json:"transaction" bin:"optional"`
	Meta        *TransactionMeta           `json:"meta,omitempty" bin:"optional"`
	Version     TransactionVersion         `json:"version"`
}
```