### PR TITLE
fix: avoid requiring all executors for predecessors calculation

### DIFF
--- a/.changeset/gentle-islands-cut.md
+++ b/.changeset/gentle-islands-cut.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix: avoid requiring all executors for converters generation

--- a/timelock_executable.go
+++ b/timelock_executable.go
@@ -262,7 +262,7 @@ func (t *TimelockExecutable) setPredecessors(ctx context.Context) error {
 	if len(t.predecessors) == 0 && len(t.executors) > 0 {
 		var err error
 		var converters = make(map[types.ChainSelector]sdk.TimelockConverter)
-		for chainSelector := range t.executors {
+		for chainSelector := range t.proposal.ChainMetadata {
 			converters[chainSelector], err = newTimelockConverter(chainSelector)
 			if err != nil {
 				return fmt.Errorf("unable to create converter from executor: %w", err)


### PR DESCRIPTION
This pull request addresses an issue in the converters generation logic for timelock executables. The main change ensures that converters are generated based on the proposal's chain metadata rather than requiring all executors, this is specially useful on the mcms cli in CLD where we need to sometimes load a subset of the chain selectors only so not all executables are provided.