### PR TITLE
ci(publish): fix broken publishing step

### DIFF
--- a/.changeset/metal-fishes-argue.md
+++ b/.changeset/metal-fishes-argue.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+retrigger publishing due to previous failure

--- a/.github/workflows/push-tag-release.yml
+++ b/.github/workflows/push-tag-release.yml
@@ -75,7 +75,7 @@ jobs:
 
           # goreleaser inputs
           goreleaser-args: "--config .goreleaser.yml"
-          goreleaser-version: '~> v2'
+          goreleaser-version: 'latest'
           goreleaser-dist: goreleaser-pro
           goreleaser-key: ${{ secrets.GORELEASER_KEY }}
 


### PR DESCRIPTION
Looks like due to external change the `'~> v2'` no longer works https://github.com/smartcontractkit/mcms/actions/runs/13261568529/job/37019757229

Error message:
`Cannot find GoReleaser release ~> v2-pro in https://goreleaser.com/static/releases-pro.json`

Temporarily changing the value to `latest` to unblock the release.