### PR TITLE
fix(solana): use smaller batch size for the "appendSigner" instructions

### DIFF
--- a/.changeset/twenty-trains-allow.md
+++ b/.changeset/twenty-trains-allow.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix(solana): use smaller batch size for the "appendSigner" instructions

--- a/sdk/solana/configurer.go
+++ b/sdk/solana/configurer.go
@@ -18,6 +18,8 @@ import (
 
 var _ sdk.Configurer = &Configurer{}
 
+const maxAppendSignerBatchSize = 20 // REVIEW: run chunking tests to verify actual limit
+
 // Configurer configures the MCM contract for Solana chains.
 type Configurer struct {
 	instructionCollection
@@ -165,7 +167,7 @@ func (c *Configurer) preloadSigners(
 		return err
 	}
 
-	for i, chunkIndex := range chunkIndexes(len(signerAddresses), config.MaxAppendSignerBatchSize) {
+	for i, chunkIndex := range chunkIndexes(len(signerAddresses), maxAppendSignerBatchSize) {
 		err = c.addInstruction(fmt.Sprintf("appendSigners%d", i), bindings.NewAppendSignersInstruction(mcmName,
 			signerAddresses[chunkIndex[0]:chunkIndex[1]], configPDA, configSignersPDA, c.authorityAccount))
 		if err != nil {


### PR DESCRIPTION
The original value (45) has caused issues in mainnet:
https://chainlink-core.slack.com/archives/C085YEEAEUD/p1747251207380869

We're reducing to 20 out of caution and will adjust again once we're able to  implement proper chunking tests.
