### PR TITLE
[DPA-1516]: fix(solana): update timelock converter scheduled operation with latest breaking change

### DIFF
--- a/.changeset/fluffy-terms-march.md
+++ b/.changeset/fluffy-terms-march.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix: incorporate timelock converter breaking api changes for scheduled operations

--- a/e2e/tests/solana/common.go
+++ b/e2e/tests/solana/common.go
@@ -376,6 +376,9 @@ func (s *SolanaTestSuite) getInitOperationIxs(timelockID [32]byte, op timelockut
 	s.Require().NoError(err)
 	operationPDA, err := solanasdk.FindTimelockOperationPDA(s.TimelockProgramID, timelockID, op.OperationID())
 	s.Require().NoError(err)
+
+	proposerAC := s.Roles[timelock.Proposer_Role].AccessController.PublicKey()
+
 	ixs := []solana.Instruction{}
 	initOpIx, ioErr := timelock.NewInitializeOperationInstruction(
 		timelockID,
@@ -385,6 +388,7 @@ func (s *SolanaTestSuite) getInitOperationIxs(timelockID [32]byte, op timelockut
 		op.IxsCountU32(),
 		operationPDA,
 		configPDA,
+		proposerAC,
 		authority,
 		solana.SystemProgramID,
 	).ValidateAndBuild()
@@ -399,6 +403,7 @@ func (s *SolanaTestSuite) getInitOperationIxs(timelockID [32]byte, op timelockut
 			[]timelock.InstructionData{instruction},
 			operationPDA,
 			configPDA,
+			proposerAC,
 			authority,
 			solana.SystemProgramID,
 		).ValidateAndBuild()
@@ -411,6 +416,7 @@ func (s *SolanaTestSuite) getInitOperationIxs(timelockID [32]byte, op timelockut
 		op.OperationID(),
 		operationPDA,
 		configPDA,
+		proposerAC,
 		authority,
 	).ValidateAndBuild()
 	s.Require().NoError(foErr)

--- a/e2e/tests/solana/compile-mcm-contracts.sh
+++ b/e2e/tests/solana/compile-mcm-contracts.sh
@@ -14,7 +14,7 @@ PROJECT_ROOT="$(dirname "$(realpath "$0")")/../../.."
 PROGRAM_DIR="chains/solana/contracts/target/deploy"
 DEST_DIR="${PROJECT_ROOT}/e2e/artifacts/solana"
 TEMP_DIR=$(mktemp -d)
-COMMIT_HASH="8a6f4c66925828b35d290510d5a18a5b76a40f33" # 22 Jan 2025
+COMMIT_HASH="bdbfcc588847d70817333487a9883e94c39a332e" # 29 Jan 2025
 
 # Programs to build
 PROGRAMS=("mcm" "timelock" "access-controller" "external-program-cpi-stub")

--- a/e2e/tests/solana/timelock_converter.go
+++ b/e2e/tests/solana/timelock_converter.go
@@ -119,6 +119,8 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 		timelockProposal, err := timelockProposalBuilder().SetAction(types.TimelockActionSchedule).Build()
 		s.Require().NoError(err)
 
+		proposerAC := s.Roles[timelock.Proposer_Role].AccessController.PublicKey()
+
 		// build expected output Proposal
 		wantProposal, err := mcms.NewProposalBuilder().
 			SetValidUntil(uint32(validUntil)).
@@ -135,6 +137,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 					Accounts: []*solana.AccountMeta{
 						{PublicKey: operation1PDA, IsWritable: true},
 						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
 						{PublicKey: solana.SystemProgramID},
 					},
@@ -149,6 +152,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 					Accounts: []*solana.AccountMeta{
 						{PublicKey: operation1PDA, IsWritable: true},
 						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
 						{PublicKey: solana.SystemProgramID},
 					},
@@ -163,6 +167,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 					Accounts: []*solana.AccountMeta{
 						{PublicKey: operation1PDA, IsWritable: true},
 						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
 						{PublicKey: solana.SystemProgramID},
 					},
@@ -177,6 +182,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 					Accounts: []*solana.AccountMeta{
 						{PublicKey: operation1PDA, IsWritable: true},
 						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
 					},
 				}),
@@ -190,7 +196,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 					Accounts: []*solana.AccountMeta{
 						{PublicKey: operation1PDA, IsWritable: true},
 						{PublicKey: configPDA},
-						{PublicKey: s.Roles[timelock.Proposer_Role].AccessController.PublicKey()},
+						{PublicKey: proposerAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
 					},
 				}),
@@ -204,6 +210,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 					Accounts: []*solana.AccountMeta{
 						{PublicKey: operation2PDA, IsWritable: true},
 						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
 						{PublicKey: solana.SystemProgramID},
 					},
