### PR TITLE
ci(publish): update cicd-build-publish-artifacts-go

### DIFF
--- a/.github/workflows/push-tag-release.yml
+++ b/.github/workflows/push-tag-release.yml
@@ -66,7 +66,7 @@ jobs:
       actions: read
     steps:
       - name: cicd-publish-release
-        uses: smartcontractkit/.github/actions/cicd-build-publish-artifacts-go@7a4d99cb349ea8f25195d2390d157942031f8a57 # cicd-build-publish-artifacts-go@0.2.4
+        uses: smartcontractkit/.github/actions/cicd-build-publish-artifacts-go@b4737861584f88fa9569d6978f70fedf8b1ae67c # cicd-build-publish-artifacts-go@0.4.0
         with:
           # general inputs
           app-name: mcms-lib
@@ -75,7 +75,7 @@ jobs:
 
           # goreleaser inputs
           goreleaser-args: "--config .goreleaser.yml"
-          goreleaser-version: 'latest'
+          goreleaser-version: '~> v2'
           goreleaser-dist: goreleaser-pro
           goreleaser-key: ${{ secrets.GORELEASER_KEY }}
 


### PR DESCRIPTION
Issue: https://chainlink-core.slack.com/archives/C038Q8K1HTR/p1739262431421559

Broken pipeline due to an external change in goreleaser, more info [here](https://github.com/smartcontractkit/mcms/pull/291)

releng has released a new [fix](https://chainlink-core.slack.com/archives/C038Q8K1HTR/p1739278624955659?thread_ts=1739262431.421559&cid=C038Q8K1HTR)

This commits bumps the `cicd-build-publish-artifacts-go` github action which contains the fix and reverts the [previous fix ](https://github.com/smartcontractkit/mcms/pull/291) of setting version to `latest`