### PR TITLE
fix(timelock): clean up

### DIFF
--- a/e2e/tests/solana/timelock_converter.go
+++ b/e2e/tests/solana/timelock_converter.go
@@ -99,7 +99,6 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 	operation2BypasserPDA, err := solanasdk.FindTimelockBypasserOperationPDA(s.TimelockProgramID, testPDASeedTimelockConverter, operation2ID)
 	s.Require().NoError(err)
 
-	s.Require().NoError(err)
 	metadata, err := solanasdk.NewChainMetadata(
 		0,
 		s.MCMProgramID,
@@ -338,7 +337,6 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 		s.Require().NoError(err)
 
 		// build expected output Proposal
-		s.Require().NoError(err)
 		wantProposal, err := mcms.NewProposalBuilder().
 			SetValidUntil(uint32(validUntil)).
 			SetDescription("proposal to test the timelock proposal converter").
@@ -392,7 +390,6 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 		bypasserAC := s.Roles[timelock.Bypasser_Role].AccessController.PublicKey()
 
 		// build expected output Proposal
-		s.Require().NoError(err)
 		wantProposal, err := mcms.NewProposalBuilder().
 			SetValidUntil(uint32(validUntil)).
 			SetDescription("proposal to test the timelock proposal converter").

--- a/factory.go
+++ b/factory.go
@@ -42,12 +42,9 @@ func newEncoder(
 	return encoder, nil
 }
 
-// newTimelockConverterFromExecutor returns a new TimelockConverter that can convert timelock proposals
+// newTimelockConverter a new TimelockConverter that can convert timelock proposals
 // for the given chain.
-func newTimelockConverterFromExecutor(
-	csel types.ChainSelector,
-	executor sdk.TimelockExecutor,
-) (sdk.TimelockConverter, error) {
+func newTimelockConverter(csel types.ChainSelector) (sdk.TimelockConverter, error) {
 	family, err := types.GetChainSelectorFamily(csel)
 	if err != nil {
 		return nil, err
@@ -61,6 +58,6 @@ func newTimelockConverterFromExecutor(
 		return &solana.TimelockConverter{}, nil
 
 	default:
-		return nil, fmt.Errorf("unsupported executor type: %T", executor)
+		return nil, fmt.Errorf("unsupported chain family %s", family)
 	}
 }

--- a/factory_test.go
+++ b/factory_test.go
@@ -3,8 +3,6 @@ package mcms
 import (
 	"testing"
 
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -92,35 +90,28 @@ func Test_NewEncoder(t *testing.T) {
 	}
 }
 
-func Test_newTimelockConverterFromExecutor(t *testing.T) {
+func Test_newTimelockConverter(t *testing.T) {
 	t.Parallel()
-
-	solanaClient := &rpc.Client{}
-	solanaAuth, _ := solana.NewRandomPrivateKey()
 
 	tests := []struct {
 		name          string
 		chainSelector types.ChainSelector
-		executor      sdk.TimelockExecutor
 		want          sdk.TimelockConverter
 		wantErr       string
 	}{
 		{
 			name:          "success: EVM executor",
 			chainSelector: chaintest.Chain1Selector,
-			executor:      &evmsdk.TimelockExecutor{},
 			want:          &evmsdk.TimelockConverter{},
 		},
 		{
 			name:          "success: Solana executor",
 			chainSelector: chaintest.Chain4Selector,
-			executor:      solanasdk.NewTimelockExecutor(solanaClient, solanaAuth),
 			want:          &solanasdk.TimelockConverter{},
 		},
 		{
 			name:          "failure: unknown selector",
 			chainSelector: types.ChainSelector(123456789),
-			executor:      &UnknownTimelockExecutor{},
 			wantErr:       "chain family not found for selector 123456789",
 		},
 	}
@@ -128,7 +119,7 @@ func Test_newTimelockConverterFromExecutor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := newTimelockConverterFromExecutor(tt.chainSelector, tt.executor)
+			got, err := newTimelockConverter(tt.chainSelector)
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)
@@ -138,8 +129,4 @@ func Test_newTimelockConverterFromExecutor(t *testing.T) {
 			}
 		})
 	}
-}
-
-type UnknownTimelockExecutor struct {
-	sdk.TimelockExecutor
 }

