### PR TITLE
feat: add IsOperationPending() and IsChainPending() to TimelockExecutable

### DIFF
--- a/.changeset/mean-students-share.md
+++ b/.changeset/mean-students-share.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+feat: add IsOperationPending() and IsChainPending() to TimelockExecutable

--- a/errors.go
+++ b/errors.go
@@ -15,8 +15,18 @@ type OperationNotReadyError struct {
 }
 
 // Error implements the error interface.
-func (e *OperationNotReadyError) Error() string {
+func (e OperationNotReadyError) Error() string {
 	return fmt.Sprintf("operation %d is not ready", e.OpIndex)
+}
+
+// OperationNotPendingError is returned when an operation is not yet pending.
+type OperationNotPendingError struct {
+	OpIndex int
+}
+
+// Error implements the error interface.
+func (e OperationNotPendingError) Error() string {
+	return fmt.Sprintf("operation %d is not pending", e.OpIndex)
 }
 
 // OperationNotDoneError is returned when an operation is not yet done.
@@ -25,7 +35,7 @@ type OperationNotDoneError struct {
 }
 
 // Error implements the error interface.
-func (e *OperationNotDoneError) Error() string {
+func (e OperationNotDoneError) Error() string {
 	return fmt.Sprintf("operation %d is not done", e.OpIndex)
 }
 


### PR DESCRIPTION
This will help us ensure a failed Timelock "schedule" call that failed in the CLD workflow can safely be re-executed.

[DX-611](https://smartcontract-it.atlassian.net/browse/DX-611)

[DX-611]: https://smartcontract-it.atlassian.net/browse/DX-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