@@ -218,6 +225,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 					Accounts: []*solana.AccountMeta{
 						{PublicKey: operation2PDA, IsWritable: true},
 						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
 						{PublicKey: solana.SystemProgramID},
 					},
@@ -232,6 +240,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 					Accounts: []*solana.AccountMeta{
 						{PublicKey: operation2PDA, IsWritable: true},
 						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
 					},
 				}),
@@ -245,7 +254,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 					Accounts: []*solana.AccountMeta{
 						{PublicKey: operation2PDA, IsWritable: true},
 						{PublicKey: configPDA},
-						{PublicKey: s.Roles[timelock.Proposer_Role].AccessController.PublicKey()},
+						{PublicKey: proposerAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
 					},
 				}),

--- a/e2e/tests/solana/timelock_execution.go
+++ b/e2e/tests/solana/timelock_execution.go
@@ -184,6 +184,9 @@ func (s *SolanaTestSuite) scheduleMintTx(
 	s.Require().NoError(err)
 	configPDA, err := mcmsSolana.FindTimelockConfigPDA(s.TimelockProgramID, testTimelockExecuteID)
 	s.Require().NoError(err)
+
+	proposerAC := s.Roles[timelock.Proposer_Role].AccessController.PublicKey()
+
 	// Preload and Init Operation
 	ixs := []solana.Instruction{}
 	initOpIx, err := timelock.NewInitializeOperationInstruction(
@@ -194,6 +197,7 @@ func (s *SolanaTestSuite) scheduleMintTx(
 		uint32(len(opInstructions)),
 		operationPDA,
 		configPDA,
+		proposerAC,
 		auth.PublicKey(),
 		solana.SystemProgramID,
 	).ValidateAndBuild()
@@ -208,6 +212,7 @@ func (s *SolanaTestSuite) scheduleMintTx(
 			[]timelock.InstructionData{ix}, // this should be a slice of instruction within 1232 bytes
 			operationPDA,
 			configPDA,
+			proposerAC,
 			auth.PublicKey(),
 			solana.SystemProgramID,
 		).ValidateAndBuild()
@@ -220,6 +225,7 @@ func (s *SolanaTestSuite) scheduleMintTx(
 		operationID,
 		operationPDA,
 		configPDA,
+		proposerAC,
 		auth.PublicKey(),
 	).ValidateAndBuild()
 	s.Require().NoError(err)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/karalabe/hid v1.0.1-0.20240306101548-573246063e52
 	github.com/smartcontractkit/chain-selectors v1.0.36
-	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250122205454-8a6f4c669258
+	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250128193522-bdbfcc588847
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,8 @@ github.com/smartcontractkit/chain-selectors v1.0.36 h1:KSpO8I+JOiuyN4FuXsV471sPo
 github.com/smartcontractkit/chain-selectors v1.0.36/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250122205454-8a6f4c669258 h1:Sv4ASwQvVSEOLJ+hnVwCXe3VrbPdXUlm4CafF2YwYbw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250122205454-8a6f4c669258/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250128193522-bdbfcc588847 h1:dw2d6UyvnCGFym2cRYsJfGdHNPa/iGKkrC+ppB3mKWo=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250128193522-bdbfcc588847/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.0 h1:GZ9MhHt5QHXSaK/sAZvKDxkEqF4fPiFHWHEPqs/2C2o=
 github.com/smartcontractkit/chainlink-common v0.4.0/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7 h1:E7k5Sym9WnMOc4X40lLnQb6BMosxi8DfUBU9pBJjHOQ=

--- a/sdk/solana/timelock_converter.go
+++ b/sdk/solana/timelock_converter.go
@@ -253,7 +253,9 @@ func scheduleBatchInstructions(
 
 	// initialize
 	instruction, err := bindings.NewInitializeOperationInstruction(pdaSeed, operationID, predecessor, salt,
-		numInstructions, operationPDA, configPDA, mcmSignerPDA, solana.SystemProgramID).ValidateAndBuild()
+		numInstructions, operationPDA, configPDA,
+		proposerAccessController,
+		mcmSignerPDA, solana.SystemProgramID).ValidateAndBuild()
 	if err != nil {
 		return []solana.Instruction{}, fmt.Errorf("unable to build InitializeOperation instruction: %w", err)
 	}
@@ -263,7 +265,9 @@ func scheduleBatchInstructions(
 	for i := range instructionsData {
 		// FIXME: InstructionData should have slices of data no bigger than 1232 bytes
 		instruction, err = bindings.NewAppendInstructionsInstruction(pdaSeed, operationID,
-			[]bindings.InstructionData{instructionsData[i]}, operationPDA, configPDA, mcmSignerPDA,
+			[]bindings.InstructionData{instructionsData[i]}, operationPDA, configPDA,
+			proposerAccessController,
+			mcmSignerPDA,
 			solana.SystemProgramID).ValidateAndBuild()
 		if err != nil {
 			return []solana.Instruction{}, fmt.Errorf("unable to build AppendInstruction instruction: %w", err)
@@ -273,7 +277,7 @@ func scheduleBatchInstructions(
 
 	// finalize
 	instruction, err = bindings.NewFinalizeOperationInstruction(pdaSeed, operationID,
-		operationPDA, configPDA, mcmSignerPDA).ValidateAndBuild()
+		operationPDA, configPDA, proposerAccessController, mcmSignerPDA).ValidateAndBuild()
 	if err != nil {
 		return []solana.Instruction{}, fmt.Errorf("unable to build FinializeOperation instruction: %w", err)
 	}

--- a/sdk/solana/timelock_converter_test.go
+++ b/sdk/solana/timelock_converter_test.go
@@ -77,6 +77,9 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 		}
 	}
 
+	proposerAC, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+
 	tests := []struct {
 		name            string
 		batchOp         types.BatchOperation
@@ -110,6 +113,7 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
 							{PublicKey: solana.MPK("3x12f1G4bt9j7rsBfLE7rZQ5hXoHuHdjtUr2UKW8gjQp"), IsWritable: true},
 							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
+							{PublicKey: solana.MPK(proposerAC.PublicKey().String())},
 							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
 							{PublicKey: solana.MPK("11111111111111111111111111111111")},
 						}}),
@@ -128,6 +132,7 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
 							{PublicKey: solana.MPK("3x12f1G4bt9j7rsBfLE7rZQ5hXoHuHdjtUr2UKW8gjQp"), IsWritable: true},
 							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
+							{PublicKey: solana.MPK(proposerAC.PublicKey().String())},
 							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
 							{PublicKey: solana.MPK("11111111111111111111111111111111")},
 						}}),
