### PR TITLE
feat: add IsOperationDone and IsChainDone to timelock executable

### DIFF
--- a/.changeset/tall-tigers-wave.md
+++ b/.changeset/tall-tigers-wave.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+feat: add IsOperationDone and IsChainDone to TimelockExecutable

--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,16 @@ func (e *OperationNotReadyError) Error() string {
 	return fmt.Sprintf("operation %d is not ready", e.OpIndex)
 }
 
+// OperationNotDoneError is returned when an operation is not yet done.
+type OperationNotDoneError struct {
+	OpIndex int
+}
+
+// Error implements the error interface.
+func (e *OperationNotDoneError) Error() string {
+	return fmt.Sprintf("operation %d is not done", e.OpIndex)
+}
+
 // InvalidProposalKindError is returned when an invalid proposal kind is provided.
 type InvalidProposalKindError struct {
 	ProvidedKind types.ProposalKind


### PR DESCRIPTION
In order to support concurrent timelock executions between the chainlink-deployments CI and the legacy timelock-worker service, the GHA running on the CI need to be able to check if an operation and/or the operations of a chain have been marked as "done" by the timelock worker.

This PR adds two methods to the TimelockExecutable type, implementing these two checks. The implementation was adapted from the existing methods: `IsOperationReady` and `IsChainReady`.

JIRA: [DPA-1613](https://smartcontract-it.atlassian.net/browse/DPA-1613)

[DPA-1613]: https://smartcontract-it.atlassian.net/browse/DPA-1613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