### PR TITLE
ci(github): fix `Cannot open: File exists` in tests ci run

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -16,7 +16,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-lint-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-lint-go@0.3.1
         with:
           golangci-lint-version: v1.61.0
           # grafana inputs
@@ -34,7 +34,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-lint-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-lint-go@0.3.1
         with:
           golangci-lint-version: v1.62.0
           golangci-lint-args: --build-tags="e2e"
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Linting Misc (yaml + sh files)
-        uses: smartcontractkit/.github/actions/ci-lint-misc@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-lint-misc@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-lint-misc@0.1.4
         with:
           # grafana inputs
           metrics-job-name: ci-lint-misc
@@ -65,7 +65,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test
-        uses: smartcontractkit/.github/actions/ci-test-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-test-go@3835daadbcefcae06d12dc42a405a856c980d2cc # ci-test-go@0.3.4
         with:
           go-test-cmd: go test -coverprofile=coverage.txt $(go list ./...)
           use-go-cache: true
@@ -90,7 +90,7 @@ jobs:
         with:
             version: 1.18.10
       - name: Build and test
-        uses: smartcontractkit/.github/actions/ci-test-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-test-go@3835daadbcefcae06d12dc42a405a856c980d2cc # ci-test-go@0.3.4
         with:
           go-test-cmd: go generate -tags=e2e ./e2e/... && CTF_CONFIGS=../config.toml go test -tags=e2e -v ./e2e/tests/...
           use-go-cache: true
@@ -107,7 +107,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Scanning with Sonarqube
-        uses: smartcontractkit/.github/actions/ci-sonarqube-go@5f4a9c9c3407dd499a1ebbc658a45b9beb9bf675
+        uses: smartcontractkit/.github/actions/ci-sonarqube-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-sonarqube-go@0.3.1
         with:
           # sonarqube inputs
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,7 +15,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-lint-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-lint-go@0.3.1
         with:
           golangci-lint-version: v1.62.0
           # grafana inputs
@@ -33,7 +33,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-lint-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-lint-go@0.3.1
         with:
           golangci-lint-version: v1.62.0
           golangci-lint-args: --build-tags="e2e"
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Linting Misc (yaml + sh files)
-        uses: smartcontractkit/.github/actions/ci-lint-misc@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-lint-misc@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-lint-misc@0.1.4
 
   ci-test:
     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
       actions: read
     steps:
       - name: ci-test
-        uses: smartcontractkit/.github/actions/ci-test-go@7a4d99cb349ea8f25195d2390d157942031f8a57 # ci-test-go@0.1.5
+        uses: smartcontractkit/.github/actions/ci-test-go@3835daadbcefcae06d12dc42a405a856c980d2cc # ci-test-go@0.3.4
         with:
           go-test-cmd: go test -coverprofile=coverage.txt $(go list ./...)
           use-go-cache: true
@@ -83,7 +83,7 @@ jobs:
         with:
           version: 1.18.10
       - name: Build and test
-        uses: smartcontractkit/.github/actions/ci-test-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-test-go@3835daadbcefcae06d12dc42a405a856c980d2cc # ci-test-go@0.3.4
         with:
           go-test-cmd: go generate -tags=e2e ./e2e/... && CTF_CONFIGS=../config.toml go test -tags=e2e -v ./e2e/tests/...
           use-go-cache: true
@@ -99,7 +99,7 @@ jobs:
       contents: read
     steps:
       - name: cd-release
-        uses: smartcontractkit/.github/actions/cicd-changesets@7a4d99cb349ea8f25195d2390d157942031f8a57 # cicd-changesets@0.3.4
+        uses: smartcontractkit/.github/actions/cicd-changesets@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # cicd-changesets@0.3.6
         with:
           # general inputs
           git-user: app-token-issuer-infra-releng[bot]
@@ -121,7 +121,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Scanning with Sonarqube
-        uses: smartcontractkit/.github/actions/ci-sonarqube-go@5f4a9c9c3407dd499a1ebbc658a45b9beb9bf675
+        uses: smartcontractkit/.github/actions/ci-sonarqube-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-sonarqube-go@0.3.1
         with:
           # sonarqube inputs
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/push-tag-release.yml
+++ b/.github/workflows/push-tag-release.yml
@@ -14,7 +14,7 @@ jobs:
       actions: read
     steps:
       - name: ci-lint
-        uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57 # ci-lint-go@0.2.4
+        uses: smartcontractkit/.github/actions/ci-lint-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-lint-go@0.3.1
         with:
           golangci-lint-version: v1.62.0
           # grafana inputs
@@ -32,7 +32,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@7a4d99cb349ea8f25195d2390d157942031f8a57
+        uses: smartcontractkit/.github/actions/ci-lint-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-lint-go@0.3.1
         with:
           golangci-lint-version: v1.62.0
           golangci-lint-args: --build-tags="e2e"
@@ -50,7 +50,7 @@ jobs:
       actions: read
     steps:
       - name: ci-test
-        uses: smartcontractkit/.github/actions/ci-test-go@7a4d99cb349ea8f25195d2390d157942031f8a57 # ci-test-go@0.1.5
+        uses: smartcontractkit/.github/actions/ci-test-go@3835daadbcefcae06d12dc42a405a856c980d2cc # ci-test-go@0.3.4
         with:
           # grafana inputs
           metrics-job-name: ci-test
@@ -100,7 +100,7 @@ jobs:
         shell: bash
 
       - name: Notify Slack
-        uses: smartcontractkit/.github/actions/slack-notify-git-ref@f1f2dac0a20f0e02408eb7f528c768fe95c39229 # slack-notify-git-ref@0.1.0
+        uses: smartcontractkit/.github/actions/slack-notify-git-ref@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # slack-notify-git-ref@0.1.4
         with:
           slack-channel-id: ${{ secrets.SLACK_CHANNEL_MCMS }}
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN_RELENG }} # Releng Bot


### PR DESCRIPTION
In our current run for test and e2e test, we always get spammed with thousands of line of `Cannot open: File exists` [here](https://github.com/smartcontractkit/mcms/actions/runs/13296746002/job/37130333507), causing the logs to take a while to load and scrolling takes ages. 

The new `ci-test-go` fixes this issue as seen [here](https://github.com/smartcontractkit/mcms/actions/runs/13297142750/job/37131542022).

I also updated the other github actions at while i am here.


## logs spamming
<img width="1425" alt="Screenshot 2025-02-13 at 11 02 31 am" src="https://github.com/user-attachments/assets/381da3a3-2f7e-45aa-9f99-2c4fdc9869ce" />



