### PR TITLE
feat: add utils to generate cancel / bypass proposals from timelock schedule proposal

### DIFF
--- a/.changeset/shy-suits-join.md
+++ b/.changeset/shy-suits-join.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Add proposal cancel and bypass helpers

--- a/timelock_proposal.go
+++ b/timelock_proposal.go
@@ -115,6 +115,7 @@ func (m *TimelockProposal) DeriveCancellationProposal() (TimelockProposal, error
 	newProposal := *m
 	newProposal.Signatures = []types.Signature{}
 	newProposal.Action = types.TimelockActionCancel
+
 	return newProposal, nil
 }
 
@@ -127,6 +128,7 @@ func (m *TimelockProposal) DeriveBypassProposal() (TimelockProposal, error) {
 	newProposal := *m
 	newProposal.Signatures = []types.Signature{}
 	newProposal.Action = types.TimelockActionBypass
+
 	return newProposal, nil
 }
 

--- a/timelock_proposal.go
+++ b/timelock_proposal.go
@@ -106,6 +106,30 @@ func (m *TimelockProposal) Validate() error {
 	return nil
 }
 
+// DeriveCancellationProposal derives a new proposal that cancels the current proposal.
+func (m *TimelockProposal) DeriveCancellationProposal() (TimelockProposal, error) {
+	if m.Action != types.TimelockActionSchedule {
+		return TimelockProposal{}, fmt.Errorf("cannot derive a cancellation proposal from a non-schedule proposal. Action needs to be of type 'schedule'")
+	}
+	// Create a copy of the current proposal, we don't want to affect the original proposal
+	newProposal := *m
+	newProposal.Signatures = []types.Signature{}
+	newProposal.Action = types.TimelockActionCancel
+	return newProposal, nil
+}
+
+// DeriveBypassProposal derives a new proposal that bypasses the current proposal.
+func (m *TimelockProposal) DeriveBypassProposal() (TimelockProposal, error) {
+	if m.Action != types.TimelockActionSchedule {
+		return TimelockProposal{}, fmt.Errorf("cannot derive a bypass proposal from a non-schedule proposal. Action needs to be of type 'schedule'")
+	}
+	// Create a copy of the current proposal, we don't want to affect the original proposal
+	newProposal := *m
+	newProposal.Signatures = []types.Signature{}
+	newProposal.Action = types.TimelockActionBypass
+	return newProposal, nil
+}
+
 // Convert the proposal to an MCMS only proposal and also return all predecessors for easy access later.
 // Every transaction to be sent from the Timelock is encoded with the corresponding timelock method.
 func (m *TimelockProposal) Convert(

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -990,8 +990,13 @@ func TestDeriveBypassProposal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			newProposal, err := tt.proposal.DeriveBypassProposal()
+			dummyAddressess := map[types.ChainSelector]types.ChainMetadata{
+				chaintest.Chain2Selector: {
+					StartingOpCount: 1,
+					MCMAddress:      "0x0000000000000000000000000000000000000001",
+				},
+			}
+			newProposal, err := tt.proposal.DeriveBypassProposal(dummyAddressess)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.EqualError(t, err, "cannot derive a bypass proposal from a non-schedule proposal. Action needs to be of type 'schedule'")
@@ -1000,6 +1005,8 @@ func TestDeriveBypassProposal(t *testing.T) {
 				assert.Equal(t, tt.wantAction, newProposal.Action)
 				assert.Empty(t, newProposal.Signatures)
 				assert.NotEqual(t, tt.proposal, newProposal)
+				assert.NotEqual(t, newProposal.Salt(), tt.proposal.Salt())
+				assert.Equal(t, dummyAddressess, newProposal.ChainMetadata)
 			}
 		})
 	}
@@ -1031,8 +1038,13 @@ func TestDeriveCancellationProposal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			newProposal, err := tt.proposal.DeriveCancellationProposal()
+			dummyAddressess := map[types.ChainSelector]types.ChainMetadata{
+				chaintest.Chain2Selector: {
+					StartingOpCount: 1,
+					MCMAddress:      "0x0000000000000000000000000000000000000001",
+				},
+			}
+			newProposal, err := tt.proposal.DeriveCancellationProposal(dummyAddressess)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.EqualError(t, err, "cannot derive a cancellation proposal from a non-schedule proposal. Action needs to be of type 'schedule'")
@@ -1041,6 +1053,8 @@ func TestDeriveCancellationProposal(t *testing.T) {
 				assert.Equal(t, tt.wantAction, newProposal.Action)
 				assert.Empty(t, newProposal.Signatures)
 				assert.NotEqual(t, tt.proposal, newProposal)
+				assert.NotEqual(t, newProposal.Salt(), tt.proposal.Salt())
+				assert.Equal(t, dummyAddressess, newProposal.ChainMetadata)
 			}
 		})
 	}

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -1005,7 +1005,7 @@ func TestDeriveBypassProposal(t *testing.T) {
 				assert.Equal(t, tt.wantAction, newProposal.Action)
 				assert.Empty(t, newProposal.Signatures)
 				assert.NotEqual(t, tt.proposal, newProposal)
-				assert.NotEqual(t, newProposal.Salt(), tt.proposal.Salt())
+				assert.Equal(t, newProposal.Salt(), tt.proposal.Salt())
 				assert.Equal(t, dummyAddressess, newProposal.ChainMetadata)
 			}
 		})
@@ -1053,7 +1053,7 @@ func TestDeriveCancellationProposal(t *testing.T) {
 				assert.Equal(t, tt.wantAction, newProposal.Action)
 				assert.Empty(t, newProposal.Signatures)
 				assert.NotEqual(t, tt.proposal, newProposal)
-				assert.NotEqual(t, newProposal.Salt(), tt.proposal.Salt())
+				assert.Equal(t, newProposal.Salt(), tt.proposal.Salt())
 				assert.Equal(t, dummyAddressess, newProposal.ChainMetadata)
 			}
 		})

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -960,10 +960,13 @@ func buildDummyProposal(action types.TimelockAction) TimelockProposal {
 	if err != nil {
 		panic(err)
 	}
+
 	return *proposal
 }
 
 func TestDeriveBypassProposal(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		proposal   TimelockProposal
@@ -986,6 +989,8 @@ func TestDeriveBypassProposal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			newProposal, err := tt.proposal.DeriveBypassProposal()
 			if tt.wantErr {
 				require.Error(t, err)
@@ -1001,6 +1006,8 @@ func TestDeriveBypassProposal(t *testing.T) {
 }
 
 func TestDeriveCancellationProposal(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		proposal   TimelockProposal
@@ -1023,6 +1030,8 @@ func TestDeriveCancellationProposal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			newProposal, err := tt.proposal.DeriveCancellationProposal()
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
add utils to generate cancel / bypass proposals from timelock schedule proposal

## AI Summary
This pull request introduces new methods to the `TimelockProposal` struct in `timelock_proposal.go` to enhance its functionality. The most significant changes include the addition of methods to derive cancellation and bypass proposals from an existing proposal.

Enhancements to `TimelockProposal`:

* Added `DeriveCancellationProposal` method to derive a new proposal that cancels the current proposal. This method ensures the original proposal remains unaffected and returns an error if the action is not of type 'schedule'.
* Added `DeriveBypassProposal` method to derive a new proposal that bypasses the current proposal. Similar to the cancellation method, it ensures the original proposal remains unaffected and returns an error if the action is not of type 'schedule'.