### PR TITLE
fix(solana): set CU limit as the maximum (1.4M) to avoid CU errors in mainnet

### DIFF
--- a/.changeset/poor-islands-kiss.md
+++ b/.changeset/poor-islands-kiss.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix: set CU limit as the maximum (1.4M) to avoid CU errors in mainnet


### PR DESCRIPTION
Calling `solana.SetRoot` with several signers is leading to CU errors in mainnet. As a quick workaround, we're temporarily setting the CU limit to the maximum value.