### PR TITLE
fix(solana): set CU limit as the maximum (1.4M) to avoid CU errors in mainnet

### DIFF
--- a/.changeset/poor-islands-kiss.md
+++ b/.changeset/poor-islands-kiss.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix: set CU limit as the maximum (1.4M) to avoid CU errors in mainnet

--- a/e2e/tests/solana/common.go
+++ b/e2e/tests/solana/common.go
@@ -29,6 +29,7 @@ import (
 	timelockutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/timelock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
 
 	e2e "github.com/smartcontractkit/mcms/e2e/tests"
 	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
@@ -548,4 +549,8 @@ func (s *SolanaTestSuite) waitForOperationToBeReady(ctx context.Context, timeloc
 
 	s.Require().Fail("operation not ready after %d attempts (scheduled for: %v, with buffer: %v)",
 		maxAttempts, scheduledTime.UTC(), scheduledTimeWithBuffer.UTC())
+}
+
+func (s *SolanaTestSuite) contextWithLogger() context.Context {
+	return context.WithValue(context.Background(), solanasdk.ContextLoggerValue, zap.NewNop().Sugar())
 }

--- a/e2e/tests/solana/set_root.go
+++ b/e2e/tests/solana/set_root.go
@@ -4,8 +4,8 @@
 package solanae2e
 
 import (
-	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -24,7 +24,8 @@ var testPDASeedSetRootTest = [32]byte{'t', 'e', 's', 't', '-', 's', 'e', 't', 'r
 // and doing the preload signers setup.
 func (s *SolanaTestSuite) Test_Solana_SetRoot() {
 	// --- arrange ---
-	ctx := context.Background()
+	ctx := s.contextWithLogger()
+
 	s.SetupMCM(testPDASeedSetRootTest)
 	s.SetupTimelock(testPDASeedSetRootTest, 1*time.Second)
 
@@ -45,24 +46,29 @@ func (s *SolanaTestSuite) Test_Solana_SetRoot() {
 		s.Roles[timelock.Canceller_Role].AccessController.PublicKey(),
 		s.Roles[timelock.Bypasser_Role].AccessController.PublicKey())
 	s.Require().NoError(err)
-	validUntil := time.Now().Add(10 * time.Hour).Unix()
-	proposal, err := mcms.NewProposalBuilder().
-		SetVersion("v1").
-		SetValidUntil(uint32(validUntil)).
-		SetDescription("proposal to test SetRoot").
-		SetOverridePreviousRoot(true).
-		AddChainMetadata(s.ChainSelector, metadata).
-		AddOperation(types.Operation{
-			ChainSelector: s.ChainSelector,
-			Transaction: types.Transaction{
-				To:               recipientAddress,
-				Data:             []byte("0x"),
-				AdditionalFields: json.RawMessage(`{"value": 0, "accounts": []}`), // FIXME: not used right now; check with jonghyeon.park
-			},
-		}).
-		Build()
-	s.Require().NoError(err)
+	buildProposal := func() *mcms.Proposal {
+		validUntil := time.Now().Add(10 * time.Hour)
+		proposal, perr := mcms.NewProposalBuilder().
+			SetVersion("v1").
+			SetValidUntil(uint32(validUntil.Unix())).
+			SetDescription(fmt.Sprintf("proposal to test SetRoot - %v", validUntil.UnixMilli())).
+			SetOverridePreviousRoot(true).
+			AddChainMetadata(s.ChainSelector, metadata).
+			AddOperation(types.Operation{
+				ChainSelector: s.ChainSelector,
+				Transaction: types.Transaction{
+					To:               recipientAddress,
+					Data:             []byte("0x"),
+					AdditionalFields: json.RawMessage(`{"value": 0, "accounts": []}`),
+				},
+			}).
+			Build()
+		s.Require().NoError(perr)
 
+		return proposal
+	}
+
+	proposal := buildProposal()
 	encoders, err := proposal.GetEncoders()
 	s.Require().NoError(err)
 	encoder := encoders[s.ChainSelector].(*solanasdk.Encoder)
@@ -76,23 +82,70 @@ func (s *SolanaTestSuite) Test_Solana_SetRoot() {
 	_, err = signable.SignAndAppend(mcms.NewPrivateKeySigner(signerEVMAccount.PrivateKey))
 	s.Require().NoError(err)
 
-	// set config
-	configurer := solanasdk.NewConfigurer(s.SolanaClient, auth, s.ChainSelector)
-	_, err = configurer.SetConfig(ctx, mcmAddress, &mcmConfig, true)
-	s.Require().NoError(err)
+	s.Run("single signer", func() {
+		// set config
+		configurer := solanasdk.NewConfigurer(s.SolanaClient, auth, s.ChainSelector)
+		_, err = configurer.SetConfig(ctx, mcmAddress, &mcmConfig, true)
+		s.Require().NoError(err)
 
-	// --- act: call SetRoot ---
-	executable, err := mcms.NewExecutable(proposal, executors)
-	s.Require().NoError(err)
-	signature, err := executable.SetRoot(ctx, s.ChainSelector)
-	s.Require().NoError(err)
+		// --- act: call SetRoot ---
+		executable, err := mcms.NewExecutable(proposal, executors)
+		s.Require().NoError(err)
+		signature, err := executable.SetRoot(ctx, s.ChainSelector)
+		s.Require().NoError(err)
 
-	// --- assert ---
-	_, err = solana.SignatureFromBase58(signature.Hash)
-	s.Require().NoError(err)
+		// --- assert ---
+		_, err = solana.SignatureFromBase58(signature.Hash)
+		s.Require().NoError(err)
 
-	gotRoot, gotValidUntil, err := inspectors[s.ChainSelector].GetRoot(ctx, mcmAddress)
-	s.Require().NoError(err)
-	s.Require().Equal(common.HexToHash("0x2b970fa3b929cafc45e8740e5123ebf150c519813bcf4d9c7284518fd5720108"), gotRoot)
-	s.Require().Equal(uint32(validUntil), gotValidUntil)
+		gotRoot, gotValidUntil, err := inspectors[s.ChainSelector].GetRoot(ctx, mcmAddress)
+		s.Require().NoError(err)
+		s.Require().Equal(common.HexToHash("0x2b970fa3b929cafc45e8740e5123ebf150c519813bcf4d9c7284518fd5720108"), gotRoot)
+		s.Require().Equal(proposal.ValidUntil, gotValidUntil)
+	})
+
+	s.Run("multiple signers - exceeds default CU Limit", func() {
+		s.T().Setenv("MCMS_SOLANA_MAX_RETRIES", "20")
+
+		signers := []common.Address{}
+		mcmsSigners := []*mcms.PrivateKeySigner{}
+		for range 20 {
+			signer := NewEVMTestAccount(s.T())
+			signers = append(signers, signer.Address)
+			mcmsSigners = append(mcmsSigners, mcms.NewPrivateKeySigner(signer.PrivateKey))
+		}
+		multiSignersMcmConfig := types.Config{Quorum: uint8(len(signers)), Signers: signers}
+
+		proposal = buildProposal()
+
+		signable, err := mcms.NewSignable(proposal, inspectors)
+		s.Require().NoError(err)
+		s.Require().NotNil(signable)
+		for _, mcmsSigner := range mcmsSigners {
+			_, err = signable.SignAndAppend(mcmsSigner)
+		}
+		s.Require().NoError(err)
+
+		// set config
+		configurer := solanasdk.NewConfigurer(s.SolanaClient, auth, s.ChainSelector)
+		_, err = configurer.SetConfig(ctx, mcmAddress, &multiSignersMcmConfig, true)
+		s.Require().NoError(err)
+
+		executable, err := mcms.NewExecutable(proposal, executors)
+		s.Require().NoError(err)
+
+		// --- act: call SetRoot with "0" CU limit - will use Solana's default ---
+		s.T().Setenv("MCMS_SOLANA_COMPUTE_UNIT_LIMIT", "0")
+		_, err = executable.SetRoot(ctx, s.ChainSelector)
+		// --- assert ---
+		s.Require().ErrorContains(err, "Computational budget exceeded")
+
+		// --- act: call SetRoot with no CU limit envvar; will use max limit: 1.4M ---
+		s.T().Setenv("MCMS_SOLANA_COMPUTE_UNIT_LIMIT", "")
+		signature, err := executable.SetRoot(ctx, s.ChainSelector)
+		s.Require().NoError(err)
+		// --- assert ---
+		_, err = solana.SignatureFromBase58(signature.Hash)
+		s.Require().NoError(err)
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.4.7
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/tools v0.31.0
 	gotest.tools/v3 v3.5.1
 )
@@ -232,7 +233,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/net v0.37.0 // indirect


### PR DESCRIPTION
Due to CU limit problems executing a `solana.SetRoot` call in mainnet, we're setting the maximum CU limit for all instructions.

This has the downside of increasing the cost of the transations, so we'll follow up with a better fix that dynamically sets the CU limit according to the transaction requirements.