### PR TITLE
fix(solana): replace solanacommon.sendTransaction with custom code

### DIFF
--- a/.changeset/swift-insects-laugh.md
+++ b/.changeset/swift-insects-laugh.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+fix(solana): use solanacommon.SendTransaction() that supports retries

--- a/go.mod
+++ b/go.mod
@@ -189,7 +189,6 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320090719-315440f5b0a7 // indirect
 	github.com/smartcontractkit/chainlink-common v0.6.1-0.20250329081313-84ec641e0758 // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/libocr v0.0.0-20250220133800-f3b940c4f298 // indirect

--- a/go.sum
+++ b/go.sum
@@ -599,14 +599,6 @@ github.com/smartcontractkit/chain-selectors v1.0.48 h1:wa03tlcGj08qZfv1p+LXZIimp
 github.com/smartcontractkit/chain-selectors v1.0.48/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250414155853-651b4e583ee9 h1:lw8RZ8IR4UX1M7djAB3IuMtcAqFX4Z4bzQczClfb8bs=
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250414155853-651b4e583ee9/go.mod h1:Sq/ddMOYch6ZuAnW2k5u9V4+TlGKFzuHQnTM8JXEU+g=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320090719-315440f5b0a7 h1:/VKrPJRo4y58whyBRhc9Fszu2eTNn0LNISaS0pjhTpk=
-github.com/smartcontractkit/chainlink-ccip v0.0.0-20250320090719-315440f5b0a7/go.mod h1:AhqYIeGF2k94J+/gzRx5dQttlgUdZid2N6E4HlHVIVA=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250422205932-c33527859fd6 h1:EWpKT2h/jyqCcblfmtHuY5oN2k8k2Mrmi5KqX+hc2lo=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250422205932-c33527859fd6/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250512155317-4615e5659ce4 h1:ZopJiCUcshj79A3tjh0f5cncXEjlfp7QOPWFppb4gxM=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250512155317-4615e5659ce4/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250512193142-11507db18550 h1:oNwu6Nk5Qs9R/cIJbrnFSsM+6icd5qg2FHLxLbYymNQ=
-github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250512193142-11507db18550/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250515132731-ad40fab9b75e h1:4Hx+m9MovqsayvKdYjnj6OQ5pxXkpU2LDz0UNRuqoA8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250515132731-ad40fab9b75e/go.mod h1:k3/Z6AvwurPUlfuDFEonRbkkiTSgNSrtVNhJEWNlUZA=
 github.com/smartcontractkit/chainlink-common v0.6.1-0.20250329081313-84ec641e0758 h1:SyaVoJtYZ54dO4HyUcfWsuvC0hRsjk+Lyy/k++WQc7Y=

--- a/sdk/solana/common_test.go
+++ b/sdk/solana/common_test.go
@@ -126,6 +126,7 @@ func Test_sendAndConfirm(t *testing.T) {
 		name            string
 		setup           func(*mocks.JSONRPCClient)
 		builder         any
+		opts            []sendTransactionOption
 		wantSignature   string
 		wantTransaction *rpc.GetTransactionResult
 		wantErr         string
@@ -184,6 +185,7 @@ func Test_sendAndConfirm(t *testing.T) {
 					"NyH6sKKEbAMjxzG9qLTcwd1yEmv46Z94XmH5Pp9AXJps8EofvpPdUn5bp7rzKnztWmxskBiVRnp4DwaHujhHvFh",
 					nil, fmt.Errorf("send and confirm error"))
 			},
+			opts:    []sendTransactionOption{WithRetries(1)},
 			wantErr: "unable to send instruction: send and confirm error",
 		},
 	}
@@ -195,7 +197,7 @@ func Test_sendAndConfirm(t *testing.T) {
 			client := rpc.NewWithCustomRPCClient(mockJSONRPCClient)
 			tt.setup(mockJSONRPCClient)
 
-			gotSignature, gotTransaction, err := sendAndConfirm(ctx, client, auth, tt.builder, commitmentType)
+			gotSignature, gotTransaction, err := sendAndConfirm(ctx, client, auth, tt.builder, commitmentType, tt.opts...)
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)

