### PR TITLE
fix: allow empty accounts in solana additional fields for transactions

### DIFF
--- a/.changeset/silver-beans-design.md
+++ b/.changeset/silver-beans-design.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+allow empty accounts in solana additional fields for transactions

--- a/sdk/solana/transaction.go
+++ b/sdk/solana/transaction.go
@@ -17,7 +17,7 @@ func ValidateAdditionalFields(additionalFields json.RawMessage) error {
 	}
 	if len(additionalFields) != 0 {
 		if err := json.Unmarshal(additionalFields, &fields); err != nil {
-			return fmt.Errorf("failed to unmarshal EVM additional fields: %w", err)
+			return fmt.Errorf("failed to unmarshal solana additional fields: %w", err)
 		}
 	}
 
@@ -29,7 +29,7 @@ func ValidateAdditionalFields(additionalFields json.RawMessage) error {
 }
 
 type AdditionalFields struct {
-	Accounts []*solana.AccountMeta `json:"accounts" validate:"required"`
+	Accounts []*solana.AccountMeta `json:"accounts" validate:"omitempty"`
 	Value    *big.Int              `json:"value" validate:"omitempty"`
 }
 


### PR DESCRIPTION
This pull request includes changes to the Solana SDK to allow empty accounts in the additional fields for transactions. The changes allow solana transactions to include empty account slices or `nil` account slices.

### Validation updates:

* [`sdk/solana/transaction.go`](diffhunk://#diff-818b97cb2182dd9070d9b993ec0a302ce1b35ca68828dd0013efb2523dd67567L20-R20): Modified the `AdditionalFields` struct to make the `Accounts` field optional by changing the validation tag from `required` to `omitempty`. Also updated the error message in `ValidateAdditionalFields` to correctly reference Solana instead of EVM. [[1]](diffhunk://#diff-818b97cb2182dd9070d9b993ec0a302ce1b35ca68828dd0013efb2523dd67567L20-R20) [[2]](diffhunk://#diff-818b97cb2182dd9070d9b993ec0a302ce1b35ca68828dd0013efb2523dd67567L32-R32)

### Test additions:

* [`sdk/solana/transaction_test.go`](diffhunk://#diff-31bead2377fc131bd4de0aad5e09a1f88d4e5219ac05024bb3be8903af83e8e1R4-R5): Added import statements for `encoding/json` and `math/big`.
* [`sdk/solana/transaction_test.go`](diffhunk://#diff-31bead2377fc131bd4de0aad5e09a1f88d4e5219ac05024bb3be8903af83e8e1R64-R172): Added `TestValidateAdditionalFields` to test various scenarios for the `ValidateAdditionalFields` function, including valid fields, missing accounts, empty accounts, malformed JSON, and empty input.
* [`sdk/solana/transaction_test.go`](diffhunk://#diff-31bead2377fc131bd4de0aad5e09a1f88d4e5219ac05024bb3be8903af83e8e1R64-R172): Added `TestAdditionalFieldsValidate` to test the `Validate` method of the `AdditionalFields` struct with different account configurations.

### Documentation:

* [`.changeset/silver-beans-design.md`](diffhunk://#diff-9774278eb988dd2dfd819b6b73aa54cc8c79ac5a8054349aaa9891f3bdf75b24R1-R5): Added a changeset to document the patch for allowing empty accounts in Solana additional fields for transactions.