### PR TITLE
[DPA-1417]: fix(solana): fix simulator side effect bug

### DIFF
--- a/.changeset/real-kangaroos-sit.md
+++ b/.changeset/real-kangaroos-sit.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix(solana): fix simulator side effect bug

--- a/sdk/solana/executor.go
+++ b/sdk/solana/executor.go
@@ -41,9 +41,9 @@ func NewExecutor(encoder *Encoder, client *rpc.Client, auth solana.PrivateKey) *
 	}
 }
 
-func (e *Executor) withSendAndConfirmFn(fn SendAndConfirmFn) *Executor {
+func (e Executor) withSendAndConfirmFn(fn SendAndConfirmFn) *Executor {
 	e.sendAndConfirm = fn
-	return e
+	return &e
 }
 
 // ExecuteOperation executes an operation on the MCMS program on the Solana chain

--- a/sdk/solana/utils_test.go
+++ b/sdk/solana/utils_test.go
@@ -176,7 +176,7 @@ func mockSolanaSimulateTransaction(
 		}}
 
 		return mockBlockHashRPCError
-	})
+	}).Once()
 	if mockBlockHashRPCError != nil {
 		return
 	}
@@ -195,7 +195,7 @@ func mockSolanaSimulateTransaction(
 		}
 
 		return nil
-	})
+	}).Once()
 }
 
 var sendTransactionParams = func(t *testing.T) any {


### PR DESCRIPTION
If we create a simulator with an executor, on construction of that simulator, the sendAndConfirm function is overwritten with a no-op version.

```
executor := mcmsSolana.NewExecutor(s.SolanaClient, auth, encoder)
simulator := mcmsSolana.NewSimulator(executor)
simulator.SimulateSetRoot(....)

executor.SetRoot(....) ????? This will not perform any transaction
```

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1417