--- a/sdk/solana/configurer_test.go
+++ b/sdk/solana/configurer_test.go
@@ -160,6 +160,8 @@ func TestConfigurer_SetConfig(t *testing.T) {
 			setup: func(t *testing.T, configurer *Configurer, mockJSONRPCClient *mocks.JSONRPCClient) {
 				t.Helper()
 
+				configurer.sendAndConfirm = sendAndConfirmInstructionsWithoutRetries
+
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
 					"4PQcRHQJT4cRQZooAhZMAP9ZXJsAka9DeKvXeYvXAvPpHb4Qkc5rmTSHDA2SZSh9aKPBguBx4kmcyHHbkytoAiRr",
 					nil, fmt.Errorf("initialize signers error"))
@@ -172,6 +174,8 @@ func TestConfigurer_SetConfig(t *testing.T) {
 			mcmConfig: defaultMcmConfig,
 			setup: func(t *testing.T, configurer *Configurer, mockJSONRPCClient *mocks.JSONRPCClient) {
 				t.Helper()
+
+				configurer.sendAndConfirm = sendAndConfirmInstructionsWithoutRetries
 
 				// initialize signers
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
@@ -190,6 +194,8 @@ func TestConfigurer_SetConfig(t *testing.T) {
 			mcmConfig: defaultMcmConfig,
 			setup: func(t *testing.T, configurer *Configurer, mockJSONRPCClient *mocks.JSONRPCClient) {
 				t.Helper()
+
+				configurer.sendAndConfirm = sendAndConfirmInstructionsWithoutRetries
 
 				// initialize signers + append signers
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
@@ -210,6 +216,8 @@ func TestConfigurer_SetConfig(t *testing.T) {
 			mcmConfig: &types.Config{Quorum: 1, Signers: []common.Address{common.HexToAddress("0x1")}},
 			setup: func(t *testing.T, configurer *Configurer, mockJSONRPCClient *mocks.JSONRPCClient) {
 				t.Helper()
+
+				configurer.sendAndConfirm = sendAndConfirmInstructionsWithoutRetries
 
 				// initialize signers + append signers + finalize signers
 				mockSolanaTransaction(t, mockJSONRPCClient, 10, 20,
@@ -259,4 +267,16 @@ func newTestConfigurer(
 	client := rpc.NewWithCustomRPCClient(mockJSONRPCClient)
 
 	return NewConfigurer(client, auth, chainSelector, options...), mockJSONRPCClient
+}
+
+func sendAndConfirmInstructionsWithoutRetries(
+	ctx context.Context,
+	client *rpc.Client,
+	auth solana.PrivateKey,
+	instructions []solana.Instruction,
+	commitmentType rpc.CommitmentType,
+	opts ...sendTransactionOption,
+) (string, *rpc.GetTransactionResult, error) {
+	opts = append(opts, WithRetries(1))
+	return sendAndConfirmInstructions(ctx, client, auth, instructions, commitmentType, opts...)
 }

--- a/sdk/solana/simulator.go
+++ b/sdk/solana/simulator.go
@@ -71,6 +71,7 @@ func (s *Simulator) collectInstructions(
 	auth solana.PrivateKey,
 	instructionBuilder any,
 	commitmentType rpc.CommitmentType,
+	opts ...sendTransactionOption,
 ) (string, *rpc.GetTransactionResult, error) {
 	instruction, err := validateAndBuildSolanaInstruction(instructionBuilder)
 	if err != nil {


### PR DESCRIPTION
The custom code is adapted from `solanaCommon.SendTransactionLookupTablesWithRetries`, but it allows the client code us to customize the number of retries and the delay. If we eventually get a better version in `chainlink-ccip/chains/solana` we should drop this custom implementation go back to using the shared implementation.