### PR TITLE
feat: construct queued proposals with predecessors

### DIFF
--- a/.changeset/shaggy-pianos-remember.md
+++ b/.changeset/shaggy-pianos-remember.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Update constructors to add predecessor proposals for queuing

--- a/docs/usage/building-proposals.md
+++ b/docs/usage/building-proposals.md
@@ -22,6 +22,7 @@ package main
 import (
   "log"
   "os"
+  "io"
 
   "github.com/smartcontractkit/mcms"
 )
@@ -35,7 +36,7 @@ func main() {
   defer file.Close()
 
   // Create the proposal from the JSON data
-  proposal, err := mcms.NewProposal(file)
+  proposal, err := mcms.NewProposal(file, []io.Reader{})
   if err != nil {
     log.Fatalf("Error creating proposal: %v", err)
   }
@@ -45,6 +46,46 @@ func main() {
 ```
 
 For the JSON structure of the proposal please check the [MCMS Proposal Format Doc.](/key-concepts/mcm-proposal.md)
+
+### Build Proposal Given Staged but Non-Executed Predecessor Proposals
+
+In scenarios where a proposal is generated with the assumption that multiple proposals are executed beforehand, you can enable proposals to be signed in parallel with a pre-determined execution order. This can be achieved by passing a list of files as the second argument in the Proposal constructor, as shown below:
+
+```go
+package main
+
+import (
+  "log"
+  "os"
+  "io"
+
+  "github.com/smartcontractkit/mcms"
+)
+
+func main() {
+  // Open the JSON file for the new proposal
+  file, err := os.Open("proposal.json")
+  if err != nil {
+    log.Fatalf("Error opening file: %v", err)
+  }
+  defer file.Close()
+
+  // Open the JSON file for the predecessor proposal
+  preFile, err := os.Open("pre-proposal.json")
+  if err != nil {
+    log.Fatalf("Error opening predecessor file: %v", err)
+  }
+  defer preFile.Close()
+
+  // Create the proposal from the JSON data
+  proposal, err := mcms.NewProposal(file, []io.Reader{preFile})
+  if err != nil {
+    log.Fatalf("Error creating proposal: %v", err)
+  }
+
+  log.Printf("Successfully created proposal: %+v", proposal)
+}
+```
 
 ## 2. Programmatic Build
 

--- a/e2e/ledger/ledger_test.go
+++ b/e2e/ledger/ledger_test.go
@@ -5,6 +5,7 @@ package ledger
 
 import (
 	"context"
+	"io"
 	"log"
 	"math/big"
 	"os"
@@ -203,7 +204,7 @@ func (s *ManualLedgerSigningTestSuite) TestManualLedgerSigning() {
 	}(file)
 	s.Require().NoError(err)
 
-	proposal, err := mcms.NewProposal(file)
+	proposal, err := mcms.NewProposal(file, []io.Reader{})
 	s.Require().NoError(err, "Failed to parse proposal")
 	s.T().Log("Proposal loaded successfully.")
 	proposal.ChainMetadata[s.chainSelectorEVM] = types.ChainMetadata{

--- a/e2e/tests/evm/signing.go
+++ b/e2e/tests/evm/signing.go
@@ -49,7 +49,7 @@ func (s *SigningTestSuite) TestReadAndSign() {
 		}
 	}(file)
 	s.Require().NoError(err)
-	proposal, err := mcms.NewProposal(file)
+	proposal, err := mcms.NewProposal(file, []io.Reader{})
 	s.Require().NoError(err)
 	s.Require().NotNil(proposal)
 	inspectors := map[mcmtypes.ChainSelector]sdk.Inspector{
@@ -81,7 +81,7 @@ func (s *SigningTestSuite) TestReadAndSign() {
 	_, err = tmpFile.Seek(0, io.SeekStart)
 	s.Require().NoError(err, "Failed to reset file pointer to the start")
 
-	writtenProposal, err := mcms.NewProposal(tmpFile)
+	writtenProposal, err := mcms.NewProposal(tmpFile, []io.Reader{})
 	s.Require().NoError(err)
 
 	// Validate the appended signature

--- a/proposal.go
+++ b/proposal.go
@@ -28,7 +28,7 @@ type ProposalInterface interface {
 	AppendSignature(signature types.Signature)
 	TransactionCounts() map[types.ChainSelector]uint64
 	ChainMetadatas() map[types.ChainSelector]types.ChainMetadata
-	SetChainMetadata(chainSelector types.ChainSelector, metadata types.ChainMetadata)
+	setChainMetadata(chainSelector types.ChainSelector, metadata types.ChainMetadata)
 	Validate() error
 }
 
@@ -87,7 +87,7 @@ func (p *BaseProposal) ChainMetadatas() map[types.ChainSelector]types.ChainMetad
 }
 
 // SetChainMetadata sets the chain metadata for a given chain selector.
-func (p *BaseProposal) SetChainMetadata(chainSelector types.ChainSelector, metadata types.ChainMetadata) {
+func (p *BaseProposal) setChainMetadata(chainSelector types.ChainSelector, metadata types.ChainMetadata) {
 	p.ChainMetadata[chainSelector] = metadata
 }
 

--- a/proposal.go
+++ b/proposal.go
@@ -83,7 +83,11 @@ func (p *BaseProposal) AppendSignature(signature types.Signature) {
 
 // ChainMetadata returns the chain metadata for the proposal.
 func (p *BaseProposal) ChainMetadatas() map[types.ChainSelector]types.ChainMetadata {
-	return p.ChainMetadata
+	copy := make(map[types.ChainSelector]types.ChainMetadata, len(p.ChainMetadata))
+	for k, v := range p.ChainMetadata {
+		copy[k] = v
+	}
+	return copy
 }
 
 // SetChainMetadata sets the chain metadata for a given chain selector.

--- a/proposal.go
+++ b/proposal.go
@@ -83,11 +83,12 @@ func (p *BaseProposal) AppendSignature(signature types.Signature) {
 
 // ChainMetadata returns the chain metadata for the proposal.
 func (p *BaseProposal) ChainMetadatas() map[types.ChainSelector]types.ChainMetadata {
-	copy := make(map[types.ChainSelector]types.ChainMetadata, len(p.ChainMetadata))
+	cmCopy := make(map[types.ChainSelector]types.ChainMetadata, len(p.ChainMetadata))
 	for k, v := range p.ChainMetadata {
-		copy[k] = v
+		cmCopy[k] = v
 	}
-	return copy
+
+	return cmCopy
 }
 
 // SetChainMetadata sets the chain metadata for a given chain selector.

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -113,7 +113,7 @@ func Test_NewProposal(t *testing.T) {
 
 			give := strings.NewReader(tt.give)
 
-			fileProposal, err := NewProposal(give, []io.Reader{}) // TOOD: predecessors
+			fileProposal, err := NewProposal(give, []io.Reader{}) // TODO: predecessors
 
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -113,7 +113,7 @@ func Test_NewProposal(t *testing.T) {
 
 			give := strings.NewReader(tt.give)
 
-			fileProposal, err := NewProposal(give)
+			fileProposal, err := NewProposal(give, []io.Reader{}) // TOOD: predecessors
 
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -188,7 +188,7 @@ func Test_NewProposal(t *testing.T) {
 			name:             "failure: could not unmarshal JSON",
 			give:             `invalid`,
 			givePredecessors: []string{},
-			wantErr:          "invalid character 'i' looking for beginning of value",
+			wantErr:          "failed to decode and validate target proposal: invalid character 'i' looking for beginning of value",
 		},
 		{
 			name: "failure: invalid proposal",
@@ -200,7 +200,7 @@ func Test_NewProposal(t *testing.T) {
 				"operations": []
 			}`,
 			givePredecessors: []string{},
-			wantErr:          "Key: 'Proposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag\nKey: 'Proposal.Operations' Error:Field validation for 'Operations' failed on the 'min' tag",
+			wantErr:          "failed to decode and validate target proposal: Key: 'Proposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag\nKey: 'Proposal.Operations' Error:Field validation for 'Operations' failed on the 'min' tag",
 		},
 	}
 

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -84,7 +84,7 @@ func Test_BaseProposal_SetChainMetadata(t *testing.T) {
 	assert.False(t, ok)
 	assert.Empty(t, md)
 
-	proposal.SetChainMetadata(chaintest.Chain1Selector, types.ChainMetadata{
+	proposal.setChainMetadata(chaintest.Chain1Selector, types.ChainMetadata{
 		StartingOpCount: 0,
 		MCMAddress:      "",
 	})
@@ -188,7 +188,7 @@ func Test_NewProposal(t *testing.T) {
 			name:             "failure: could not unmarshal JSON",
 			give:             `invalid`,
 			givePredecessors: []string{},
-			wantErr:          "failed to decode and validate target proposal: invalid character 'i' looking for beginning of value",
+			wantErr:          "failed to decode and validate target proposal: failed to decode proposal: invalid character 'i' looking for beginning of value",
 		},
 		{
 			name: "failure: invalid proposal",
@@ -200,7 +200,7 @@ func Test_NewProposal(t *testing.T) {
 				"operations": []
 			}`,
 			givePredecessors: []string{},
-			wantErr:          "failed to decode and validate target proposal: Key: 'Proposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag\nKey: 'Proposal.Operations' Error:Field validation for 'Operations' failed on the 'min' tag",
+			wantErr:          "failed to decode and validate target proposal: failed to validate proposal: Key: 'Proposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag\nKey: 'Proposal.Operations' Error:Field validation for 'Operations' failed on the 'min' tag",
 		},
 	}
 

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -27,7 +27,10 @@ var (
 		"kind": "Proposal",
 		"validUntil": 2004259681,
 		"chainMetadata": {
-			"3379446385462418246": {}
+			"3379446385462418246": {
+				"startingOpCount": 0,
+				"mcmAddress": ""
+			}
 		},
 		"operations": [
 			{
@@ -111,6 +114,62 @@ func Test_NewProposal(t *testing.T) {
 					ValidUntil: 2004259681,
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
 						chaintest.Chain1Selector: {},
+					},
+				},
+				Operations: []types.Operation{
+					{
+						ChainSelector: chaintest.Chain1Selector,
+						Transaction: types.Transaction{
+							To:               "0xsomeaddress",
+							Data:             []byte{0x12, 0x33},              // Representing "0x123" as bytes
+							AdditionalFields: json.RawMessage(`{"value": 0}`), // JSON-encoded `{"value": 0}`
+						},
+					},
+				},
+			},
+		},
+		{
+			name:             "success: initializes a proposal with 1 predecessor proposals",
+			give:             ValidProposal,
+			givePredecessors: []string{ValidProposal},
+			want: Proposal{
+				BaseProposal: BaseProposal{
+					Version:    "v1",
+					Kind:       types.KindProposal,
+					ValidUntil: 2004259681,
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						chaintest.Chain1Selector: {
+							StartingOpCount: 1,
+							MCMAddress:      "",
+						},
+					},
+				},
+				Operations: []types.Operation{
+					{
+						ChainSelector: chaintest.Chain1Selector,
+						Transaction: types.Transaction{
+							To:               "0xsomeaddress",
+							Data:             []byte{0x12, 0x33},              // Representing "0x123" as bytes
+							AdditionalFields: json.RawMessage(`{"value": 0}`), // JSON-encoded `{"value": 0}`
+						},
+					},
+				},
+			},
+		},
+		{
+			name:             "success: initializes a proposal with 2 predecessor proposals",
+			give:             ValidProposal,
+			givePredecessors: []string{ValidProposal, ValidProposal},
+			want: Proposal{
+				BaseProposal: BaseProposal{
+					Version:    "v1",
+					Kind:       types.KindProposal,
+					ValidUntil: 2004259681,
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						chaintest.Chain1Selector: {
+							StartingOpCount: 2,
+							MCMAddress:      "",
+						},
 					},
 				},
 				Operations: []types.Operation{

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -241,7 +241,7 @@ func Test_NewTimelockProposal(t *testing.T) {
 			name:             "failure: could not unmarshal JSON",
 			give:             `invalid`,
 			givePredecessors: []string{},
-			wantErr:          "failed to decode and validate target proposal: invalid character 'i' looking for beginning of value",
+			wantErr:          "failed to decode and validate target proposal: failed to decode proposal: invalid character 'i' looking for beginning of value",
 		},
 		{
 			name: "failure: invalid proposal",
@@ -271,7 +271,7 @@ func Test_NewTimelockProposal(t *testing.T) {
 				]
 			}`,
 			givePredecessors: []string{},
-			wantErr:          "failed to decode and validate target proposal: Key: 'TimelockProposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag",
+			wantErr:          "failed to decode and validate target proposal: failed to validate proposal: Key: 'TimelockProposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag",
 		},
 	}
 

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -241,7 +241,7 @@ func Test_NewTimelockProposal(t *testing.T) {
 			name:             "failure: could not unmarshal JSON",
 			give:             `invalid`,
 			givePredecessors: []string{},
-			wantErr:          "invalid character 'i' looking for beginning of value",
+			wantErr:          "failed to decode and validate target proposal: invalid character 'i' looking for beginning of value",
 		},
 		{
 			name: "failure: invalid proposal",
@@ -271,7 +271,7 @@ func Test_NewTimelockProposal(t *testing.T) {
 				]
 			}`,
 			givePredecessors: []string{},
-			wantErr:          "Key: 'TimelockProposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag",
+			wantErr:          "failed to decode and validate target proposal: Key: 'TimelockProposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag",
 		},
 	}
 

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -202,7 +202,7 @@ func Test_NewTimelockProposal(t *testing.T) {
 
 			give := strings.NewReader(tt.give)
 
-			got, err := NewTimelockProposal(give)
+			got, err := NewTimelockProposal(give, []io.Reader{}) // TODO: predecessors
 
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -54,14 +54,16 @@ func Test_NewTimelockProposal(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		give    string
-		want    TimelockProposal
-		wantErr string
+		name             string
+		give             string
+		givePredecessors []string
+		want             TimelockProposal
+		wantErr          string
 	}{
 		{
-			name: "success: initializes a proposal from an io.Reader",
-			give: ValidTimelockProposal,
+			name:             "success: initializes a proposal from an io.Reader",
+			give:             ValidTimelockProposal,
+			givePredecessors: []string{},
 			want: TimelockProposal{
 				BaseProposal: BaseProposal{
 					Version:     "v1",
@@ -71,6 +73,80 @@ func Test_NewTimelockProposal(t *testing.T) {
 					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
 						chaintest.Chain2Selector: {
 							StartingOpCount: 0,
+							MCMAddress:      "0x0000000000000000000000000000000000000000",
+						},
+					},
+					OverridePreviousRoot: false,
+				},
+				Action: types.TimelockActionSchedule,
+				Delay:  types.MustParseDuration("1h"),
+				TimelockAddresses: map[types.ChainSelector]string{
+					chaintest.Chain2Selector: "0x01",
+				},
+				Operations: []types.BatchOperation{
+					{
+						ChainSelector: chaintest.Chain2Selector,
+						Transactions: []types.Transaction{
+							{
+								To:               "0x0000000000000000000000000000000000000000",
+								AdditionalFields: []byte(`{"value": 0}`),
+								Data:             []byte("data"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:             "success: initializes a proposal with 1 predecessor from an io.Reader",
+			give:             ValidTimelockProposal,
+			givePredecessors: []string{ValidTimelockProposal},
+			want: TimelockProposal{
+				BaseProposal: BaseProposal{
+					Version:     "v1",
+					Kind:        types.KindTimelockProposal,
+					ValidUntil:  2004259681,
+					Description: "Test proposal",
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						chaintest.Chain2Selector: {
+							StartingOpCount: 1,
+							MCMAddress:      "0x0000000000000000000000000000000000000000",
+						},
+					},
+					OverridePreviousRoot: false,
+				},
+				Action: types.TimelockActionSchedule,
+				Delay:  types.MustParseDuration("1h"),
+				TimelockAddresses: map[types.ChainSelector]string{
+					chaintest.Chain2Selector: "0x01",
+				},
+				Operations: []types.BatchOperation{
+					{
+						ChainSelector: chaintest.Chain2Selector,
+						Transactions: []types.Transaction{
+							{
+								To:               "0x0000000000000000000000000000000000000000",
+								AdditionalFields: []byte(`{"value": 0}`),
+								Data:             []byte("data"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:             "success: initializes a proposal with 2 predecessors from an io.Reader",
+			give:             ValidTimelockProposal,
+			givePredecessors: []string{ValidTimelockProposal, ValidTimelockProposal},
+			want: TimelockProposal{
+				BaseProposal: BaseProposal{
+					Version:     "v1",
+					Kind:        types.KindTimelockProposal,
+					ValidUntil:  2004259681,
+					Description: "Test proposal",
+					ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+						chaintest.Chain2Selector: {
+							StartingOpCount: 2,
 							MCMAddress:      "0x0000000000000000000000000000000000000000",
 						},
 					},
@@ -127,6 +203,7 @@ func Test_NewTimelockProposal(t *testing.T) {
 					}
 				]
 			}`,
+			givePredecessors: []string{},
 			want: TimelockProposal{
 				BaseProposal: BaseProposal{
 					Version:     "v1",
@@ -161,9 +238,10 @@ func Test_NewTimelockProposal(t *testing.T) {
 			},
 		},
 		{
-			name:    "failure: could not unmarshal JSON",
-			give:    `invalid`,
-			wantErr: "invalid character 'i' looking for beginning of value",
+			name:             "failure: could not unmarshal JSON",
+			give:             `invalid`,
+			givePredecessors: []string{},
+			wantErr:          "invalid character 'i' looking for beginning of value",
 		},
 		{
 			name: "failure: invalid proposal",
@@ -192,7 +270,8 @@ func Test_NewTimelockProposal(t *testing.T) {
 					}
 				]
 			}`,
-			wantErr: "Key: 'TimelockProposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag",
+			givePredecessors: []string{},
+			wantErr:          "Key: 'TimelockProposal.BaseProposal.ChainMetadata' Error:Field validation for 'ChainMetadata' failed on the 'min' tag",
 		},
 	}
 
@@ -201,8 +280,12 @@ func Test_NewTimelockProposal(t *testing.T) {
 			t.Parallel()
 
 			give := strings.NewReader(tt.give)
+			givePredecessors := []io.Reader{}
+			for _, p := range tt.givePredecessors {
+				givePredecessors = append(givePredecessors, strings.NewReader(p))
+			}
 
-			got, err := NewTimelockProposal(give, []io.Reader{}) // TODO: predecessors
+			got, err := NewTimelockProposal(give, givePredecessors)
 
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)

--- a/utils.go
+++ b/utils.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+
 	"github.com/smartcontractkit/mcms/types"
 )
 

--- a/utils.go
+++ b/utils.go
@@ -42,12 +42,12 @@ func decodeAndValidateProposal[T ProposalInterface](reader io.Reader) (T, error)
 	// Decode the proposal
 	var proposal T
 	if err := json.NewDecoder(reader).Decode(&proposal); err != nil {
-		return proposal, err
+		return proposal, fmt.Errorf("failed to decode proposal: %w", err)
 	}
 
 	// Validate the proposal
 	if err := proposal.Validate(); err != nil {
-		return proposal, err
+		return proposal, fmt.Errorf("failed to validate proposal: %w", err)
 	}
 
 	return proposal, nil

--- a/utils.go
+++ b/utils.go
@@ -1,8 +1,12 @@
 package mcms
 
 import (
+	"encoding/json"
+	"io"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/smartcontractkit/mcms/types"
 )
 
 // Applies the EIP191 prefix to the payload and hashes it.
@@ -13,4 +17,67 @@ func toEthSignedMessageHash(payload []byte) common.Hash {
 
 	// Hash the prefixed message
 	return crypto.Keccak256Hash(data)
+}
+
+func generateQueuedProposalStartingOpCounts[T ProposalInterface](predecessorProposals []T) map[types.ChainSelector]uint64 {
+	// Set the transaction counts for each chain selector
+	startingOpCounts := make(map[types.ChainSelector]uint64)
+	for _, pred := range predecessorProposals {
+		chainMetadata := pred.ChainMetadatas()
+		for chainSelector, count := range pred.TransactionCounts() {
+			if _, ok := startingOpCounts[chainSelector]; !ok {
+				startingOpCounts[chainSelector] = chainMetadata[chainSelector].StartingOpCount
+			}
+
+			startingOpCounts[chainSelector] += count
+		}
+	}
+
+	return startingOpCounts
+}
+
+func decodeAndValidateProposal[T ProposalInterface](reader io.Reader) (T, error) {
+	// Decode the proposal
+	var proposal T
+	if err := json.NewDecoder(reader).Decode(&proposal); err != nil {
+		return proposal, err
+	}
+
+	// Validate the proposal
+	if err := proposal.Validate(); err != nil {
+		return proposal, err
+	}
+
+	return proposal, nil
+}
+
+func newProposal[T ProposalInterface](r io.Reader, predecessors []io.Reader) (T, error) {
+	p, err := decodeAndValidateProposal[T](r)
+	if err != nil {
+		return p, err
+	}
+
+	predecessorProposals := make([]T, len(predecessors))
+	for i, pred := range predecessors {
+		if err := json.NewDecoder(pred).Decode(&predecessorProposals[i]); err != nil {
+			return p, err
+		}
+
+		if err := predecessorProposals[i].Validate(); err != nil {
+			return p, err
+		}
+	}
+
+	startingOpCounts := generateQueuedProposalStartingOpCounts(predecessorProposals)
+
+	// Set the starting op count for each chain selector in the new proposal
+	for chainSelector, chainMetadata := range p.ChainMetadatas() {
+		if count, ok := startingOpCounts[chainSelector]; ok {
+			chainMetadata.StartingOpCount = count
+		}
+
+		p.SetChainMetadata(chainSelector, chainMetadata)
+	}
+
+	return p, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -77,7 +77,7 @@ func newProposal[T ProposalInterface](r io.Reader, predecessors []io.Reader) (T,
 			chainMetadata.StartingOpCount = count
 		}
 
-		p.SetChainMetadata(chainSelector, chainMetadata)
+		p.setChainMetadata(chainSelector, chainMetadata)
 	}
 
 	return p, nil


### PR DESCRIPTION

Enables users to construct proposals given a list of preceding, non-executed proposals, such that proposal signing can happen in parallel assuming a pre-determined sequential execution order. The key changes are as follows:

### Enhancements to Proposal Creation:

* Updated the `NewProposal` and `NewTimelockProposal` functions to accept a list of predecessor proposals, allowing for the configuration of operation counts based on the execution order of proposals. (`proposal.go`, `timelock_proposal.go`) [[1]](diffhunk://#diff-76c5df6d4d3acdc6b2bc63b2377214b642e59a655957a9e65884ed21f204a27bL90-R116) [[2]](diffhunk://#diff-22aa9f90e7ed0f30eb381e769a6ce492d3472c4e8029e134f0074e1913ce482fR54-R63)

### Documentation Updates:

* Added a new section in `docs/usage/building-proposals.md` to explain how to build proposals with staged but non-executed predecessor proposals.

### Code Refactoring:

* Modified various test files to accommodate the new `NewProposal` and `NewTimelockProposal` function signatures that include predecessor proposals. (`ledger_test.go`, `signing.go`, `proposal_test.go`, `timelock_proposal_test.go`) [[1]](diffhunk://#diff-046f7b9890699bc5c0782f4c739ef15b5f8be4727b0c2f7cf932fa171d9f514dL206-R207) [[2]](diffhunk://#diff-0c8a658097684777bc5992740e4c927a02a88830e4a6783742f7a3de02b6bfa3L52-R52) [[3]](diffhunk://#diff-f54ef2790620db06a34dcf62d0565c5536ddeb0b22274fafc6d0cff158c9b789R131-R190) [[4]](diffhunk://#diff-b80686a8969c14a89af64e7ed45e5a1e0dc025880256405d9e48eac6e33722b9R100-R173)

### New Methods:

* Added `TransactionCounts`, `ChainMetadatas`, and `SetChainMetadata` methods to the `ProposalInterface` to manage chain metadata more effectively. (`proposal.go`, `timelock_proposal.go`) [[1]](diffhunk://#diff-76c5df6d4d3acdc6b2bc63b2377214b642e59a655957a9e65884ed21f204a27bR84-R93) [[2]](diffhunk://#diff-22aa9f90e7ed0f30eb381e769a6ce492d3472c4e8029e134f0074e1913ce482fR54-R63)

### Minor Changes:

* Updated the `.changeset/shaggy-pianos-remember.md` file to reflect the minor version update for the `@smartcontractkit/mcms` package.