### PR TITLE
fix(solana): fix accounts added to BypassExecute instruction

### DIFF
--- a/.changeset/pretty-flies-chew.md
+++ b/.changeset/pretty-flies-chew.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+fix(solana): fix the accounts added to the BypassExecuteBatch instruction

--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -35,10 +35,10 @@ public_key ="9n1pyVGGo6V4mpiSDMVay5As9NurEkY283wwRk1Kto2C"
 
 
 [solana_config.solana_programs]
-mcm = "6UmMZr5MEqiKWD5jqTJd1WCR5kT8oZuFYBLJFi1o6GQX"
-timelock = "LoCoNsJFuhTkSQjfdDfn3yuwqhSYoPujmviRHVCzsqn"
-access_controller = "9xi644bRR8birboDGdTiwBq3C7VEeR7VuamRYYXCubUW"
-external_program_cpi_stub = "4HeqEoSyfYpeC2goFLj9eHgkxV33mR5G7JYAbRsN14uQ"
+mcm = "5vNJx78mz7KVMjhuipyr9jKBKcMrKYGdjGkgE4LUmjKk"
+timelock = "DoajfR5tK24xVw51fWcawUZWhAXD8yrBJVacc13neVQA"
+access_controller = "6KsN58MTnRQ8FfPaXHiFPPFGDRioikj9CdPvPxZJdCjb"
+external_program_cpi_stub = "2zZwzyptLqwFJFEFxjPvrdhiGpH9pJ3MfrrmZX6NTKxm"
 
 [aptos_config]
 type = "aptos"

