### PR TITLE
fix(solana): check current root before calling SetRoot

### DIFF
--- a/.changeset/sweet-taxis-check.md
+++ b/.changeset/sweet-taxis-check.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix(solana): check current root before calling SetRoot

--- a/e2e/tests/solana/set_root.go
+++ b/e2e/tests/solana/set_root.go
@@ -102,6 +102,10 @@ func (s *SolanaTestSuite) Test_Solana_SetRoot() {
 		s.Require().NoError(err)
 		s.Require().Equal(common.HexToHash("0x2b970fa3b929cafc45e8740e5123ebf150c519813bcf4d9c7284518fd5720108"), gotRoot)
 		s.Require().Equal(proposal.ValidUntil, gotValidUntil)
+
+		// --- act: call SetRoot again ---
+		_, err = executable.SetRoot(ctx, s.ChainSelector)
+		s.Require().ErrorContains(err, "SignedHashAlreadySeen: ")
 	})
 
 	s.Run("multiple signers - exceeds default CU Limit", func() {

--- a/sdk/solana/executor.go
+++ b/sdk/solana/executor.go
@@ -20,6 +20,8 @@ import (
 
 var _ sdk.Executor = (*Executor)(nil)
 
+var ErrSignedHashAlreadySeen = func(root [32]byte) error { return fmt.Errorf("SignedHashAlreadySeen: 0x%x", root) }
+
 const maxPreloadSignaturesAttempts = 3
 
 // Executor is an Executor implementation for Solana chains, allowing for the execution of
@@ -130,6 +132,14 @@ func (e *Executor) SetRoot(
 	validUntil uint32,
 	sortedSignatures []types.Signature,
 ) (types.TransactionResult, error) {
+	sameRoot, err := e.equalCurrentRoot(ctx, metadata.MCMAddress, root)
+	if err != nil {
+		return types.TransactionResult{}, err
+	}
+	if sameRoot {
+		return types.TransactionResult{}, ErrSignedHashAlreadySeen(root)
+	}
+
 	programID, pdaSeed, err := ParseContractAddress(metadata.MCMAddress)
 	if err != nil {
 		return types.TransactionResult{}, err
@@ -270,6 +280,15 @@ func (e *Executor) solanaMetadata(metadata types.ChainMetadata, configPDA [32]by
 		PostOpCount:          metadata.StartingOpCount + e.TxCount,
 		OverridePreviousRoot: e.OverridePreviousRoot,
 	}
+}
+
+func (e *Executor) equalCurrentRoot(ctx context.Context, mcmAddress string, newRoot [32]byte) (bool, error) {
+	currentRoot, _, err := e.GetRoot(ctx, mcmAddress)
+	if err != nil {
+		return false, fmt.Errorf("failed to get root: %w", err)
+	}
+
+	return currentRoot == newRoot, nil
 }
 
 // solanaProof converts a proof coming as a slice of common.Hash to a slice of [32]byte.


### PR DESCRIPTION
If the root matches the current one, we return an error. The message returned is similar to the one return by the EVM contract to simplify the client's error handling logic.