--- a/sdk/mocks/timelock_converter.go
+++ b/sdk/mocks/timelock_converter.go
@@ -25,9 +25,9 @@ func (_m *TimelockConverter) EXPECT() *TimelockConverter_Expecter {
 	return &TimelockConverter_Expecter{mock: &_m.Mock}
 }
 
-// ConvertBatchToChainOperations provides a mock function with given fields: ctx, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt
-func (_m *TimelockConverter) ConvertBatchToChainOperations(ctx context.Context, bop types.BatchOperation, timelockAddress string, mcmAddress string, delay types.Duration, action types.TimelockAction, predecessor common.Hash, salt common.Hash) ([]types.Operation, common.Hash, error) {
-	ret := _m.Called(ctx, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
+// ConvertBatchToChainOperations provides a mock function with given fields: ctx, metadata, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt
+func (_m *TimelockConverter) ConvertBatchToChainOperations(ctx context.Context, metadata types.ChainMetadata, bop types.BatchOperation, timelockAddress string, mcmAddress string, delay types.Duration, action types.TimelockAction, predecessor common.Hash, salt common.Hash) ([]types.Operation, common.Hash, error) {
+	ret := _m.Called(ctx, metadata, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ConvertBatchToChainOperations")
@@ -36,27 +36,27 @@ func (_m *TimelockConverter) ConvertBatchToChainOperations(ctx context.Context, 
 	var r0 []types.Operation
 	var r1 common.Hash
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) ([]types.Operation, common.Hash, error)); ok {
-		return rf(ctx, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
+	if rf, ok := ret.Get(0).(func(context.Context, types.ChainMetadata, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) ([]types.Operation, common.Hash, error)); ok {
+		return rf(ctx, metadata, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) []types.Operation); ok {
-		r0 = rf(ctx, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
+	if rf, ok := ret.Get(0).(func(context.Context, types.ChainMetadata, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) []types.Operation); ok {
+		r0 = rf(ctx, metadata, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]types.Operation)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) common.Hash); ok {
-		r1 = rf(ctx, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
+	if rf, ok := ret.Get(1).(func(context.Context, types.ChainMetadata, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) common.Hash); ok {
+		r1 = rf(ctx, metadata, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(common.Hash)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) error); ok {
-		r2 = rf(ctx, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
+	if rf, ok := ret.Get(2).(func(context.Context, types.ChainMetadata, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) error); ok {
+		r2 = rf(ctx, metadata, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -71,6 +71,7 @@ type TimelockConverter_ConvertBatchToChainOperations_Call struct {
 
 // ConvertBatchToChainOperations is a helper method to define mock.On call
 //   - ctx context.Context
+//   - metadata types.ChainMetadata
 //   - bop types.BatchOperation
 //   - timelockAddress string
 //   - mcmAddress string
@@ -78,13 +79,13 @@ type TimelockConverter_ConvertBatchToChainOperations_Call struct {
 //   - action types.TimelockAction
 //   - predecessor common.Hash
 //   - salt common.Hash
-func (_e *TimelockConverter_Expecter) ConvertBatchToChainOperations(ctx interface{}, bop interface{}, timelockAddress interface{}, mcmAddress interface{}, delay interface{}, action interface{}, predecessor interface{}, salt interface{}) *TimelockConverter_ConvertBatchToChainOperations_Call {
-	return &TimelockConverter_ConvertBatchToChainOperations_Call{Call: _e.mock.On("ConvertBatchToChainOperations", ctx, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)}
+func (_e *TimelockConverter_Expecter) ConvertBatchToChainOperations(ctx interface{}, metadata interface{}, bop interface{}, timelockAddress interface{}, mcmAddress interface{}, delay interface{}, action interface{}, predecessor interface{}, salt interface{}) *TimelockConverter_ConvertBatchToChainOperations_Call {
+	return &TimelockConverter_ConvertBatchToChainOperations_Call{Call: _e.mock.On("ConvertBatchToChainOperations", ctx, metadata, bop, timelockAddress, mcmAddress, delay, action, predecessor, salt)}
 }
 
-func (_c *TimelockConverter_ConvertBatchToChainOperations_Call) Run(run func(ctx context.Context, bop types.BatchOperation, timelockAddress string, mcmAddress string, delay types.Duration, action types.TimelockAction, predecessor common.Hash, salt common.Hash)) *TimelockConverter_ConvertBatchToChainOperations_Call {
+func (_c *TimelockConverter_ConvertBatchToChainOperations_Call) Run(run func(ctx context.Context, metadata types.ChainMetadata, bop types.BatchOperation, timelockAddress string, mcmAddress string, delay types.Duration, action types.TimelockAction, predecessor common.Hash, salt common.Hash)) *TimelockConverter_ConvertBatchToChainOperations_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(types.BatchOperation), args[2].(string), args[3].(string), args[4].(types.Duration), args[5].(types.TimelockAction), args[6].(common.Hash), args[7].(common.Hash))
+		run(args[0].(context.Context), args[1].(types.ChainMetadata), args[2].(types.BatchOperation), args[3].(string), args[4].(string), args[5].(types.Duration), args[6].(types.TimelockAction), args[7].(common.Hash), args[8].(common.Hash))
 	})
 	return _c
 }
@@ -94,7 +95,7 @@ func (_c *TimelockConverter_ConvertBatchToChainOperations_Call) Return(_a0 []typ
 	return _c
 }
 
-func (_c *TimelockConverter_ConvertBatchToChainOperations_Call) RunAndReturn(run func(context.Context, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) ([]types.Operation, common.Hash, error)) *TimelockConverter_ConvertBatchToChainOperations_Call {
+func (_c *TimelockConverter_ConvertBatchToChainOperations_Call) RunAndReturn(run func(context.Context, types.ChainMetadata, types.BatchOperation, string, string, types.Duration, types.TimelockAction, common.Hash, common.Hash) ([]types.Operation, common.Hash, error)) *TimelockConverter_ConvertBatchToChainOperations_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sdk/solana/chain_metadata.go
+++ b/sdk/solana/chain_metadata.go
@@ -76,7 +76,7 @@ func NewChainMetadata(
 	}, nil
 }
 
-// NewChainMetadataFromTimelock creates a new ChainMetadata from and RPC client
+// NewChainMetadataFromTimelock creates a new ChainMetadata from an RPC client
 // useful when access controller accounts are not available for the client
 func NewChainMetadataFromTimelock(
 	ctx context.Context,

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -36,8 +36,7 @@ func NewTimelockExecutable(
 
 func (t *TimelockExecutable) GetOpID(ctx context.Context, opIdx int, bop types.BatchOperation, selector types.ChainSelector) (common.Hash, error) {
 	// Convert the batch operation
-	executor := t.executors[selector]
-	converter, err := newTimelockConverterFromExecutor(selector, executor)
+	converter, err := newTimelockConverter(selector)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("unable to create converter from executor: %w", err)
 	}
@@ -199,8 +198,8 @@ func (t *TimelockExecutable) setPredecessors(ctx context.Context) error {
 	if len(t.predecessors) == 0 && len(t.executors) > 0 {
 		var err error
 		var converters = make(map[types.ChainSelector]sdk.TimelockConverter)
-		for chainSelector, executor := range t.executors {
-			converters[chainSelector], err = newTimelockConverterFromExecutor(chainSelector, executor)
+		for chainSelector := range t.executors {
+			converters[chainSelector], err = newTimelockConverter(chainSelector)
 			if err != nil {
 				return fmt.Errorf("unable to create converter from executor: %w", err)
 			}


### PR DESCRIPTION
A few clean up were missed from the previous [PR](https://github.com/smartcontractkit/mcms/pull/313) on removing the rpc.Client dependency on the timelock converter.

- newTimelockConverterFromExecutor no longer needs the executor
- a few unneeded require.NoError check
- missing test assertion
- mockery regeneration