--- a/e2e/tests/solana/set_root.go
+++ b/e2e/tests/solana/set_root.go
@@ -26,6 +26,7 @@ func (s *SolanaTestSuite) Test_Solana_SetRoot() {
 	// --- arrange ---
 	ctx := context.Background()
 	s.SetupMCM(testPDASeedSetRootTest)
+	s.SetupTimelock(testPDASeedSetRootTest, 1*time.Second)
 
 	mcmAddress := solanasdk.ContractAddress(s.MCMProgramID, testPDASeedSetRootTest)
 
@@ -92,6 +93,6 @@ func (s *SolanaTestSuite) Test_Solana_SetRoot() {
 
 	gotRoot, gotValidUntil, err := inspectors[s.ChainSelector].GetRoot(ctx, mcmAddress)
 	s.Require().NoError(err)
-	s.Require().Equal(common.HexToHash("0x11329486f2a7bb589320f2a8e9fad50fd5ed9ceeb3c1e2f71491d5ab848c7f60"), gotRoot)
+	s.Require().Equal(common.HexToHash("0x2b970fa3b929cafc45e8740e5123ebf150c519813bcf4d9c7284518fd5720108"), gotRoot)
 	s.Require().Equal(uint32(validUntil), gotValidUntil)
 }

--- a/e2e/tests/solana/timelock_converter.go
+++ b/e2e/tests/solana/timelock_converter.go
@@ -19,10 +19,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	cpistub "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/external_program_cpi_stub"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
+	solanaCommon "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/mcms"
-	testutils "github.com/smartcontractkit/mcms/e2e/utils/solana"
+	e2eutils "github.com/smartcontractkit/mcms/e2e/utils/solana"
 	"github.com/smartcontractkit/mcms/sdk"
 	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/smartcontractkit/mcms/types"
@@ -46,11 +47,13 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 	s.Require().NoError(err)
 	s.AssignRoleToAccounts(ctx, testPDASeedTimelockConverter, wallet, []solana.PublicKey{mcmSignerPDA},
 		timelock.Proposer_Role)
+	s.AssignRoleToAccounts(ctx, testPDASeedTimelockConverter, wallet, []solana.PublicKey{mcmSignerPDA},
+		timelock.Bypasser_Role)
 
 	timelockSignerPDA, err := solanasdk.FindTimelockSignerPDA(s.TimelockProgramID, testPDASeedTimelockConverter)
 	s.Require().NoError(err)
 
-	testutils.FundAccounts(s.T(), ctx, []solana.PublicKey{mcmSignerPDA, timelockSignerPDA}, 1, s.SolanaClient)
+	e2eutils.FundAccounts(s.T(), ctx, []solana.PublicKey{mcmSignerPDA, timelockSignerPDA}, 1, s.SolanaClient)
 
 	validUntil := 2051222400 // 2035-01-01T12:00:00 UTC
 	mcmAddress := solanasdk.ContractAddress(s.MCMProgramID, testPDASeedTimelockConverter)
@@ -87,26 +90,26 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 	// operation ids and timelock pdas
 	configPDA, err := solanasdk.FindTimelockConfigPDA(s.TimelockProgramID, testPDASeedTimelockConverter)
 	s.Require().NoError(err)
-	operation1ID := common.HexToHash("0x5177a0f841d284b16378790668accd634692d8f2b0a03170f9625c24b46866b7")
+	operation1ID := common.HexToHash("0x8716a69ad1b666929ef2d88cb978f93ec3d3492f053c0c638800f956f044df4e")
 	operation1PDA, err := solanasdk.FindTimelockOperationPDA(s.TimelockProgramID, testPDASeedTimelockConverter, operation1ID)
 	s.Require().NoError(err)
-	operation2ID := common.HexToHash("0xf3b4a6b4ccfbef30504c7400bd075dc25780c122081b84a6a633dd152c572476")
+	operation2ID := common.HexToHash("0x21573e854c17e4bda196f6e518604c7776d96926b13ef8a211f9b4ba4c83beeb")
 	operation2PDA, err := solanasdk.FindTimelockOperationPDA(s.TimelockProgramID, testPDASeedTimelockConverter, operation2ID)
 	s.Require().NoError(err)
 
-	operation1BypasserPDA, err := solanasdk.FindTimelockBypasserOperationPDA(s.TimelockProgramID, testPDASeedTimelockConverter, operation1ID)
-	s.Require().NoError(err)
-	operation2BypasserPDA, err := solanasdk.FindTimelockBypasserOperationPDA(s.TimelockProgramID, testPDASeedTimelockConverter, operation2ID)
-	s.Require().NoError(err)
+	chainMetadata := func() types.ChainMetadata {
+		address := solanasdk.ContractAddress(s.MCMProgramID, testPDASeedTimelockConverter)
+		opCount, err := solanasdk.NewInspector(s.SolanaClient).GetOpCount(ctx, address)
+		s.Require().NoError(err)
 
-	metadata, err := solanasdk.NewChainMetadata(
-		0,
-		s.MCMProgramID,
-		testPDASeedTimelockConverter,
-		s.Roles[timelock.Proposer_Role].AccessController.PublicKey(),
-		s.Roles[timelock.Canceller_Role].AccessController.PublicKey(),
-		s.Roles[timelock.Bypasser_Role].AccessController.PublicKey())
-	s.Require().NoError(err)
+		metadata, err := solanasdk.NewChainMetadata(opCount, s.MCMProgramID, testPDASeedTimelockConverter,
+			s.Roles[timelock.Proposer_Role].AccessController.PublicKey(),
+			s.Roles[timelock.Canceller_Role].AccessController.PublicKey(),
+			s.Roles[timelock.Bypasser_Role].AccessController.PublicKey())
+		s.Require().NoError(err)
+
+		return metadata
+	}
 	timelockProposalBuilder := func() *mcms.TimelockProposalBuilder {
 		return mcms.NewTimelockProposalBuilder().
 			SetValidUntil(uint32(validUntil)).
@@ -115,7 +118,6 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			SetVersion("v1").
 			SetDelay(types.NewDuration(1*time.Second)).
 			AddTimelockAddress(s.ChainSelector, timelockAddress).
-			AddChainMetadata(s.ChainSelector, metadata).
 			AddOperation(types.BatchOperation{ // op1
 				ChainSelector: s.ChainSelector,
 				Transactions:  []types.Transaction{emptyFnTransaction, u8DataTransaction},
@@ -127,7 +129,11 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 	}
 
 	s.Run("schedule", func() {
-		timelockProposal, err := timelockProposalBuilder().SetAction(types.TimelockActionSchedule).Build()
+		cMetadata := chainMetadata()
+		timelockProposal, err := timelockProposalBuilder().
+			AddChainMetadata(s.ChainSelector, cMetadata).
+			SetAction(types.TimelockActionSchedule).
+			Build()
 		s.Require().NoError(err)
 
 		proposerAC := s.Roles[timelock.Proposer_Role].AccessController.PublicKey()
@@ -138,11 +144,11 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			SetDescription("proposal to test the timelock proposal converter").
 			SetOverridePreviousRoot(true).
 			SetVersion("v1").
-			AddChainMetadata(s.ChainSelector, metadata).
+			AddChainMetadata(s.ChainSelector, chainMetadata()).
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: initialize operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "D2DZq3wEcfN0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB6QyuAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAA="),
+				Data:              base64Decode(s.T(), "D2DZq3wEcfN0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB6QyuAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAA="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -157,7 +163,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: initialize 1st timelock instruction ("empty" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "w+bVh5CUjlV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsAAAAA"),
+				Data:              base64Decode(s.T(), "w+bVh5CUjlV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OHZsMOrpAUG6C9rfHs8ScgG/m6HCBWCuHg3gToZkUBSoAAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -172,7 +178,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: append 1st timelock instruction ("empty" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "TE1mg4gMLQV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AAAAAAgAAADWLAT3DCnZbg=="),
+				Data:              base64Decode(s.T(), "TE1mg4gMLQV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OAAAAAAgAAADWLAT3DCnZbg=="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -187,7 +193,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: initialize 2nd timelock instruction ("u8_value" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "w+bVh5CUjlV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsAAAAA"),
+				Data:              base64Decode(s.T(), "w+bVh5CUjlV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OHZsMOrpAUG6C9rfHs8ScgG/m6HCBWCuHg3gToZkUBSoAAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -202,7 +208,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: append 2nd timelock instruction ("u8_value" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "TE1mg4gMLQV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AQAAAAkAAAARr5z9W60a5Hs="),
+				Data:              base64Decode(s.T(), "TE1mg4gMLQV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OAQAAAAkAAAARr5z9W60a5Hs="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -217,7 +223,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: finalize timelock operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "P9AgYlW27Ix0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3"),
+				Data:              base64Decode(s.T(), "P9AgYlW27Ix0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9O"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -231,7 +237,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: schedule batch instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "8oxXakfiViB0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AQAAAAAAAAA="),
+				Data:              base64Decode(s.T(), "8oxXakfiViB0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OAQAAAAAAAAA="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -245,7 +251,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: initialize operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "D2DZq3wEcfN0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2UXeg+EHShLFjeHkGaKzNY0aS2PKwoDFw+WJcJLRoZrd6QyuAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAA="),
+				Data:              base64Decode(s.T(), "D2DZq3wEcfN0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAACFXPoVMF+S9oZb25RhgTHd22WkmsT74ohH5tLpMg77rhxammtG2ZpKe8tiMuXj5PsPTSS8FPAxjiAD5VvBE3056QyuAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAA="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -260,7 +266,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: initialize 1st timelock instruction ("account_mut" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "w+bVh5CUjlV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsDAAAAb4Ezc71PQCcAP8nkYKXix7gp+hT0j5UUJCouW5tBzooAAcSFrcjukyvq73/bE9YO/KFljWLRDY+RGpHMk4NkhqT6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+				Data:              base64Decode(s.T(), "w+bVh5CUjlV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAACFXPoVMF+S9oZb25RhgTHd22WkmsT74ohH5tLpMg77rHZsMOrpAUG6C9rfHs8ScgG/m6HCBWCuHg3gToZkUBSoDAAAAA0JRWm+fXW6dROTGvs1O7lJ17sSZwXdnofi7kQPhnScAAe5KiXXNoYn8wsyXPimFZjXn1bDQqROtngZAnboEB+hqAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -275,7 +281,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: append 1st timelock instruction ("account_mut" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "TE1mg4gMLQV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2AAAAAAgAAAAMAokTFuuQRg=="),
+				Data:              base64Decode(s.T(), "TE1mg4gMLQV0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAACFXPoVMF+S9oZb25RhgTHd22WkmsT74ohH5tLpMg77rAAAAAAgAAAAMAokTFuuQRg=="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -290,7 +296,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: finalize timelock operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "P9AgYlW27Ix0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2"),
+				Data:              base64Decode(s.T(), "P9AgYlW27Ix0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAACFXPoVMF+S9oZb25RhgTHd22WkmsT74ohH5tLpMg77r"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -304,7 +310,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: schedule batch instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "8oxXakfiViB0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2AQAAAAAAAAA="),
+				Data:              base64Decode(s.T(), "8oxXakfiViB0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAACFXPoVMF+S9oZb25RhgTHd22WkmsT74ohH5tLpMg77rAQAAAAAAAAA="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -326,14 +332,25 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 		s.Require().Equal([]common.Hash{mcms.ZERO_HASH, operation1ID}, gotPredecessors)
 		s.Require().Empty(cmp.Diff(toJSONString(s.T(), wantProposal), toJSONString(s.T(), &gotProposal)))
 
+		// --- act ---
 		// TODO(gustavogama-cll): remove this; should refactor and use as base of a "full workflow" e2e test
+		initialValue := readCPIStubU8Value(ctx, s.T(), s.SolanaClient, u8ValuePDA)
 		s.executeConvertedProposal(ctx, wallet, gotProposal, mcmAddress) // call ScheduleBatch
 		s.waitForOperationToBeReady(ctx, testPDASeedTimelockConverter, operation2ID)
 		s.executeTimelockProposal(ctx, wallet, timelockProposal)
+
+		// --- assert ---
+		// check that the AccountMut instruction executed successfully
+		finalValue := readCPIStubU8Value(ctx, s.T(), s.SolanaClient, u8ValuePDA)
+		s.Require().Equal(initialValue+1, finalValue)
 	})
 
 	s.Run("cancel", func() {
-		timelockProposal, err := timelockProposalBuilder().SetAction(types.TimelockActionCancel).Build()
+		metadata := chainMetadata()
+		timelockProposal, err := timelockProposalBuilder().
+			AddChainMetadata(s.ChainSelector, metadata).
+			SetAction(types.TimelockActionCancel).
+			Build()
 		s.Require().NoError(err)
 
 		// build expected output Proposal
@@ -346,7 +363,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: cancel operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "6NvfKdvs3L50ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3"),
+				Data:              base64Decode(s.T(), "6NvfKdvs3L50ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9O"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -360,7 +377,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: cancel operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "6NvfKdvs3L50ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2"),
+				Data:              base64Decode(s.T(), "6NvfKdvs3L50ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAACFXPoVMF+S9oZb25RhgTHd22WkmsT74ohH5tLpMg77r"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -384,7 +401,18 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 	})
 
 	s.Run("bypass", func() {
-		timelockProposal, err := timelockProposalBuilder().SetAction(types.TimelockActionBypass).Build()
+		bypassOperation1ID := common.HexToHash("0x8716a69ad1b666929ef2d88cb978f93ec3d3492f053c0c638800f956f044df4e")
+		operation1BypasserPDA, err := solanasdk.FindTimelockBypasserOperationPDA(s.TimelockProgramID, testPDASeedTimelockConverter, bypassOperation1ID)
+		s.Require().NoError(err)
+		bypassOperation2ID := common.HexToHash("0xfff6a19846af52bf2b905db2126ce0953f5a0d463c73cea09505c323c1df35d4")
+		operation2BypasserPDA, err := solanasdk.FindTimelockBypasserOperationPDA(s.TimelockProgramID, testPDASeedTimelockConverter, bypassOperation2ID)
+		s.Require().NoError(err)
+
+		metadata := chainMetadata()
+		timelockProposal, err := timelockProposalBuilder().
+			AddChainMetadata(s.ChainSelector, metadata).
+			SetAction(types.TimelockActionBypass).
+			Build()
 		s.Require().NoError(err)
 
 		bypasserAC := s.Roles[timelock.Bypasser_Role].AccessController.PublicKey()
@@ -399,7 +427,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: initialize operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "OhswzBPFPxp0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3ekMrgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAA"),
+				Data:              base64Decode(s.T(), "OhswzBPFPxp0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OekMrgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -414,7 +442,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: initialize 1st timelock instruction ("empty" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "MhHNrK+Mwyd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsAAAAA"),
+				Data:              base64Decode(s.T(), "MhHNrK+Mwyd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OHZsMOrpAUG6C9rfHs8ScgG/m6HCBWCuHg3gToZkUBSoAAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -429,7 +457,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: append 1st timelock instruction ("empty" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "uOiX3m9118V0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AAAAAAgAAADWLAT3DCnZbg=="),
+				Data:              base64Decode(s.T(), "uOiX3m9118V0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OAAAAAAgAAADWLAT3DCnZbg=="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -444,7 +472,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: initialize 2nd timelock instruction ("u8_value" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "MhHNrK+Mwyd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsAAAAA"),
+				Data:              base64Decode(s.T(), "MhHNrK+Mwyd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OHZsMOrpAUG6C9rfHs8ScgG/m6HCBWCuHg3gToZkUBSoAAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -459,7 +487,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: append 2nd timelock instruction ("u8_value" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "uOiX3m9118V0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3AQAAAAkAAAARr5z9W60a5Hs="),
+				Data:              base64Decode(s.T(), "uOiX3m9118V0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9OAQAAAAkAAAARr5z9W60a5Hs="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -474,7 +502,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: finalize timelock operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "LTfGM3wYqfp0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3"),
+				Data:              base64Decode(s.T(), "LTfGM3wYqfp0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9O"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -488,7 +516,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op1: bypass execute batch instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "Wj5CBuOuHsJ0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAFF3oPhB0oSxY3h5BmiszWNGktjysKAxcPliXCS0aGa3"),
+				Data:              base64Decode(s.T(), "Wj5CBuOuHsJ0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAIcWpprRtmaSnvLYjLl4+T7D00kvBTwMY4gA+VbwRN9O"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op1Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -497,13 +525,14 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 						{PublicKey: timelockSignerPDA},
 						{PublicKey: bypasserAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
+						{PublicKey: cpistub.ProgramID},
 					},
 				}),
 			}}).
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: initialize operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "OhswzBPFPxp0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2ekMrgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAA"),
+				Data:              base64Decode(s.T(), "OhswzBPFPxp0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAP/2oZhGr1K/K5BdshJs4JU/Wg1GPHPOoJUFwyPB3zXUekMrgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -518,7 +547,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: initialize 1st timelock instruction ("account_mut" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "MhHNrK+Mwyd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2MNchUZRm56fGBpH3X0lzSVS+4C/bZwDdfwKhnelyzNsDAAAAb4Ezc71PQCcAP8nkYKXix7gp+hT0j5UUJCouW5tBzooAAcSFrcjukyvq73/bE9YO/KFljWLRDY+RGpHMk4NkhqT6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+				Data:              base64Decode(s.T(), "MhHNrK+Mwyd0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAP/2oZhGr1K/K5BdshJs4JU/Wg1GPHPOoJUFwyPB3zXUHZsMOrpAUG6C9rfHs8ScgG/m6HCBWCuHg3gToZkUBSoDAAAAA0JRWm+fXW6dROTGvs1O7lJ17sSZwXdnofi7kQPhnScAAe5KiXXNoYn8wsyXPimFZjXn1bDQqROtngZAnboEB+hqAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -533,7 +562,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: append 1st timelock instruction ("account_mut" call)
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "uOiX3m9118V0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2AAAAAAgAAAAMAokTFuuQRg=="),
+				Data:              base64Decode(s.T(), "uOiX3m9118V0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAP/2oZhGr1K/K5BdshJs4JU/Wg1GPHPOoJUFwyPB3zXUAAAAAAgAAAAMAokTFuuQRg=="),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -548,7 +577,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: finalize timelock operation instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "LTfGM3wYqfp0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2"),
+				Data:              base64Decode(s.T(), "LTfGM3wYqfp0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAP/2oZhGr1K/K5BdshJs4JU/Wg1GPHPOoJUFwyPB3zXU"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -562,7 +591,7 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 			AddOperation(types.Operation{ChainSelector: s.ChainSelector, Transaction: types.Transaction{
 				// op2: bypass execute batch instruction
 				To:                s.TimelockProgramID.String(),
-				Data:              base64Decode(s.T(), "Wj5CBuOuHsJ0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAPO0prTM++8wUEx0AL0HXcJXgMEiCBuEpqYz3RUsVyR2"),
+				Data:              base64Decode(s.T(), "Wj5CBuOuHsJ0ZXN0LXRpbWVsb2NrY29udmVydGVyAAAAAAAAAAAAAP/2oZhGr1K/K5BdshJs4JU/Wg1GPHPOoJUFwyPB3zXU"),
 				OperationMetadata: types.OperationMetadata{ContractType: "RBACTimelock", Tags: op2Tags},
 				AdditionalFields: marshalAdditionalFields(s.T(), solanasdk.AdditionalFields{
 					Accounts: []*solana.AccountMeta{
@@ -571,19 +600,32 @@ func (s *SolanaTestSuite) Test_TimelockConverter() {
 						{PublicKey: timelockSignerPDA},
 						{PublicKey: bypasserAC},
 						{PublicKey: mcmSignerPDA, IsWritable: true},
+						{PublicKey: cpistub.ProgramID},
+						{PublicKey: u8ValuePDA, IsWritable: true},
+						{PublicKey: timelockSignerPDA},
+						{PublicKey: solana.SystemProgramID},
 					},
 				}),
 			}}).
 			Build()
 		s.Require().NoError(err)
 
-		// --- act ---
+		// --- act: convert proposal ---
 		gotProposal, gotPredecessors, err := timelockProposal.Convert(ctx, converters)
 		s.Require().NoError(err)
 
 		// --- assert ---
-		s.Require().Equal([]common.Hash{mcms.ZERO_HASH, operation1ID}, gotPredecessors)
+		s.Require().Equal([]common.Hash{mcms.ZERO_HASH, bypassOperation1ID}, gotPredecessors)
 		s.Require().Empty(cmp.Diff(toJSONString(s.T(), wantProposal), toJSONString(s.T(), &gotProposal)))
+
+		// --- act: executed converted proposal ---
+		initialValue := readCPIStubU8Value(ctx, s.T(), s.SolanaClient, u8ValuePDA)
+		s.executeConvertedProposal(ctx, wallet, gotProposal, mcmAddress) // call BypassExecuteBatch
+
+		// --- assert ---
+		// check that the AccountMut instruction executed successfully
+		finalValue := readCPIStubU8Value(ctx, s.T(), s.SolanaClient, u8ValuePDA)
+		s.Require().Equal(initialValue+1, finalValue)
 	})
 }
 
@@ -641,15 +683,6 @@ func (s *SolanaTestSuite) executeTimelockProposal(
 	s.Require().Contains(getTransactionLogs(s.T(), ctx, s.SolanaClient, tx.Hash), "Called `account_mut`")
 }
 
-func newRandomAccount(t *testing.T) (solana.PrivateKey, solana.PublicKey) { //nolint:unused
-	t.Helper()
-
-	privateKey, err := solana.NewRandomPrivateKey()
-	require.NoError(t, err)
-
-	return privateKey, privateKey.PublicKey()
-}
-
 func marshalAdditionalFields(t *testing.T, additionalFields solanasdk.AdditionalFields) []byte {
 	t.Helper()
 	marshalledBytes, err := json.Marshal(additionalFields)
@@ -685,4 +718,14 @@ func getTransactionLogs(t *testing.T, ctx context.Context, client *rpc.Client, s
 	require.NoError(t, err)
 
 	return strings.Join(result.Meta.LogMessages, "\n")
+}
+
+func readCPIStubU8Value(ctx context.Context, t *testing.T, client *rpc.Client, pda solana.PublicKey) uint8 {
+	t.Helper()
+
+	var account cpistub.Value
+	err := solanaCommon.GetAccountDataBorshInto(ctx, client, pda, rpc.CommitmentConfirmed, &account)
+	require.NoError(t, err)
+
+	return account.Value
 }

--- a/e2e/tests/solana/timelock_execution.go
+++ b/e2e/tests/solana/timelock_execution.go
@@ -5,15 +5,18 @@ package solanae2e
 
 import (
 	"context"
+	"testing"
+	"time"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/programs/token"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/testutils"
-	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/access_controller"
-	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
-	timelockutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/timelock"
+	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/timelock"
+
+	e2eutils "github.com/smartcontractkit/mcms/e2e/utils/solana"
 	mcmsSolana "github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -25,117 +28,61 @@ const BatchAddAccessChunkSize = 24
 // Test_Solana_TimelockExecute tests the timelock Execute functionality by scheduling a mint tokens transaction and
 // executing it via the timelock ExecuteBatch
 func (s *SolanaTestSuite) Test_Solana_TimelockExecute() {
-	s.SetupTimelock(testTimelockExecuteID, 1)
-	// Get required programs and accounts
-	ctx := context.Background()
-	timelock.SetProgramID(s.TimelockProgramID)
-	access_controller.SetProgramID(s.AccessControllerProgramID)
+	// --- arrange ---
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	s.T().Cleanup(cancel)
 
-	// Fund the auth private key
+	token.SetProgramID(solana.Token2022ProgramID)
+	s.SetupMCM(testTimelockExecuteID)
+	s.SetupTimelock(testTimelockExecuteID, 1)
+
+	// Create auth and executor private keys
 	auth, err := solana.PrivateKeyFromBase58(privateKey)
+	s.Require().NoError(err)
+	proposerAndExecutorKey, err := solana.NewRandomPrivateKey()
+	s.Require().NoError(err)
+	mintKey, err := solana.NewRandomPrivateKey()
+	s.Require().NoError(err)
+
+	e2eutils.FundAccounts(s.T(), ctx, []solana.PublicKey{auth.PublicKey(), proposerAndExecutorKey.PublicKey()}, 1, s.SolanaClient)
+
+	s.AssignRoleToAccounts(ctx, testTimelockExecuteID, auth, []solana.PublicKey{proposerAndExecutorKey.PublicKey()},
+		timelock.Proposer_Role)
+	s.AssignRoleToAccounts(ctx, testTimelockExecuteID, auth, []solana.PublicKey{proposerAndExecutorKey.PublicKey()},
+		timelock.Executor_Role)
+
+	signerPDA, err := mcmsSolana.FindTimelockSignerPDA(s.TimelockProgramID, testTimelockExecuteID)
 	s.Require().NoError(err)
 
 	// Setup SPL token for testing a mint via timelock
-	mintKeypair, err := solana.NewRandomPrivateKey()
-	s.Require().NoError(err)
-	mint := mintKeypair.PublicKey()
-	// set up the token program
-	signerPDA, err := mcmsSolana.FindTimelockSignerPDA(s.TimelockProgramID, testTimelockExecuteID)
-	s.Require().NoError(err)
-	receiverATA := s.setupTokenProgram(ctx, auth, signerPDA, mintKeypair)
+	receiverATA := s.setupTokenProgram(ctx, auth, signerPDA, mintKey)
 
-	// Get receiverATA initial balance
-	initialBalance, err := s.SolanaClient.GetTokenAccountBalance(
-		context.Background(),
-		receiverATA, // The associated token account address
-		rpc.CommitmentProcessed,
-	)
-	s.Require().NoError(err)
-
-	// Set propose roles
-	proposerAndExecutorKey := s.setProposerAndExecutor(ctx, auth, s.Roles)
-	s.Require().NotNil(proposerAndExecutorKey)
-
-	// Schedule the mint tx
-	var predecessor [32]byte
+	predecessor := [32]byte{}
 	salt := [32]byte{123}
-	mintIx, operationID := s.scheduleMintTx(ctx,
-		mint,
-		receiverATA,
-		s.Roles[timelock.Proposer_Role].AccessController.PublicKey(),
-		signerPDA,
-		*proposerAndExecutorKey,
-		predecessor,
-		salt)
+	executor := mcmsSolana.NewTimelockExecutor(s.SolanaClient, proposerAndExecutorKey)
+	timelockAddress := mcmsSolana.ContractAddress(s.TimelockProgramID, testTimelockExecuteID)
+
+	initialBalance := getBalance(ctx, s.T(), s.SolanaClient, receiverATA)
+
+	// schedule mint transaction and build batch operation from the returned ScheduleBatch instruction
+	mintIx, operationID := s.scheduleMintTx(ctx, mintKey.PublicKey(), receiverATA,
+		s.Roles[timelock.Proposer_Role].AccessController.PublicKey(), signerPDA, proposerAndExecutorKey,
+		predecessor, salt)
+	s.waitForOperationToBeReady(ctx, testTimelockExecuteID, operationID)
 
 	// --- act: call Timelock Execute ---
-	executor := mcmsSolana.NewTimelockExecutor(s.SolanaClient, *proposerAndExecutorKey)
-	contractID := mcmsSolana.ContractAddress(s.TimelockProgramID, testTimelockExecuteID)
-	ixData, err := mintIx.Data()
+	mcmsTransaction, err := mcmsSolana.NewTransactionFromInstruction(mintIx, "Token", nil)
 	s.Require().NoError(err)
-	accounts := mintIx.Accounts()
-	accounts = append(accounts, &solana.AccountMeta{PublicKey: solana.Token2022ProgramID, IsSigner: false, IsWritable: false})
-	solanaTx, err := mcmsSolana.NewTransaction(solana.Token2022ProgramID.String(), ixData, nil, accounts, "Token", []string{})
+	batchOp := types.BatchOperation{Transactions: []types.Transaction{mcmsTransaction}, ChainSelector: s.ChainSelector}
+
+	signature, err := executor.Execute(ctx, batchOp, timelockAddress, predecessor, salt)
 	s.Require().NoError(err)
-	batchOp := types.BatchOperation{
-		Transactions:  []types.Transaction{solanaTx},
-		ChainSelector: s.ChainSelector,
-	}
-	// --- Wait for the operation to be ready ---
-	s.waitForOperationToBeReady(ctx, testTimelockExecuteID, operationID)
-	signature, err := executor.Execute(ctx, batchOp, contractID, predecessor, salt)
-	s.Require().NoError(err)
-	s.Require().NotEqual(signature, "")
+	s.Require().NotEqual("", signature)
 
-	// --- assert balances
-	finalBalance, err := s.SolanaClient.GetTokenAccountBalance(
-		ctx,
-		receiverATA,
-		rpc.CommitmentProcessed,
-	)
-	s.Require().NoError(err)
-
-	// final balance should be 1000000000000 more units
-	s.Require().Equal(initialBalance.Value.Amount, "0")
-	s.Require().Equal(finalBalance.Value.Amount, "1000000000000")
-}
-
-// setProposerAndExecutor sets the proposer for the timelock
-func (s *SolanaTestSuite) setProposerAndExecutor(ctx context.Context, auth solana.PrivateKey, roleMap timelockutils.RoleMap) *solana.PrivateKey {
-	proposerAndExecutorKey := solana.NewWallet()
-	testutils.FundAccounts(ctx, []solana.PrivateKey{proposerAndExecutorKey.PrivateKey}, s.SolanaClient, s.T())
-
-	// Add proposers to the timelock program
-	batchAddAccessIxs, err := timelockutils.GetBatchAddAccessIxs(
-		ctx,
-		testTimelockExecuteID,
-		roleMap[timelock.Proposer_Role].AccessController.PublicKey(),
-		timelock.Proposer_Role,
-		[]solana.PublicKey{proposerAndExecutorKey.PublicKey()},
-		auth,
-		BatchAddAccessChunkSize,
-		s.SolanaClient)
-	s.Require().NoError(err)
-	for _, ix := range batchAddAccessIxs {
-		testutils.SendAndConfirm(ctx, s.T(), s.SolanaClient, []solana.Instruction{ix}, auth, rpc.CommitmentConfirmed)
-	}
-
-	// Add executor to the timelock program
-	batchAddAccessIxs, err = timelockutils.GetBatchAddAccessIxs(
-		ctx,
-		testTimelockExecuteID,
-		roleMap[timelock.Executor_Role].AccessController.PublicKey(),
-		timelock.Executor_Role,
-		[]solana.PublicKey{proposerAndExecutorKey.PublicKey()},
-		auth,
-		BatchAddAccessChunkSize,
-		s.SolanaClient)
-	s.Require().NoError(err)
-	for _, ix := range batchAddAccessIxs {
-		testutils.SendAndConfirm(ctx, s.T(), s.SolanaClient, []solana.Instruction{ix}, auth, rpc.CommitmentConfirmed)
-	}
-
-	return &proposerAndExecutorKey.PrivateKey
+	// --- assert ---
+	finalBalance := getBalance(ctx, s.T(), s.SolanaClient, receiverATA)
+	s.Require().Equal("0", initialBalance)
+	s.Require().Equal("1000000000000", finalBalance)
 }
 
 // scheduleMintTx schedules a MintTx on the timelock
@@ -151,7 +98,9 @@ func (s *SolanaTestSuite) scheduleMintTx(
 	// and not the deployer account.
 	authPublicKey solana.PublicKey,
 	auth solana.PrivateKey, // The account to sign the init, append schedule instructions.
-	predecessor, salt [32]byte) (instruction *token.Instruction, operationID [32]byte) {
+	predecessor,
+	salt [32]byte,
+) (instruction *token.Instruction, operationID [32]byte) {
 	amount := 1000 * solana.LAMPORTS_PER_SOL
 	mintIx, err := token.NewMintToInstruction(amount, mint, receiverATA, authPublicKey, nil).ValidateAndBuild()
 	s.Require().NoError(err)
@@ -160,31 +109,27 @@ func (s *SolanaTestSuite) scheduleMintTx(
 			acc.IsSigner = false
 		}
 	}
-	s.Require().NoError(err)
+
 	// Get the operation ID
 	ixData, err := mintIx.Data()
 	s.Require().NoError(err)
-	accounts := make([]timelock.InstructionAccount, 0, len(mintIx.Accounts())+1)
-	for _, account := range mintIx.Accounts() {
-		accounts = append(accounts, timelock.InstructionAccount{
+	accounts := make([]timelock.InstructionAccount, len(mintIx.Accounts()))
+	for i, account := range mintIx.Accounts() {
+		accounts[i] = timelock.InstructionAccount{
 			Pubkey:     account.PublicKey,
 			IsSigner:   account.IsSigner,
 			IsWritable: account.IsWritable,
-		})
+		}
 	}
-	accounts = append(accounts, timelock.InstructionAccount{
-		Pubkey:     solana.Token2022ProgramID,
-		IsSigner:   false,
-		IsWritable: false,
-	})
-	opInstructions := []timelock.InstructionData{{Data: ixData, ProgramId: solana.Token2022ProgramID, Accounts: accounts}}
+	opInstructions := []timelock.InstructionData{{Data: ixData, ProgramId: mintIx.ProgramID(), Accounts: accounts}}
+
 	operationID, err = mcmsSolana.HashOperation(opInstructions, predecessor, salt)
 	s.Require().NoError(err)
+
 	operationPDA, err := mcmsSolana.FindTimelockOperationPDA(s.TimelockProgramID, testTimelockExecuteID, operationID)
 	s.Require().NoError(err)
 	configPDA, err := mcmsSolana.FindTimelockConfigPDA(s.TimelockProgramID, testTimelockExecuteID)
 	s.Require().NoError(err)
-
 	proposerAC := s.Roles[timelock.Proposer_Role].AccessController.PublicKey()
 
 	// Preload and Init Operation
@@ -257,6 +202,7 @@ func (s *SolanaTestSuite) scheduleMintTx(
 	s.Require().NoError(err)
 	ixs = append(ixs, finOpIx)
 	testutils.SendAndConfirm(ctx, s.T(), s.SolanaClient, ixs, auth, rpc.CommitmentConfirmed)
+
 	// Schedule the operation
 	scheduleIx, err := timelock.NewScheduleBatchInstruction(
 		testTimelockExecuteID,
@@ -271,4 +217,13 @@ func (s *SolanaTestSuite) scheduleMintTx(
 	testutils.SendAndConfirm(ctx, s.T(), s.SolanaClient, []solana.Instruction{scheduleIx}, auth, rpc.CommitmentConfirmed)
 
 	return mintIx, operationID
+}
+
+func getBalance(ctx context.Context, t *testing.T, client *rpc.Client, account solana.PublicKey) string {
+	t.Helper()
+
+	balance, err := client.GetTokenAccountBalance(ctx, account, rpc.CommitmentProcessed)
+	require.NoError(t, err)
+
+	return balance.Value.Amount
 }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/karalabe/hid v1.0.1-0.20240306101548-573246063e52
 	github.com/smartcontractkit/chain-selectors v1.0.48
 	github.com/smartcontractkit/chainlink-aptos v0.0.0-20250414155853-651b4e583ee9
-	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250226104101-11778f2ead98
+	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250422205932-c33527859fd6
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0
@@ -30,6 +30,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
+	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/AlekSi/pointer v1.1.0/go.mod h1:y7BvfRI3wXPWKXEBhU71nbnIEEZX0QTSB2Bj4
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -597,8 +599,8 @@ github.com/smartcontractkit/chain-selectors v1.0.48 h1:wa03tlcGj08qZfv1p+LXZIimp
 github.com/smartcontractkit/chain-selectors v1.0.48/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250414155853-651b4e583ee9 h1:lw8RZ8IR4UX1M7djAB3IuMtcAqFX4Z4bzQczClfb8bs=
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250414155853-651b4e583ee9/go.mod h1:Sq/ddMOYch6ZuAnW2k5u9V4+TlGKFzuHQnTM8JXEU+g=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250226104101-11778f2ead98 h1:uHdawaiGBA3Xmju92tzbQ2SwsG2DDVJS5E+Jm5QnsQg=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250226104101-11778f2ead98/go.mod h1:Bmwq4lNb5tE47sydN0TKetcLEGbgl+VxHEWp4S0LI60=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250422205932-c33527859fd6 h1:EWpKT2h/jyqCcblfmtHuY5oN2k8k2Mrmi5KqX+hc2lo=
+github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250422205932-c33527859fd6/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.6.1-0.20250329081313-84ec641e0758 h1:SyaVoJtYZ54dO4HyUcfWsuvC0hRsjk+Lyy/k++WQc7Y=
 github.com/smartcontractkit/chainlink-common v0.6.1-0.20250329081313-84ec641e0758/go.mod h1:ASXpANdCfcKd+LF3Vhz37q4rmJ/XYQKEQ3La1k7idp0=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7 h1:E7k5Sym9WnMOc4X40lLnQb6BMosxi8DfUBU9pBJjHOQ=
@@ -922,6 +924,8 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhSt0ABwskkZKjD3bXGnZGpNY=
 golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
+gonum.org/v1/gonum v0.15.1 h1:FNy7N6OUZVUaWG9pTiD+jlhdQ3lMP+/LcTpJ6+a8sQ0=
+gonum.org/v1/gonum v0.15.1/go.mod h1:eZTZuRFrzu5pcyjN5wJhcIhnUdNijYxX1T2IcrOGY0o=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/sdk/solana/executor.go
+++ b/sdk/solana/executor.go
@@ -97,7 +97,6 @@ func (e *Executor) ExecuteOperation(
 		uint64(nonce),
 		op.Transaction.Data,
 		byteProof,
-
 		configPDA,
 		rootMetadataPDA,
 		expiringRootAndOpCountPDA,
@@ -105,8 +104,8 @@ func (e *Executor) ExecuteOperation(
 		signedPDA,
 		e.auth.PublicKey(),
 	)
-	// Append the accounts from the AdditionalFields
 	ix.AccountMetaSlice = append(ix.AccountMetaSlice, additionalFields.Accounts...)
+
 	signature, tx, err := e.sendAndConfirm(ctx, e.client, e.auth, ix, rpc.CommitmentConfirmed)
 	if err != nil {
 		return types.TransactionResult{}, fmt.Errorf("unable to call execute operation instruction: %w", err)

--- a/sdk/solana/timelock_converter_test.go
+++ b/sdk/solana/timelock_converter_test.go
@@ -396,7 +396,7 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 					},
 				},
 				{
-					// schedule batch
+					// bypass batch execute
 					ChainSelector: chaintest.Chain4Selector,
 					Transaction: types.Transaction{
 						To:   testTimelockProgramID.String(),
@@ -407,6 +407,10 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 							{PublicKey: solana.MPK("2g4vS5Y9g5FKoBakfNTEQcoyuPxuqgiXhribGxE1Vrsb")},
 							{PublicKey: solana.MPK(bypasserAC.PublicKey().String())},
 							{PublicKey: solana.MPK("62gDM6BRLf2w1yXfmpePUTsuvbeBbu4QqdjV32wcc4UG"), IsWritable: true},
+							{PublicKey: solana.MPK("GwAQ33PbytKignFmKvyVSLp7pD8tKMaBXXNwFTTkGsME"), IsWritable: false, IsSigner: false},
+							{PublicKey: solana.MPK("8na2HyqgS15GcjiWmMQvQ87o8kw188QgaVSTa6q94orU"), IsWritable: true, IsSigner: false},
+							{PublicKey: solana.MPK("AjfVZUFzzC8nyA37GXBEdB57RfqPYXifYNtP9jRdRtCw"), IsWritable: true, IsSigner: false},
+							{PublicKey: solana.MPK("t3ChqFTKHUFdjNPDf8CuhFGwkwzqR47LL7sDbeU99XD"), IsWritable: false, IsSigner: false},
 						}}),
 						OperationMetadata: types.OperationMetadata{
 							ContractType: "RBACTimelock",
@@ -488,8 +492,8 @@ func Test_TimelockConverter_ConvertBatchToChainOperations(t *testing.T) {
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)
-				require.Empty(t, cmp.Diff(tt.wantOperations, operations))
 				require.Empty(t, cmp.Diff(tt.wantPredecessor, predecessors))
+				require.Empty(t, cmp.Diff(tt.wantOperations, operations))
 			} else {
 				require.ErrorContains(t, err, tt.wantErr)
 			}

--- a/sdk/solana/transaction.go
+++ b/sdk/solana/transaction.go
@@ -82,12 +82,5 @@ func NewTransactionFromInstruction(
 		return types.Transaction{}, fmt.Errorf("unable to get instruction data: %w", err)
 	}
 
-	// ensure PDAs don't have the "IsSigner" flag
-	for _, account := range instruction.Accounts() {
-		if account != nil && !solana.IsOnCurve(account.PublicKey[:]) {
-			account.IsSigner = false
-		}
-	}
-
 	return NewTransaction(instruction.ProgramID().String(), data, nil, instruction.Accounts(), contractType, tags)
 }


### PR DESCRIPTION
After investigating issues with the RMNRemote curse integration tests, we realized that we were mishandling the accounts that are passed to the BypassExecuteBatch instruction. This PR fixes that, by implementing the following changes:

* add the Program ID to the list of "remaining accounts"
* de-duplicate the accounts in the "remaining accounts" slice, ensuring the "signer" attribute is unset
* adjust the writable attribute of the non-remaining accounts of the BypassExecuteBatch instruction itself

In addition, the PR also fixes the predecessor value used when computing the operation id -- since bypass executions don't respect the predecessor value, the operation id computed by the onchain Solana program assumes that the predecessor is always "null".

[DX-610](https://smartcontract-it.atlassian.net/browse/DX-610)

[DX-610]: https://smartcontract-it.atlassian.net/browse/DX-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