### PR TITLE
fix: update timelock conversion logic to manage predecessors per chain instead of globally

### DIFF
--- a/.changeset/swift-turtles-notice.md
+++ b/.changeset/swift-turtles-notice.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Fix bug with multichain timelock execution with predecessors calculation

--- a/e2e/tests/solana/timelock_converter.go
+++ b/e2e/tests/solana/timelock_converter.go
@@ -272,7 +272,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 		s.Require().NoError(err)
 
 		// --- assert ---
-		s.Require().Equal([]common.Hash{mcms.ZERO_HASH, operation1ID, operation2ID}, gotPredecessors)
+		s.Require().Equal([]common.Hash{mcms.ZERO_HASH, operation1ID}, gotPredecessors)
 		s.Require().Empty(cmp.Diff(toJSONString(s.T(), wantProposal), toJSONString(s.T(), &gotProposal)))
 
 		// TODO(gustavogama-cll): remove this; should refactor and use as base of a "full workflow" e2e test
@@ -328,7 +328,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 		s.Require().NoError(err)
 
 		// --- assert ---
-		s.Require().Equal([]common.Hash{mcms.ZERO_HASH, operation1ID, operation2ID}, gotPredecessors)
+		s.Require().Equal([]common.Hash{mcms.ZERO_HASH, operation1ID}, gotPredecessors)
 		s.Require().Empty(cmp.Diff(toJSONString(s.T(), wantProposal), toJSONString(s.T(), &gotProposal)))
 	})
 
@@ -486,7 +486,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 		s.Require().NoError(err)
 
 		// --- assert ---
-		s.Require().Equal([]common.Hash{mcms.ZERO_HASH, operation1ID, operation2ID}, gotPredecessors)
+		s.Require().Equal([]common.Hash{mcms.ZERO_HASH, operation1ID}, gotPredecessors)
 		s.Require().Empty(cmp.Diff(toJSONString(s.T(), wantProposal), toJSONString(s.T(), &gotProposal)))
 	})
 }

--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,16 @@ import (
 	"github.com/smartcontractkit/mcms/types"
 )
 
+// OperationNotReadyError is returned when an operation is not yet ready.
+type OperationNotReadyError struct {
+	GlobalIndex int
+}
+
+// Error implements the error interface.
+func (e *OperationNotReadyError) Error() string {
+	return fmt.Sprintf("operation %d is not ready", e.GlobalIndex)
+}
+
 // InvalidProposalKindError is returned when an invalid proposal kind is provided.
 type InvalidProposalKindError struct {
 	ProvidedKind types.ProposalKind

--- a/errors.go
+++ b/errors.go
@@ -11,12 +11,12 @@ import (
 
 // OperationNotReadyError is returned when an operation is not yet ready.
 type OperationNotReadyError struct {
-	GlobalIndex int
+	OpIndex int
 }
 
 // Error implements the error interface.
 func (e *OperationNotReadyError) Error() string {
-	return fmt.Sprintf("operation %d is not ready", e.GlobalIndex)
+	return fmt.Sprintf("operation %d is not ready", e.OpIndex)
 }
 
 // InvalidProposalKindError is returned when an invalid proposal kind is provided.

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -94,7 +94,7 @@ func (t *TimelockExecutable) IsReady(ctx context.Context) error {
 			return err
 		}
 		if !isReady {
-			return fmt.Errorf("operation %d is not ready", globalIndex)
+			return &OperationNotReadyError{GlobalIndex: globalIndex}
 		}
 	}
 

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -33,6 +33,7 @@ func NewTimelockExecutable(
 		executors: executors,
 	}, nil
 }