@@ -146,6 +151,7 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
 							{PublicKey: solana.MPK("3x12f1G4bt9j7rsBfLE7rZQ5hXoHuHdjtUr2UKW8gjQp"), IsWritable: true},
 							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
+							{PublicKey: solana.MPK(proposerAC.PublicKey().String())},
 							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
 							{PublicKey: solana.MPK("11111111111111111111111111111111")},
 						}}),
@@ -164,6 +170,7 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
 							{PublicKey: solana.MPK("3x12f1G4bt9j7rsBfLE7rZQ5hXoHuHdjtUr2UKW8gjQp"), IsWritable: true},
 							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
+							{PublicKey: solana.MPK(proposerAC.PublicKey().String())},
 							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
 						}}),
 						OperationMetadata: types.OperationMetadata{
@@ -181,7 +188,7 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
 							{PublicKey: solana.MPK("3x12f1G4bt9j7rsBfLE7rZQ5hXoHuHdjtUr2UKW8gjQp"), IsWritable: true},
 							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
-							{PublicKey: solana.MPK("11111111111111111111111111111111")},
+							{PublicKey: solana.MPK(proposerAC.PublicKey().String())},
 							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
 						}}),
 						OperationMetadata: types.OperationMetadata{
@@ -194,7 +201,9 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 			wantPredecessor: common.HexToHash("0xeccdce20b98da2001e6ae8c81c34a3aae1ce4aa757897906f15a2f257132dc7f"),
 			setup: func(t *testing.T, mockJSONRPCClient *mocks.JSONRPCClient) {
 				t.Helper()
-				config := &bindings.Config{}
+				config := &bindings.Config{
+					ProposerRoleAccessController: proposerAC.PublicKey(),
+				}
 				mockGetAccountInfo(t, mockJSONRPCClient, configPDA, config, nil)
 			},
 		},

--- a/sdk/solana/timelock_inspector_test.go
+++ b/sdk/solana/timelock_inspector_test.go
@@ -595,15 +595,11 @@ func newTestTimelockInspector(t *testing.T) (*TimelockInspector, *mocks.JSONRPCC
 func createTimelockOperation(t *testing.T, timestamp uint64) *timelock.Operation {
 	t.Helper()
 
-	pk, err := solana.NewRandomPrivateKey()
-	require.NoError(t, err)
-
 	operation := &timelock.Operation{
 		Timestamp:         timestamp,
 		Id:                [32]uint8{},
 		Predecessor:       [32]uint8{},
 		Salt:              [32]uint8{},
-		Authority:         pk.PublicKey(),
 		IsFinalized:       false,
 		TotalInstructions: 5,
 		Instructions:      nil,


### PR DESCRIPTION
- pull in the latest `github.com/smartcontractkit/chainlink-ccip/chains/solana` with the [breaking api change](https://github.com/smartcontractkit/chainlink-ccip/pull/474/files#)
- update scheduled operations to include proposer access controller key
- update breaking e2e tests
- update other API changes

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1516