### PR TITLE
feat: add ConvertedOperationCounts function to timelock proposal

### DIFF
--- a/.changeset/solid-books-wish.md
+++ b/.changeset/solid-books-wish.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+feat: add converted operations count function

--- a/sdk/evm/timelock_converter.go
+++ b/sdk/evm/timelock_converter.go
@@ -21,6 +21,11 @@ var _ sdk.TimelockConverter = (*TimelockConverter)(nil)
 
 type TimelockConverter struct{}
 
+// NewTimelockConverter creates a new TimelockConverter
+func NewTimelockConverter() *TimelockConverter {
+	return &TimelockConverter{}
+}
+
 func (t *TimelockConverter) ConvertBatchToChainOperations(
 	_ context.Context,
 	metadata types.ChainMetadata,

--- a/sdk/solana/timelock_converter.go
+++ b/sdk/solana/timelock_converter.go
@@ -23,6 +23,11 @@ var _ sdk.TimelockConverter = (*TimelockConverter)(nil)
 
 type TimelockConverter struct{}
 
+// NewTimelockConverter creates a new instance of the TimelockConverter
+func NewTimelockConverter() *TimelockConverter {
+	return &TimelockConverter{}
+}
+
 func (t TimelockConverter) ConvertBatchToChainOperations(
 	ctx context.Context,
 	metadata types.ChainMetadata,

--- a/timelock_proposal.go
+++ b/timelock_proposal.go
@@ -10,9 +10,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-playground/validator/v10"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/sdk/aptos"
+	"github.com/smartcontractkit/mcms/sdk/evm"
+	"github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/smartcontractkit/mcms/types"
 )
 
@@ -267,6 +271,64 @@ func (m *TimelockProposal) Decode(decoders map[types.ChainSelector]sdk.Decoder, 
 	}
 
 	return decodedOps, nil
+}
+
+// buildTimelockConverters builds a map of chain selectors to their corresponding TimelockConverter implementations.
+func (m *TimelockProposal) buildTimelockConverters() (map[types.ChainSelector]sdk.TimelockConverter, error) {
+	converters := make(map[types.ChainSelector]sdk.TimelockConverter)
+	for chain := range m.ChainMetadata {
+		fam, err := types.GetChainSelectorFamily(chain)
+		if err != nil {
+			return nil, fmt.Errorf("error getting chain family: %w", err)
+		}
+
+		var converter sdk.TimelockConverter
+		switch fam {
+		case chain_selectors.FamilyEVM:
+			converter = evm.NewTimelockConverter()
+		case chain_selectors.FamilySolana:
+			converter = solana.NewTimelockConverter()
+		case chain_selectors.FamilyAptos:
+			converter = aptos.NewTimelockConverter()
+		default:
+			return nil, fmt.Errorf("unsupported chain family %s", fam)
+		}
+
+		converters[chain] = converter
+	}
+	return converters, nil
+}
+
+// ConvertedOperationCounts returns per-chain counts *after* conversion for all chains in
+// the proposal, as some chains have different operation counts after conversion.
+func (m *TimelockProposal) ConvertedOperationCounts(
+	ctx context.Context,
+
+) (map[types.ChainSelector]uint64, error) {
+	// Start with raw counts (works for all non-converted chains)
+	out := m.TransactionCounts()
+
+	converters, err := m.buildTimelockConverters()
+
+	// Convert the proposal with the provided converters
+	prop, _, err := m.Convert(ctx, converters)
+	if err != nil {
+		return nil, err
+	}
+
+	// Count converted ops per chain
+	convCounts := make(map[types.ChainSelector]uint64)
+	for _, op := range prop.Operations {
+		convCounts[op.ChainSelector]++
+	}
+
+	// Overlay converted counts only for chains we attempted to convert
+	for sel := range converters {
+		if n, ok := convCounts[sel]; ok {
+			out[sel] = n
+		}
+	}
+	return out, nil
 }
 
 // timeLockProposalValidateBasic basic validation for an MCMS proposal


### PR DESCRIPTION
This pull request adds support for per-chain operation count conversion in timelock proposals, refactors the creation of `TimelockConverter` instances for multiple chain families, and introduces comprehensive tests for the new logic. The main changes are grouped below:

### TimelockConverter instantiation improvements

* Added `NewTimelockConverter` constructor functions to both `sdk/evm/timelock_converter.go` and `sdk/solana/timelock_converter.go` to standardize the creation of `TimelockConverter` instances for EVM and Solana chains. [[1]](diffhunk://#diff-46c9e3eff7152d7e12bf5c9cb9e16604d57bc2c3edbc9985b2d283af4a058f1cR24-R28) [[2]](diffhunk://#diff-8ed88f63d8d6bc4a9201b82b303262ce4763d13abb4756be007400a3c20ce977R26-R30)

### TimelockProposal conversion logic

* Implemented the `buildTimelockConverters` method in `timelock_proposal.go` to dynamically map chain selectors to the correct `TimelockConverter` implementation based on chain family (EVM, Solana, Aptos).
* Added the `ConvertedOperationCounts` method to `TimelockProposal`, which computes per-chain operation counts after conversion, reflecting differences in how chains process batch operations.

### Test coverage enhancements

* Added a new test `Test_TimelockProposal_ConvertedOperationCounts` in `timelock_proposal_test.go` to verify the correct behavior of operation count conversion across multiple chain types.
* Added helper function `marshalAdditionalFields` to assist with test data preparation for Solana chains.

### Dependency and import updates

* Updated imports in `timelock_proposal.go` and `timelock_proposal_test.go` to include necessary chain SDKs and dependencies for EVM, Solana, and Aptos support. [[1]](diffhunk://#diff-22aa9f90e7ed0f30eb381e769a6ce492d3472c4e8029e134f0074e1913ce482fR13-R19) [[2]](diffhunk://#diff-b80686a8969c14a89af64e7ed45e5a1e0dc025880256405d9e48eac6e33722b9R14-R22)