+
 func (t *TimelockExecutable) GetOpID(ctx context.Context, opIdx int, bop types.BatchOperation, selector types.ChainSelector) (common.Hash, error) {
 	// Convert the batch operation
 	executor := t.executors[selector]

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -94,7 +94,7 @@ func (t *TimelockExecutable) IsReady(ctx context.Context) error {
 			return err
 		}
 		if !isReady {
-			return &OperationNotReadyError{GlobalIndex: globalIndex}
+			return &OperationNotReadyError{OpIndex: globalIndex}
 		}
 	}
 

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -43,9 +43,11 @@ func (t *TimelockExecutable) GetOpID(ctx context.Context, opIdx int, bop types.B
 	timelockAddr, ok := t.proposal.TimelockAddresses[selector]
 	if !ok {
 		return common.Hash{}, fmt.Errorf("timelock address not found for chain selector %v", selector)
-
 	}
 	chainMetadata, ok := t.proposal.ChainMetadata[selector]
+	if !ok {
+		return common.Hash{}, fmt.Errorf("chain metadata not found for chain selector %v", selector)
+	}
 	_, operationID, err := converter.ConvertBatchToChainOperations(
 		ctx,
 		bop,
@@ -58,10 +60,9 @@ func (t *TimelockExecutable) GetOpID(ctx context.Context, opIdx int, bop types.B
 	)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("unable to convert batch to chain operations: %w", err)
-
 	}
-	return operationID, nil
 
+	return operationID, nil
 }
 
 // IsReady checks if ALL the operations in the proposal are ready

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -15,7 +15,7 @@ import (
 // for scheduled calls
 type TimelockExecutable struct {
 	proposal     *TimelockProposal
-	predecessors []common.Hash
+	predecessors map[types.ChainSelector][]common.Hash
 	executors    map[types.ChainSelector]sdk.TimelockExecutor
 }
 
@@ -48,7 +48,7 @@ func (t *TimelockExecutable) IsReady(ctx context.Context) error {
 	for i, op := range t.proposal.Operations {
 		cs := op.ChainSelector
 		timelock := t.proposal.TimelockAddresses[cs]
-		isOpReady, err := t.executors[cs].IsOperationReady(ctx, timelock, t.predecessors[i+1])
+		isOpReady, err := t.executors[cs].IsOperationReady(ctx, timelock, t.predecessors[cs][i+1])
 		if err != nil {
 			return err
 		}
@@ -100,7 +100,7 @@ func (t *TimelockExecutable) Execute(ctx context.Context, index int, opts ...Opt
 		ctx,
 		op,
 		execAddress,
-		t.predecessors[index],
+		t.predecessors[op.ChainSelector][index],
 		t.proposal.Salt(),
 	)
 }

--- a/timelock_executable_test.go
+++ b/timelock_executable_test.go
@@ -532,13 +532,13 @@ func scheduleAndExecuteGrantRolesProposal(t *testing.T, ctx context.Context, tar
 		}
 
 		var isOperation, isOperationPending, isOperationReady bool
-		isOperation, err = timelockC.IsOperation(&bind.CallOpts{}, predecessors[i])
+		isOperation, err = timelockC.IsOperation(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.True(t, isOperation)
-		isOperationPending, err = timelockC.IsOperationPending(&bind.CallOpts{}, predecessors[i])
+		isOperationPending, err = timelockC.IsOperationPending(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.True(t, isOperationPending)
-		isOperationReady, err = timelockC.IsOperationReady(&bind.CallOpts{}, predecessors[i])
+		isOperationReady, err = timelockC.IsOperationReady(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.False(t, isOperationReady)
 	}
@@ -566,7 +566,7 @@ func scheduleAndExecuteGrantRolesProposal(t *testing.T, ctx context.Context, tar
 			continue
 		}
 
-		isOperationDone, err := timelockC.IsOperationDone(&bind.CallOpts{}, predecessors[i])
+		isOperationDone, err := timelockC.IsOperationDone(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.True(t, isOperationDone)
 	}
@@ -685,13 +685,13 @@ func scheduleAndCancelGrantRolesProposal(t *testing.T, ctx context.Context, targ
 		}
 
 		var isOperation, isOperationPending, isOperationReady bool
-		isOperation, err = timelockC.IsOperation(&bind.CallOpts{}, predecessors[i])
+		isOperation, err = timelockC.IsOperation(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.True(t, isOperation)
-		isOperationPending, err = timelockC.IsOperationPending(&bind.CallOpts{}, predecessors[i])
+		isOperationPending, err = timelockC.IsOperationPending(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.True(t, isOperationPending)
-		isOperationReady, err = timelockC.IsOperationReady(&bind.CallOpts{}, predecessors[i])
+		isOperationReady, err = timelockC.IsOperationReady(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.False(t, isOperationReady)
 	}
@@ -791,13 +791,13 @@ func scheduleAndCancelGrantRolesProposal(t *testing.T, ctx context.Context, targ
 		}
 
 		var isOperation, isOperationPending, isOperationReady bool
-		isOperation, err = timelockC.IsOperation(&bind.CallOpts{}, predecessors[i])
+		isOperation, err = timelockC.IsOperation(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.False(t, isOperation)
-		isOperationPending, err = timelockC.IsOperationPending(&bind.CallOpts{}, predecessors[i])
+		isOperationPending, err = timelockC.IsOperationPending(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.False(t, isOperationPending)
-		isOperationReady, err = timelockC.IsOperationReady(&bind.CallOpts{}, predecessors[i])
+		isOperationReady, err = timelockC.IsOperationReady(&bind.CallOpts{}, predecessors[chaintest.Chain1Selector][i])
 		require.NoError(t, err)
 		require.False(t, isOperationReady)
 	}

--- a/timelock_proposal.go
+++ b/timelock_proposal.go
@@ -98,24 +98,12 @@ func (m *TimelockProposal) Validate() error {
 	return nil
 }
 
-func getNumOperationsForChain(ops []types.BatchOperation, chain types.ChainSelector) int {
-	count := 0
-	for _, op := range ops {
-		if op.ChainSelector == chain {
-			count++
-		}
-	}
-
-	return count
-}
-
 // Convert the proposal to an MCMS only proposal and also return all predecessors for easy access later.
 // Every transaction to be sent from the Timelock is encoded with the corresponding timelock method.
 func (m *TimelockProposal) Convert(
 	ctx context.Context,
 	converters map[types.ChainSelector]sdk.TimelockConverter,
 ) (Proposal, []common.Hash, error) {
-
 	// 1) Clone the base proposal, update the kind, etc.
 	baseProposal := m.BaseProposal
 	baseProposal.Kind = types.KindProposal

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -626,9 +626,10 @@ func Test_TimelockProposal_Convert(t *testing.T) {
 	require.Equal(t, "description", mcmsProposal.Description)
 	require.Len(t, mcmsProposal.Operations, 3)
 
-	require.Len(t, predecessors, 2)
-	require.Len(t, predecessors[chaintest.Chain1Selector], 2)
-	require.Len(t, predecessors[chaintest.Chain2Selector], 3)
+	require.Len(t, predecessors, 3)
+	require.Equal(t, predecessors[0], ZERO_HASH)
+	require.Equal(t, predecessors[1], ZERO_HASH)
+	require.NotEqual(t, predecessors[2], ZERO_HASH)
 }
 
 func TestProposal_WithSaltOverride(t *testing.T) {

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -531,16 +531,41 @@ func Test_TimelockProposal_Convert(t *testing.T) {
 				StartingOpCount: 1,
 				MCMAddress:      "0x123",
 			},
+			chaintest.Chain2Selector: {
+				StartingOpCount: 1,
+				MCMAddress:      "0x456",
+			},
 		}
 
 		validTimelockAddresses = map[types.ChainSelector]string{
 			chaintest.Chain1Selector: "0x123",
+			chaintest.Chain2Selector: "0x456",
 		}
 
-		validTx = types.Transaction{
+		validTx1 = types.Transaction{
 			To:               "0x123",
 			AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
 			Data:             common.Hex2Bytes("0x"),
+			OperationMetadata: types.OperationMetadata{
+				ContractType: "Sample contract",
+				Tags:         []string{"tag1", "tag2"},
+			},
+		}
+
+		validTx2 = types.Transaction{
+			To:               "0x123",
+			AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
+			Data:             common.Hex2Bytes("0x1"),
+			OperationMetadata: types.OperationMetadata{
+				ContractType: "Sample contract",
+				Tags:         []string{"tag1", "tag2"},
+			},
+		}
+
+		validTx3 = types.Transaction{
+			To:               "0x123",
+			AdditionalFields: json.RawMessage([]byte(`{"value": 0}`)),
+			Data:             common.Hex2Bytes("0x2"),
 			OperationMetadata: types.OperationMetadata{
 				ContractType: "Sample contract",
 				Tags:         []string{"tag1", "tag2"},
@@ -551,7 +576,19 @@ func Test_TimelockProposal_Convert(t *testing.T) {
 			{
 				ChainSelector: chaintest.Chain1Selector,
 				Transactions: []types.Transaction{
-					validTx,
+					validTx1,
+				},
+			},
+			{
+				ChainSelector: chaintest.Chain2Selector,
+				Transactions: []types.Transaction{
+					validTx2,
+				},
+			},
+			{
+				ChainSelector: chaintest.Chain2Selector,
+				Transactions: []types.Transaction{
+					validTx3,
 				},
 			},
 		}
@@ -574,20 +611,24 @@ func Test_TimelockProposal_Convert(t *testing.T) {
 
 		converters = map[types.ChainSelector]sdk.TimelockConverter{
 			chaintest.Chain1Selector: &evmsdk.TimelockConverter{},
+			chaintest.Chain2Selector: &evmsdk.TimelockConverter{},
 		}
 	)
 
 	mcmsProposal, predecessors, err := proposal.Convert(ctx, converters)
 	require.NoError(t, err)
 
-	assert.Equal(t, "v1", mcmsProposal.Version)
-	assert.Equal(t, uint32(2004259681), mcmsProposal.ValidUntil)
-	assert.Equal(t, []types.Signature{}, mcmsProposal.Signatures)
-	assert.False(t, mcmsProposal.OverridePreviousRoot)
-	assert.Equal(t, validChainMetadata, mcmsProposal.ChainMetadata)
-	assert.Equal(t, "description", mcmsProposal.Description)
-	assert.Len(t, mcmsProposal.Operations, 1)
-	assert.Len(t, predecessors, 2)
+	require.Equal(t, "v1", mcmsProposal.Version)
+	require.Equal(t, uint32(2004259681), mcmsProposal.ValidUntil)
+	require.Equal(t, []types.Signature{}, mcmsProposal.Signatures)
+	require.False(t, mcmsProposal.OverridePreviousRoot)
+	require.Equal(t, validChainMetadata, mcmsProposal.ChainMetadata)
+	require.Equal(t, "description", mcmsProposal.Description)
+	require.Len(t, mcmsProposal.Operations, 3)
+
+	require.Len(t, predecessors, 2)
+	require.Len(t, predecessors[chaintest.Chain1Selector], 2)
+	require.Len(t, predecessors[chaintest.Chain2Selector], 3)
 }
 
 func TestProposal_WithSaltOverride(t *testing.T) {


### PR DESCRIPTION
This pull request includes significant updates and additions to the `timelock_executable.go` and related test files to enhance functionality and improve test coverage. The key changes include the introduction of new methods for operation ID retrieval and chain-specific indexing, as well as updates to existing tests to accommodate these changes.

### Enhancements to `timelock_executable.go`:

* Added `GetOpID` method to `TimelockExecutable` for retrieving operation IDs.
* Introduced `GetChainSpecificIndex` method to `TimelockExecutable` to determine the index of an operation within a specific chain.

### Updates to Tests:

* Modified `Test_TimelockConverter` to adjust the expected predecessors in assertions. [[1]](diffhunk://#diff-715e94216372225cfc4c7393c82b553f0b784dcd30d21f067bade69b1ef7c38cL275-R275) [[2]](diffhunk://#diff-715e94216372225cfc4c7393c82b553f0b784dcd30d21f067bade69b1ef7c38cL331-R331) [[3]](diffhunk://#diff-715e94216372225cfc4c7393c82b553f0b784dcd30d21f067bade69b1ef7c38cL489-R489)
* Updated `scheduleAndExecuteGrantRolesProposal` to use the new `GetOpID` method and validate operation completion. [[1]](diffhunk://#diff-2ee0863eda6e2cdffe4fda89ec41b6a744cf57c0028ffba28c5d2b7bab8cbc55L530-L533) [[2]](diffhunk://#diff-2ee0863eda6e2cdffe4fda89ec41b6a744cf57c0028ffba28c5d2b7bab8cbc55L559-L572)
* Added a new test `Test_TimelockExecutable_GetChainSpecificIndex` to verify the chain-specific indexing functionality.

### Improvements to `timelock_proposal.go`:

* Refactored `Convert` method in `TimelockProposal` to streamline predecessor handling and chain metadata conversion. [[1]](diffhunk://#diff-22aa9f90e7ed0f30eb381e769a6ce492d3472c4e8029e134f0074e1913ce482fR107-R166) [[2]](diffhunk://#diff-22aa9f90e7ed0f30eb381e769a6ce492d3472c4e8029e134f0074e1913ce482fL151-R179)

### Test Enhancements:

* Expanded `Test_TimelockProposal_Convert` to include additional chain selectors and transactions, ensuring comprehensive validation of the conversion process. [[1]](diffhunk://#diff-b80686a8969c14a89af64e7ed45e5a1e0dc025880256405d9e48eac6e33722b9R534-R545) [[2]](diffhunk://#diff-b80686a8969c14a89af64e7ed45e5a1e0dc025880256405d9e48eac6e33722b9R555-R591) [[3]](diffhunk://#diff-b80686a8969c14a89af64e7ed45e5a1e0dc025880256405d9e48eac6e33722b9R614-R632)