### PR TITLE
[DPA-1552 & DPA-1553]: fix(solana): address latest breaking change

### DIFF
--- a/.changeset/brave-pianos-bake.md
+++ b/.changeset/brave-pianos-bake.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Address latest breaking change (new Operation Enums and Chunk based instructions for timelock converter)

--- a/e2e/tests/solana/timelock_converter.go
+++ b/e2e/tests/solana/timelock_converter.go
@@ -149,9 +149,39 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 				}),
 			}}).
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
+				// op1: initialize 1st timelock instruction ("empty" call)
+				To:                s.TimelockProgramID.String(),
+				Data:              base64Decode(s.T(), "w+bVh5CUjlV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsAAAAA"),
+				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
+				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
+					Accounts: []*solana.AccountMeta{
+						{PublicKey: operation1PDA, IsWritable: true},
+						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
+						{PublicKey: mcmSignerPDA, IsWritable: true},
+						{PublicKey: solana.SystemProgramID},
+					},
+				}),
+			}}).
+			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: append 1st timelock instruction ("empty" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "OjqJenMzkIZ0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AQAAADDXIVGUZuenxgaR919Jc0lUvuAv22cA3X8CoZ3pcszbCAAAANYsBPcMKdluAAAAAA=="),
+				Data:              base64Decode(s.T(), "TE1mg4gMLQV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AAAAAAgAAADWLAT3DCnZbg=="),
+				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
+				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
+					Accounts: []*solana.AccountMeta{
+						{PublicKey: operation1PDA, IsWritable: true},
+						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
+						{PublicKey: mcmSignerPDA, IsWritable: true},
+						{PublicKey: solana.SystemProgramID},
+					},
+				}),
+			}}).
+			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
+				// op1: initialize 2nd timelock instruction ("u8_value" call)
+				To:                s.TimelockProgramID.String(),
+				Data:              base64Decode(s.T(), "w+bVh5CUjlV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsAAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -166,7 +196,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: append 2nd timelock instruction ("u8_value" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "OjqJenMzkIZ0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AQAAADDXIVGUZuenxgaR919Jc0lUvuAv22cA3X8CoZ3pcszbCQAAABGvnP1brRrkewAAAAA="),
+				Data:              base64Decode(s.T(), "TE1mg4gMLQV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AQAAAAkAAAARr5z9W60a5Hs="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -222,9 +252,24 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 				}),
 			}}).
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
+				// op2: initialize 1st timelock instruction ("account_mut" call)
+				To:                s.TimelockProgramID.String(),
+				Data:              base64Decode(s.T(), "w+bVh5CUjlV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsDAAAAb4Ezc71PQCcAP8nkYKXix7gp+hT0j5UUJCouW5tBzooAAcSFrcjukyvq73/bE9YO/KFljWLRDY+RGpHMk4NkhqT6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
+				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
+					Accounts: []*solana.AccountMeta{
+						{PublicKey: operation2PDA, IsWritable: true},
+						{PublicKey: configPDA},
+						{PublicKey: proposerAC},
+						{PublicKey: mcmSignerPDA, IsWritable: true},
+						{PublicKey: solana.SystemProgramID},
+					},
+				}),
+			}}).
+			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: append 1st timelock instruction ("account_mut" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "OjqJenMzkIZ0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2AQAAADDXIVGUZuenxgaR919Jc0lUvuAv22cA3X8CoZ3pcszbCAAAAAwCiRMW65BGAwAAAG+BM3O9T0AnAD/J5GCl4se4KfoU9I+VFCQqLlubQc6KAAHEha3I7pMr6u9/2xPWDvyhZY1i0Q2PkRqRzJODZIak+gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="),
+				Data:              base64Decode(s.T(), "TE1mg4gMLQV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2AAAAAAgAAAAMAokTFuuQRg=="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -361,9 +406,39 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 				}),
 			}}).
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
+				// op1: initialize 1st timelock instruction ("empty" call)
+				To:                s.TimelockProgramID.String(),
+				Data:              base64Decode(s.T(), "MhHNrK+Mwyd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsAAAAA"),
+				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
+				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
+					Accounts: []*solana.AccountMeta{
+						{PublicKey: operation1BypasserPDA, IsWritable: true},
+						{PublicKey: configPDA},
+						{PublicKey: bypasserAC},
+						{PublicKey: mcmSignerPDA, IsWritable: true},
+						{PublicKey: solana.SystemProgramID},
+					},
+				}),
+			}}).
+			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: append 1st timelock instruction ("empty" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "f0QI0mrVGdd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AQAAADDXIVGUZuenxgaR919Jc0lUvuAv22cA3X8CoZ3pcszbCAAAANYsBPcMKdluAAAAAA=="),
+				Data:              base64Decode(s.T(), "uOiX3m9118V0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AAAAAAgAAADWLAT3DCnZbg=="),
+				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
+				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
+					Accounts: []*solana.AccountMeta{
+						{PublicKey: operation1BypasserPDA, IsWritable: true},
+						{PublicKey: configPDA},
+						{PublicKey: bypasserAC},
+						{PublicKey: mcmSignerPDA, IsWritable: true},
+						{PublicKey: solana.SystemProgramID},
+					},
+				}),
+			}}).
+			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
+				// op1: initialize 2nd timelock instruction ("u8_value" call)
+				To:                s.TimelockProgramID.String(),
+				Data:              base64Decode(s.T(), "MhHNrK+Mwyd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsAAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -378,7 +453,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: append 2nd timelock instruction ("u8_value" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "f0QI0mrVGdd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AQAAADDXIVGUZuenxgaR919Jc0lUvuAv22cA3X8CoZ3pcszbCQAAABGvnP1brRrkewAAAAA="),
+				Data:              base64Decode(s.T(), "uOiX3m9118V0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AQAAAAkAAAARr5z9W60a5Hs="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -405,7 +480,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 				}),
 			}}).
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
-				// op1: bypass operation instruction
+				// op1: bypass execute batch instruction
 				To:                s.TimelockProgramID.String(),
 				Data:              base64Decode(s.T(), "Wj5CBuOuHsJ0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
@@ -435,9 +510,24 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 				}),
 			}}).
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
+				// op2: initialize 1st timelock instruction ("account_mut" call)
+				To:                s.TimelockProgramID.String(),
+				Data:              base64Decode(s.T(), "MhHNrK+Mwyd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsDAAAAb4Ezc71PQCcAP8nkYKXix7gp+hT0j5UUJCouW5tBzooAAcSFrcjukyvq73/bE9YO/KFljWLRDY+RGpHMk4NkhqT6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
+				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
+					Accounts: []*solana.AccountMeta{
+						{PublicKey: operation2BypasserPDA, IsWritable: true},
+						{PublicKey: configPDA},
+						{PublicKey: bypasserAC},
+						{PublicKey: mcmSignerPDA, IsWritable: true},
+						{PublicKey: solana.SystemProgramID},
+					},
+				}),
+			}}).
+			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: append 1st timelock instruction ("account_mut" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "f0QI0mrVGdd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2AQAAADDXIVGUZuenxgaR919Jc0lUvuAv22cA3X8CoZ3pcszbCAAAAAwCiRMW65BGAwAAAG+BM3O9T0AnAD/J5GCl4se4KfoU9I+VFCQqLlubQc6KAAHEha3I7pMr6u9/2xPWDvyhZY1i0Q2PkRqRzJODZIak+gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="),
+				Data:              base64Decode(s.T(), "uOiX3m9118V0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2AAAAAAgAAAAMAokTFuuQRg=="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -464,7 +554,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 				}),
 			}}).
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
-				// op2: bypass operation instruction
+				// op2: bypass execute batch instruction
 				To:                s.TimelockProgramID.String(),
 				Data:              base64Decode(s.T(), "Wj5CBuOuHsJ0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/karalabe/hid v1.0.1-0.20240306101548-573246063e52
 	github.com/smartcontractkit/chain-selectors v1.0.36
-	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250128193522-bdbfcc588847
+	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250210201649-d9b9b053905e
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/chain-selectors v1.0.36 h1:KSpO8I+JOiuyN4FuXsV471sPorGF//PAqwq2Cm4gRK0=
 github.com/smartcontractkit/chain-selectors v1.0.36/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250128193522-bdbfcc588847 h1:dw2d6UyvnCGFym2cRYsJfGdHNPa/iGKkrC+ppB3mKWo=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250128193522-bdbfcc588847/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250210201649-d9b9b053905e h1:ivjjw4j0psSIRfEdGa5WSqXlV6KJ1CPb61Entm7fdVA=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250210201649-d9b9b053905e/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.0 h1:GZ9MhHt5QHXSaK/sAZvKDxkEqF4fPiFHWHEPqs/2C2o=
 github.com/smartcontractkit/chainlink-common v0.4.0/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7 h1:E7k5Sym9WnMOc4X40lLnQb6BMosxi8DfUBU9pBJjHOQ=

--- a/sdk/solana/timelock_converter_test.go
+++ b/sdk/solana/timelock_converter_test.go
@@ -108,7 +108,7 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 			salt:            defaultSalt,
 			wantOperations: []types.Operation{
 				{
-					// initialize
+					// initialize operation
 					ChainSelector: chaintest.Chain4Selector,
 					Transaction: types.Transaction{
 						To:   testTimelockProgramID.String(),
@@ -127,11 +127,11 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 					},
 				},
 				{
-					// append first operation
+					// initialize first instruction
 					ChainSelector: chaintest.Chain4Selector,
 					Transaction: types.Transaction{
 						To:   testTimelockProgramID.String(),
-						Data: base64Decode(t, "OjqJenMzkIZ0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/AQAAAOy/SwEm9OHsR3Iyhg37tMCACi9OJO1mbYf2EdbL8BdlBgAAADB4MTIzNAIAAABzrkiHQ+JGjN94Ifr0hyI7xbfT2AUTMNwqcY6ldOvyZQEBkKcZjjIczPUeb2jNRtBAfOQA/tDFWu7x9HDKmqHFfGAAAQ=="),
+						Data: base64Decode(t, "w+bVh5CUjlV0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/7L9LASb04exHcjKGDfu0wIAKL04k7WZth/YR1svwF2UCAAAAc65Ih0PiRozfeCH69IciO8W309gFEzDcKnGOpXTr8mUBAZCnGY4yHMz1Hm9ozUbQQHzkAP7QxVru8fRwypqhxXxgAAE="),
 						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
 							{PublicKey: solana.MPK("3x12f1G4bt9j7rsBfLE7rZQ5hXoHuHdjtUr2UKW8gjQp"), IsWritable: true},
 							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
@@ -146,11 +146,49 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 					},
 				},
 				{
-					// append second operation
+					// append first instruction data
 					ChainSelector: chaintest.Chain4Selector,
 					Transaction: types.Transaction{
 						To:   testTimelockProgramID.String(),
-						Data: base64Decode(t, "OjqJenMzkIZ0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/AQAAAA0THF/kMtia7NQl9/Z+bKF0Ggj7DNa/3WxLGpQ1QAaIBgAAADB4NTY3OAAAAAA="),
+						Data: base64Decode(t, "TE1mg4gMLQV0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/AAAAAAYAAAAweDEyMzQ="),
+						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
+							{PublicKey: solana.MPK("3x12f1G4bt9j7rsBfLE7rZQ5hXoHuHdjtUr2UKW8gjQp"), IsWritable: true},
+							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
+							{PublicKey: proposerAC.PublicKey()},
+							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
+							{PublicKey: solana.MPK("11111111111111111111111111111111")},
+						}}),
+						OperationMetadata: types.OperationMetadata{
+							ContractType: "RBACTimelock",
+							Tags:         []string{"tag1.1", "tag1.2", "tag2.1", "tag2.2"},
+						},
+					},
+				},
+				{
+					// initialize second instruction
+					ChainSelector: chaintest.Chain4Selector,
+					Transaction: types.Transaction{
+						To:   testTimelockProgramID.String(),
+						Data: base64Decode(t, "w+bVh5CUjlV0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/DRMcX+Qy2Jrs1CX39n5soXQaCPsM1r/dbEsalDVABogAAAAA"),
+						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
+							{PublicKey: solana.MPK("3x12f1G4bt9j7rsBfLE7rZQ5hXoHuHdjtUr2UKW8gjQp"), IsWritable: true},
+							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
+							{PublicKey: proposerAC.PublicKey()},
+							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
+							{PublicKey: solana.MPK("11111111111111111111111111111111")},
+						}}),
+						OperationMetadata: types.OperationMetadata{
+							ContractType: "RBACTimelock",
+							Tags:         []string{"tag1.1", "tag1.2", "tag2.1", "tag2.2"},
+						},
+					},
+				},
+				{
+					// append second instruction data
+					ChainSelector: chaintest.Chain4Selector,
+					Transaction: types.Transaction{
+						To:   testTimelockProgramID.String(),
+						Data: base64Decode(t, "TE1mg4gMLQV0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/AQAAAAYAAAAweDU2Nzg="),
 						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
 							{PublicKey: solana.MPK("3x12f1G4bt9j7rsBfLE7rZQ5hXoHuHdjtUr2UKW8gjQp"), IsWritable: true},
 							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
@@ -276,11 +314,11 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 					},
 				},
 				{
-					// append first operation
+					// initialize first instruction
 					ChainSelector: chaintest.Chain4Selector,
 					Transaction: types.Transaction{
 						To:   testTimelockProgramID.String(),
-						Data: base64Decode(t, "f0QI0mrVGdd0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/AQAAAOy/SwEm9OHsR3Iyhg37tMCACi9OJO1mbYf2EdbL8BdlBgAAADB4MTIzNAIAAABzrkiHQ+JGjN94Ifr0hyI7xbfT2AUTMNwqcY6ldOvyZQEBkKcZjjIczPUeb2jNRtBAfOQA/tDFWu7x9HDKmqHFfGAAAQ=="),
+						Data: base64Decode(t, "MhHNrK+Mwyd0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/7L9LASb04exHcjKGDfu0wIAKL04k7WZth/YR1svwF2UCAAAAc65Ih0PiRozfeCH69IciO8W309gFEzDcKnGOpXTr8mUBAZCnGY4yHMz1Hm9ozUbQQHzkAP7QxVru8fRwypqhxXxgAAE="),
 						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
 							{PublicKey: solana.MPK("5kA68ZDhLguQqxoEraVvdSYzR43JddUZXEm8SCdCEQfh"), IsWritable: true},
 							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
@@ -295,11 +333,49 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 					},
 				},
 				{
-					// append second operation
+					// append first instruction
 					ChainSelector: chaintest.Chain4Selector,
 					Transaction: types.Transaction{
 						To:   testTimelockProgramID.String(),
-						Data: base64Decode(t, "f0QI0mrVGdd0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/AQAAAA0THF/kMtia7NQl9/Z+bKF0Ggj7DNa/3WxLGpQ1QAaIBgAAADB4NTY3OAAAAAA="),
+						Data: base64Decode(t, "uOiX3m9118V0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/AAAAAAYAAAAweDEyMzQ="),
+						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
+							{PublicKey: solana.MPK("5kA68ZDhLguQqxoEraVvdSYzR43JddUZXEm8SCdCEQfh"), IsWritable: true},
+							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
+							{PublicKey: solana.MPK(bypasserAC.PublicKey().String())},
+							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
+							{PublicKey: solana.MPK("11111111111111111111111111111111")},
+						}}),
+						OperationMetadata: types.OperationMetadata{
+							ContractType: "RBACTimelock",
+							Tags:         []string{"tag1.1", "tag1.2", "tag2.1", "tag2.2"},
+						},
+					},
+				},
+				{
+					// initialize second instruction
+					ChainSelector: chaintest.Chain4Selector,
+					Transaction: types.Transaction{
+						To:   testTimelockProgramID.String(),
+						Data: base64Decode(t, "MhHNrK+Mwyd0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/DRMcX+Qy2Jrs1CX39n5soXQaCPsM1r/dbEsalDVABogAAAAA"),
+						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
+							{PublicKey: solana.MPK("5kA68ZDhLguQqxoEraVvdSYzR43JddUZXEm8SCdCEQfh"), IsWritable: true},
+							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},
+							{PublicKey: solana.MPK(bypasserAC.PublicKey().String())},
+							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
+							{PublicKey: solana.MPK("11111111111111111111111111111111")},
+						}}),
+						OperationMetadata: types.OperationMetadata{
+							ContractType: "RBACTimelock",
+							Tags:         []string{"tag1.1", "tag1.2", "tag2.1", "tag2.2"},
+						},
+					},
+				},
+				{
+					// append second instruction
+					ChainSelector: chaintest.Chain4Selector,
+					Transaction: types.Transaction{
+						To:   testTimelockProgramID.String(),
+						Data: base64Decode(t, "uOiX3m9118V0ZXN0LW1jbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOzNziC5jaIAHmroyBw0o6rhzkqnV4l5BvFaLyVxMtx/AQAAAAYAAAAweDU2Nzg="),
 						AdditionalFields: toJSON(t, AdditionalFields{Accounts: []*solana.AccountMeta{
 							{PublicKey: solana.MPK("5kA68ZDhLguQqxoEraVvdSYzR43JddUZXEm8SCdCEQfh"), IsWritable: true},
 							{PublicKey: solana.MPK("GYWcPzXkdzY9DJLcbFs67phqyYzmJxeEKSTtqEoo8oKz")},


### PR DESCRIPTION
Breaking change on operation state and new chunk based instructions for timelock ops

Context:
- https://github.com/smartcontractkit/chainlink-ccip/pull/549
- https://github.com/smartcontractkit/chainlink-ccip/pull/528
- https://chainlink-core.slack.com/archives/C024M6N5MS8/p1738862087360339

This commit pulls the latest chainlink-ccip/solana and resolve all the latest breaking change.
- Updates the timelock inspector to use the new enums provided in the generated bindings instead of using timestamp.
- Updates timelock converted to use the new chunk based instructions for bypasser and schedule batch

JIRA:
- https://smartcontract-it.atlassian.net/browse/DPA-1552
- https://smartcontract-it.atlassian.net/browse/DPA-1553