### PR TITLE
feat: add a labels field to attach process related metadata to a proposal [DX-1187]

### DIFF
--- a/.changeset/friendly-swans-know.md
+++ b/.changeset/friendly-swans-know.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Add labels field to proposal base type

--- a/proposal.go
+++ b/proposal.go
@@ -70,7 +70,7 @@ type BaseProposal struct {
 	OverridePreviousRoot bool                                        `json:"overridePreviousRoot"`
 	ChainMetadata        map[types.ChainSelector]types.ChainMetadata `json:"chainMetadata" validate:"required,min=1"`
 	Description          string                                      `json:"description"`
-	Labels               map[string]any                              `json:"metadata,omitempty"`
+	Metadata             map[string]any                              `json:"metadata,omitempty"`
 	// This field is passed to SDK implementations to indicate whether the proposal is being run
 	// against a simulated environment. This is only used for testing purposes.
 	useSimulatedBackend bool `json:"-"`

--- a/proposal.go
+++ b/proposal.go
@@ -70,7 +70,7 @@ type BaseProposal struct {
 	OverridePreviousRoot bool                                        `json:"overridePreviousRoot"`
 	ChainMetadata        map[types.ChainSelector]types.ChainMetadata `json:"chainMetadata" validate:"required,min=1"`
 	Description          string                                      `json:"description"`
-
+	Labels               map[string]any                              `json:"metadata,omitempty"`
 	// This field is passed to SDK implementations to indicate whether the proposal is being run
 	// against a simulated environment. This is only used for testing purposes.
 	useSimulatedBackend bool `json:"-"`


### PR DESCRIPTION
As part of being able to attach slack related metadata to a proposal, we propose adding an optional `Metadata` field to attach metadata to a proposal. This can be used to attach the slack thread ID to a proposal or in future other metadata (pager duty groups, categories, risk data, etc) to better categorize proposals or add process related fields to it. 