### PR TITLE
Install Aptos CLI in push-main workflow

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -68,6 +68,10 @@ jobs:
         uses: metaplex-foundation/actions/install-solana@2389940047edc63a5781911f6a53fbdf784748d8 # v1.0.4
         with:
           version: 1.18.10
+      - name: Install Aptos CLI
+        uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
+        with:
+          CLI_VERSION: 7.0.0
       - name: Build and test
         uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/0.3.5
         with:


### PR DESCRIPTION
This installs the Aptos CLI in the `push-main` workflow