### PR TITLE
fix: update changeset to minor to keep ourselves on the 0.x versions

### DIFF
--- a/.changeset/hip-adults-sniff.md
+++ b/.changeset/hip-adults-sniff.md
@@ -1,5 +1,5 @@
 ---
-"@smartcontractkit/mcms": major
+"@smartcontractkit/mcms": minor
 ---
 
 fix: make predecessors parameter optional on NewProposal and NewTimelockProposal


### PR DESCRIPTION
We are still not going to V1 so we'll keep breaking changes as minor versions