### PR TITLE
[WIP] ci(publish): fix goreleaser-pro version 

### DIFF
--- a/.github/workflows/push-tag-release.yml
+++ b/.github/workflows/push-tag-release.yml
@@ -75,7 +75,7 @@ jobs:
 
           # goreleaser inputs
           goreleaser-args: "--config .goreleaser.yml"
-          goreleaser-version: 'latest'
+          goreleaser-version: 'v2.6.1-pro'
           goreleaser-dist: goreleaser-pro
           goreleaser-key: ${{ secrets.GORELEASER_KEY }}
 


### PR DESCRIPTION
The previous [fix didn work](https://github.com/smartcontractkit/mcms/pull/291) as expected as for some reason the `latest` version is using [an old version](https://github.com/smartcontractkit/mcms/actions/runs/13262406886/job/37021796511)

This commit fixed the goreleaser version to `'v2.6.1-pro'` which is the newest pro version.

Issue was raise in slack [here](https://chainlink-core.slack.com/archives/C038Q8K1HTR/p1739262431421559)