### PR TITLE
fix: chain/operation timelock isReady helpers

### DIFF
--- a/.changeset/clean-turtles-peel.md
+++ b/.changeset/clean-turtles-peel.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Add additional isReady helpers to API

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -82,7 +82,7 @@ func (t *TimelockExecutable) IsReady(ctx context.Context) error {
 
 	// Check readiness for each global operation in the proposal
 	for globalIndex := range t.proposal.Operations {
-		err := t.isOperationReady(ctx, globalIndex)
+		err := t.IsOperationReady(ctx, globalIndex)
 		if err != nil {
 			return err
 		}
@@ -104,7 +104,7 @@ func (t *TimelockExecutable) IsChainReady(ctx context.Context, chainSelector typ
 	// Check readiness for each global operation in the proposal
 	for globalIndex, op := range t.proposal.Operations {
 		if op.ChainSelector == chainSelector {
-			err := t.isOperationReady(ctx, globalIndex)
+			err := t.IsOperationReady(ctx, globalIndex)
 			if err != nil {
 				return err
 			}
@@ -114,7 +114,7 @@ func (t *TimelockExecutable) IsChainReady(ctx context.Context, chainSelector typ
 	return nil
 }
 
-func (t *TimelockExecutable) isOperationReady(ctx context.Context, idx int) error {
+func (t *TimelockExecutable) IsOperationReady(ctx context.Context, idx int) error {
 	op := t.proposal.Operations[idx]
 
 	cs := op.ChainSelector

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -81,22 +81,56 @@ func (t *TimelockExecutable) IsReady(ctx context.Context) error {
 	}
 
 	// Check readiness for each global operation in the proposal
-	for globalIndex, op := range t.proposal.Operations {
-		cs := op.ChainSelector
-		timelock := t.proposal.TimelockAddresses[cs]
-
-		operationID, err := t.GetOpID(ctx, globalIndex, op, cs)
-		if err != nil {
-			return fmt.Errorf("unable to get operation ID: %w", err)
-		}
-
-		isReady, err := t.executors[cs].IsOperationReady(ctx, timelock, operationID)
+	for globalIndex := range t.proposal.Operations {
+		err := t.isOperationReady(ctx, globalIndex)
 		if err != nil {
 			return err
 		}
-		if !isReady {
-			return &OperationNotReadyError{OpIndex: globalIndex}
+	}
+
+	return nil
+}
+
+// IsChainReady checks if the chain is ready for execution.
+func (t *TimelockExecutable) IsChainReady(ctx context.Context, chainSelector types.ChainSelector) error {
+	// setPredecessors populates t.predecessors[chainSelector] = []common.Hash
+	// (one array per chain). The 0th element is zero-hash, the 1st is the
+	// operationID for that chain's 1st operation, etc.
+	err := t.setPredecessors(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to set predecessors: %w", err)
+	}
+
+	// Check readiness for each global operation in the proposal
+	for globalIndex, op := range t.proposal.Operations {
+		if op.ChainSelector == chainSelector {
+			err := t.isOperationReady(ctx, globalIndex)
+			if err != nil {
+				return err
+			}
 		}
+	}
+
+	return nil
+}
+
+func (t *TimelockExecutable) isOperationReady(ctx context.Context, idx int) error {
+	op := t.proposal.Operations[idx]
+
+	cs := op.ChainSelector
+	timelock := t.proposal.TimelockAddresses[cs]
+
+	operationID, err := t.GetOpID(ctx, idx, op, cs)
+	if err != nil {
+		return fmt.Errorf("unable to get operation ID: %w", err)
+	}
+
+	isReady, err := t.executors[cs].IsOperationReady(ctx, timelock, operationID)
+	if err != nil {
+		return err
+	}
+	if !isReady {
+		return &OperationNotReadyError{OpIndex: idx}
 	}
 
 	return nil

--- a/timelock_executable_test.go
+++ b/timelock_executable_test.go
@@ -546,6 +546,12 @@ func scheduleAndExecuteGrantRolesProposal(t *testing.T, ctx context.Context, tar
 	err = tExecutable.IsReady(ctx)
 	require.Error(t, err)
 
+	// Check IsChainReady function fails
+	for chainSelector := range proposal.ChainMetadata {
+		err = tExecutable.IsChainReady(ctx, chainSelector)
+		require.Error(t, err)
+	}
+
 	// sleep for 5 seconds and then mine a block
 	require.NoError(t, sim.Backend.AdjustTime(5*time.Second))
 	sim.Backend.Commit() // Note < 1.14 geth needs a commit after adjusting time.
@@ -553,6 +559,12 @@ func scheduleAndExecuteGrantRolesProposal(t *testing.T, ctx context.Context, tar
 	// Check that the operation is now ready
 	err = tExecutable.IsReady(ctx)
 	require.NoError(t, err)
+
+	// Check IsChainReady function succeeds
+	for chainSelector := range proposal.ChainMetadata {
+		err = tExecutable.IsChainReady(ctx, chainSelector)
+		require.NoError(t, err)
+	}
 
 	// Execute the proposal
 	idx := 0


### PR DESCRIPTION

This pull request introduces additional helper functions to the `TimelockExecutable` API to enhance readiness checks. The main changes include the addition of `IsChainReady` and `IsOperationReady` methods, as well as updates to the existing `IsReady` method to incorporate these new checks. Additionally, new tests have been added to verify the functionality of these methods.

Enhancements to readiness checks:

* Added `IsChainReady` method to `timelock_executable.go` to check if the chain is ready for execution.
* Added `IsOperationReady` method to `timelock_executable.go` to check if a specific operation is ready.
* Updated `IsReady` method to call `IsOperationReady` for each global operation in the proposal. [[1]](diffhunk://#diff-5a1d103cef63b5dba0cfe2c93618b65a233c43862c69a6ba89fbee2b09bbc1ceR83-R123) [[2]](diffhunk://#diff-5a1d103cef63b5dba0cfe2c93618b65a233c43862c69a6ba89fbee2b09bbc1ceL98-R133)

Testing improvements:

* Added tests for `IsChainReady` method in `timelock_executable_test.go` to ensure it fails and succeeds under appropriate conditions. [[1]](diffhunk://#diff-2ee0863eda6e2cdffe4fda89ec41b6a744cf57c0028ffba28c5d2b7bab8cbc55R549-R554) [[2]](diffhunk://#diff-2ee0863eda6e2cdffe4fda89ec41b6a744cf57c0028ffba28c5d2b7bab8cbc55R563-R568)

Documentation updates:

* Updated `.changeset/clean-turtles-peel.md` to document the addition of new `isReady` helpers to the API.