### PR TITLE
[DPA-1584]: fix(solana): update rootSignaturesPDA to include new seed

### DIFF
--- a/.changeset/nasty-teachers-relax.md
+++ b/.changeset/nasty-teachers-relax.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+solana: update rootSignaturesPDA to include authority as new seed

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/karalabe/hid v1.0.1-0.20240306101548-573246063e52
 	github.com/smartcontractkit/chain-selectors v1.0.36
-	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01
+	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250226104101-11778f2ead98
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,10 @@ github.com/smartcontractkit/chain-selectors v1.0.36 h1:KSpO8I+JOiuyN4FuXsV471sPo
 github.com/smartcontractkit/chain-selectors v1.0.36/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01 h1:R3OD6Phi0ULIQ2uvHiKVWYdgpi/O1Mt46CUK1UApcXU=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250214202341-4190f2db1c01/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250225164838-7c5ccfb7353e h1:jYPm/3OMAfZ+D0jaLQGl0pR7+WCJ6u1tSnJyQL2B4rY=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250225164838-7c5ccfb7353e/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250226104101-11778f2ead98 h1:uHdawaiGBA3Xmju92tzbQ2SwsG2DDVJS5E+Jm5QnsQg=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250226104101-11778f2ead98/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
 github.com/smartcontractkit/chainlink-common v0.4.0 h1:GZ9MhHt5QHXSaK/sAZvKDxkEqF4fPiFHWHEPqs/2C2o=
 github.com/smartcontractkit/chainlink-common v0.4.0/go.mod h1:yti7e1+G9hhkYhj+L5sVUULn9Bn3bBL5/AxaNqdJ5YQ=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7 h1:E7k5Sym9WnMOc4X40lLnQb6BMosxi8DfUBU9pBJjHOQ=

--- a/sdk/solana/common.go
+++ b/sdk/solana/common.go
@@ -45,9 +45,9 @@ func FindExpiringRootAndOpCountPDA(programID solana.PublicKey, pdaSeed PDASeed) 
 }
 
 func FindRootSignaturesPDA(
-	programID solana.PublicKey, msigID PDASeed, root common.Hash, validUntil uint32,
+	programID solana.PublicKey, msigID PDASeed, root common.Hash, validUntil uint32, authority solana.PublicKey,
 ) (solana.PublicKey, error) {
-	seeds := [][]byte{[]byte("root_signatures"), msigID[:], root[:], validUntilBytes(validUntil)}
+	seeds := [][]byte{[]byte("root_signatures"), msigID[:], root[:], validUntilBytes(validUntil), authority[:]}
 	return findPDA(programID, seeds)
 }
 

--- a/sdk/solana/common_test.go
+++ b/sdk/solana/common_test.go
@@ -67,9 +67,12 @@ func Test_FindExpiringRootAndOpCountPDA(t *testing.T) {
 
 func Test_FindRootSignaturesPDA(t *testing.T) {
 	t.Parallel()
-	pda, err := FindRootSignaturesPDA(testMCMProgramID, testPDASeed, testRoot, 1735689600)
+	authority, err := solana.PublicKeyFromBase58("LoCoNsJFuhTkSQjfdDfn3yuwqhSYoPujmviRHVCzsqn")
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(pda, solana.MustPublicKeyFromBase58("528jBx5Mn1EPt4vG47CRkr1zhj8QVfSMvfvBZksZdrHr")))
+
+	pda, err := FindRootSignaturesPDA(testMCMProgramID, testPDASeed, testRoot, 1735689600, authority)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(pda, solana.MustPublicKeyFromBase58("98m4KuqTruBS7oXDm4Kzq43TmF1Lih3J6pHHZ6Lo9hty")))
 }
 
 func Test_FindSeenSignedHashesPDA(t *testing.T) {

--- a/sdk/solana/executor.go
+++ b/sdk/solana/executor.go
@@ -153,7 +153,7 @@ func (e *Executor) SetRoot(
 	if err != nil {
 		return types.TransactionResult{}, err
 	}
-	rootSignaturesPDA, err := FindRootSignaturesPDA(programID, pdaSeed, root, validUntil)
+	rootSignaturesPDA, err := FindRootSignaturesPDA(programID, pdaSeed, root, validUntil, e.auth.PublicKey())
 	if err != nil {
 		return types.TransactionResult{}, err
 	}


### PR DESCRIPTION
Include authority as part of the rootSignaturesPDA seed

**Do not merge** this PR until 
- core repo [supports the latest version](https://github.com/smartcontractkit/mcms/pull/320) of chainlink-ccip/solana
- ~Jade's [PR](https://github.com/smartcontractkit/chainlink-ccip/pull/657) is merged~

Context: https://chainlink-core.slack.com/archives/C084CRQEQ5B/p1740497581832509?thread_ts=1740130591.644569&cid=C084CRQEQ5B

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1584