### PR TITLE
fix: use GetSlot+GetBlockTime to retrieve the current time in Solana

### DIFF
--- a/.changeset/light-bags-behave.md
+++ b/.changeset/light-bags-behave.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix: use GetLatestBlockhash to retrive curr. block time in Solana

--- a/sdk/solana/timelock_inspector.go
+++ b/sdk/solana/timelock_inspector.go
@@ -96,9 +96,14 @@ func (t TimelockInspector) IsOperationReady(ctx context.Context, address string,
 		return false, err
 	}
 
-	blockTime, err := solanaCommon.GetBlockTime(ctx, t.client, rpc.CommitmentConfirmed)
+	slot, err := t.client.GetSlot(ctx, rpc.CommitmentConfirmed)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to get slot: %w", err)
+	}
+
+	blockTime, err := t.client.GetBlockTime(ctx, slot)
+	if err != nil {
+		return false, fmt.Errorf("failed to get block time: %w", err)
 	}
 
 	ts, err := safecast.Uint64ToInt64(op.Timestamp)

--- a/sdk/solana/timelock_inspector_test.go
+++ b/sdk/solana/timelock_inspector_test.go
@@ -419,7 +419,7 @@ func TestTimelockInspector_IsOperationReady(t *testing.T) {
 				mockGetAccountInfo(t, mockJSONRPCClient, operationPDA, operation, nil)
 				mockGetBlockTime(t, mockJSONRPCClient, 1, &blockTime, errors.New("rpc error"), nil)
 			},
-			wantErr: "failed to get block height: rpc error",
+			wantErr: "failed to get slot: rpc error",
 		},
 		{
 			name: "error: GetBlockTime rpc error",

--- a/sdk/solana/utils_test.go
+++ b/sdk/solana/utils_test.go
@@ -46,20 +46,20 @@ func mockGetAccountInfo(
 }
 
 func mockGetBlockTime(
-	t *testing.T, client *mocks.JSONRPCClient, block uint64,
+	t *testing.T, client *mocks.JSONRPCClient, slot uint64,
 	blockTime *solana.UnixTimeSeconds, mockBlockHeightError error,
 	mockBlockTimeError error,
 ) {
 	t.Helper()
 
 	// mock getBlockHeight
-	client.EXPECT().CallForInto(anyContext, mock.Anything, "getBlockHeight",
+	client.EXPECT().CallForInto(anyContext, mock.Anything, "getSlot",
 		[]any{rpc.M{"commitment": rpc.CommitmentConfirmed}},
 	).RunAndReturn(func(_ context.Context, output any, _ string, _ []any) error {
 		result, ok := output.(*uint64)
 		require.True(t, ok)
 
-		*result = block // set block height as 1
+		*result = slot
 
 		return mockBlockHeightError
 	}).Once()
@@ -69,7 +69,7 @@ func mockGetBlockTime(
 	}
 
 	client.EXPECT().CallForInto(
-		anyContext, mock.Anything, "getBlockTime", []any{block},
+		anyContext, mock.Anything, "getBlockTime", []any{slot},
 	).RunAndReturn(func(_ context.Context, output any, _ string, _ []any) error {
 		result, ok := output.(**solana.UnixTimeSeconds)
 		require.True(t, ok)


### PR DESCRIPTION
The previous implementation, which used chainlink-ccip's `GetBlockTime()` helper function -- which, on its turn, used `rpc.GetBlockHeight` -- was returning an error in devnet:
```
  failed to get block time: (*jsonrpc.RPCError)(0xc0017784b0)({
   Code: (int) -32001,
   Message: (string) (len=84) "Block 357750972 cleaned up, does not exist on node. First available block: 362548764",
   Data: (interface {}) <nil>
})
```

This PR simply replaces the `GetBlockTime()` with direct calls to `rpc.GetSlot` and `rpc.GetBlockTime(slot)`.

[DPA-1636](https://smartcontract-it.atlassian.net/browse/DPA-1636)

[DPA-1636]: https://smartcontract-it.atlassian.net/browse/DPA-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