### PR TITLE
fix: set predecessors in constructor

### DIFF
--- a/.changeset/metal-terms-attack.md
+++ b/.changeset/metal-terms-attack.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+setPredecessors in constructor and refactor

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -115,6 +115,14 @@ func (t *TimelockExecutable) IsChainReady(ctx context.Context, chainSelector typ
 }
 
 func (t *TimelockExecutable) IsOperationReady(ctx context.Context, idx int) error {
+	// setPredecessors populates t.predecessors[chainSelector] = []common.Hash
+	// (one array per chain). The 0th element is zero-hash, the 1st is the
+	// operationID for that chain's 1st operation, etc.
+	err := t.setPredecessors(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to set predecessors: %w", err)
+	}
+
 	op := t.proposal.Operations[idx]
 
 	cs := op.ChainSelector

--- a/timelock_executable_test.go
+++ b/timelock_executable_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	geth_types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -26,7 +24,6 @@ import (
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
 	"github.com/smartcontractkit/mcms/sdk/mocks"
-	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/smartcontractkit/mcms/types"
 )
 
@@ -99,10 +96,56 @@ func Test_NewTimelockExecutable(t *testing.T) {
 				Operations:        batchOps,
 			},
 			giveExecutors: map[types.ChainSelector]sdk.TimelockExecutor{
-				types.ChainSelector(1): executor,
+				chaintest.Chain1Selector: executor,
 			},
 			wantErr:    false,
 			wantErrMsg: "",
+		},
+		{
+			name: "failure: converter from executor error",
+			giveProposal: &TimelockProposal{
+				BaseProposal: BaseProposal{
+					Version:              "v1",
+					Kind:                 types.KindTimelockProposal,
+					Description:          "description",
+					ValidUntil:           2004259681,
+					OverridePreviousRoot: false,
+					Signatures:           []types.Signature{},
+					ChainMetadata:        chainMetadata,
+				},
+				Action:            types.TimelockActionSchedule,
+				Delay:             types.MustParseDuration("1h"),
+				TimelockAddresses: timelockAddresses,
+				Operations:        batchOps,
+			},
+			giveExecutors: map[types.ChainSelector]sdk.TimelockExecutor{
+				types.ChainSelector(1): executor,
+			},
+			wantErr:    true,
+			wantErrMsg: "unable to set predecessors: unable to create converter from executor: chain family not found for selector",
+		},
+		{
+			name: "failure: convert error",
+			giveProposal: &TimelockProposal{
+				BaseProposal: BaseProposal{
+					Version:              "v1",
+					Kind:                 types.KindTimelockProposal,
+					Description:          "description",
+					ValidUntil:           2004259681,
+					OverridePreviousRoot: false,
+					Signatures:           []types.Signature{},
+					ChainMetadata:        chainMetadata,
+				},
+				Action:            types.TimelockActionSchedule,
+				Delay:             types.MustParseDuration("1h"),
+				TimelockAddresses: timelockAddresses,
+				Operations:        batchOps,
+			},
+			giveExecutors: map[types.ChainSelector]sdk.TimelockExecutor{
+				chaintest.Chain2Selector: executor,
+			},
+			wantErr:    true,
+			wantErrMsg: "unable to set predecessors: unable to find converter for chain selector",
 		},
 	}
 
@@ -204,34 +247,6 @@ func Test_TimelockExecutable_Execute(t *testing.T) {
 			},
 			option: WithCallProxy("0xABCD"),
 			want:   "signature",
-		},
-		{
-			name: "failure: converter from executor error",
-			setup: func(t *testing.T) (*TimelockProposal, map[types.ChainSelector]sdk.TimelockExecutor) {
-				t.Helper()
-				executors := map[types.ChainSelector]sdk.TimelockExecutor{
-					types.ChainSelector(12345789): mocks.NewTimelockExecutor(t),
-				}
-
-				return defaultProposal(), executors
-			},
-			wantErr: "unable to set predecessors: unable to create converter from executor: chain family not found for selector",
-		},
-		{
-			name: "failure: convert error",
-			setup: func(t *testing.T) (*TimelockProposal, map[types.ChainSelector]sdk.TimelockExecutor) {
-				t.Helper()
-
-				solanaClient := &rpc.Client{}
-				solanaAuth, err := solana.NewRandomPrivateKey()
-				require.NoError(t, err)
-				executors := map[types.ChainSelector]sdk.TimelockExecutor{
-					chaintest.Chain4Selector: solanasdk.NewTimelockExecutor(solanaClient, solanaAuth),
-				}
-
-				return defaultProposal(), executors
-			},
-			wantErr: "unable to set predecessors: unable to find converter for chain selector",
 		},
 		{
 			name: "failure: execute error",


### PR DESCRIPTION
This pull request includes several changes to the `timelock_executable.go` file and its corresponding tests to refactor the `setPredecessors` method and improve error handling. The most important changes include moving the `setPredecessors` call to the constructor, removing redundant calls to `setPredecessors` in other methods, and updating test cases accordingly.

Refactoring and error handling improvements:

* [`timelock_executable.go`](diffhunk://#diff-5a1d103cef63b5dba0cfe2c93618b65a233c43862c69a6ba89fbee2b09bbc1ceL31-R44): Moved the `setPredecessors` call to the constructor `NewTimelockExecutable` and removed redundant calls to `setPredecessors` in the `IsReady`, `IsChainReady`, and `Execute` methods. [[1]](diffhunk://#diff-5a1d103cef63b5dba0cfe2c93618b65a233c43862c69a6ba89fbee2b09bbc1ceL31-R44) [[2]](diffhunk://#diff-5a1d103cef63b5dba0cfe2c93618b65a233c43862c69a6ba89fbee2b09bbc1ceL75-L82) [[3]](diffhunk://#diff-5a1d103cef63b5dba0cfe2c93618b65a233c43862c69a6ba89fbee2b09bbc1ceL96-L103) [[4]](diffhunk://#diff-5a1d103cef63b5dba0cfe2c93618b65a233c43862c69a6ba89fbee2b09bbc1ceL175-L179)

Test updates:

* [`timelock_executable_test.go`](diffhunk://#diff-2ee0863eda6e2cdffe4fda89ec41b6a744cf57c0028ffba28c5d2b7bab8cbc55L15-L16): Removed unused Solana imports and updated test cases to reflect the changes in `timelock_executable.go`. Added new test cases for error scenarios related to `setPredecessors`. [[1]](diffhunk://#diff-2ee0863eda6e2cdffe4fda89ec41b6a744cf57c0028ffba28c5d2b7bab8cbc55L15-L16) [[2]](diffhunk://#diff-2ee0863eda6e2cdffe4fda89ec41b6a744cf57c0028ffba28c5d2b7bab8cbc55L29) [[3]](diffhunk://#diff-2ee0863eda6e2cdffe4fda89ec41b6a744cf57c0028ffba28c5d2b7bab8cbc55L102-R149) [[4]](diffhunk://#diff-2ee0863eda6e2cdffe4fda89ec41b6a744cf57c0028ffba28c5d2b7bab8cbc55L208-L235)

Documentation:

* [`.changeset/metal-terms-attack.md`](diffhunk://#diff-0106d178e029a5f01859c3d39648e6ebff620d35a78ebe45b53e3b49b1b0a8d2R1-R5): Added a changeset entry for the refactor of `setPredecessors` in the constructor.