### PR TITLE
fix: use deep map merge when merging proposal Metadata

### DIFF
--- a/.changeset/old-experts-travel.md
+++ b/.changeset/old-experts-travel.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+fix: use deep map merge when merging proposal Metadata

--- a/proposal.go
+++ b/proposal.go
@@ -151,7 +151,7 @@ func WriteProposal(w io.Writer, proposal *Proposal) error {
 
 func (p *Proposal) Validate() error {
 	// Run tag-based validation
-	var validate = validator.New()
+	validate := validator.New()
 	if err := validate.Struct(p); err != nil {
 		return err
 	}
@@ -392,20 +392,28 @@ func wrapTreeGenErr(err error) error {
 	return fmt.Errorf("merkle tree generation error: %w", err)
 }
 
-func mergeMetadata(m1, m2 map[string]any) (map[string]any, error) {
+func mergeMetadata(m1, m2 map[string]any) map[string]any {
 	if len(m2) == 0 {
-		return m1, nil
+		return m1
 	}
 
-	merged := make(map[string]any, len(m1))
-	maps.Copy(merged, m1)
-	for k, v2 := range m2 {
-		v1, exists := m1[k]
-		if exists && v1 != v2 {
-			return nil, fmt.Errorf("conflicting metadata for key %s: %v vs %v (%T %T %v)", k, v1, v2, v1, v2, v1 == v2)
+	return mergeMetadataMaps(m1, m2)
+}
+
+func mergeMetadataMaps(a, b map[string]any) map[string]any {
+	out := make(map[string]any, len(a))
+	maps.Copy(out, a)
+	for k, v := range b {
+		if v, ok := v.(map[string]any); ok {
+			if bv, ok := out[k]; ok {
+				if bv, ok := bv.(map[string]any); ok {
+					out[k] = mergeMetadataMaps(bv, v)
+					continue
+				}
+			}
 		}
-		merged[k] = v2
+		out[k] = v
 	}
 
-	return merged, nil
+	return out
 }

--- a/timelock_proposal.go
+++ b/timelock_proposal.go
@@ -361,11 +361,7 @@ func (m *TimelockProposal) Merge(_ context.Context, other *TimelockProposal) (*T
 
 	m.Signatures = nil // reset signatures, as existing ones are no longer valid
 
-	var err error
-	m.Metadata, err = mergeMetadata(m.Metadata, other.Metadata)
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge proposal metadata: %w", err)
-	}
+	m.Metadata = mergeMetadata(m.Metadata, other.Metadata)
 
 	for chainSelector, otherMetadata := range other.ChainMetadata {
 		thisMetadata, exists := m.ChainMetadata[chainSelector]

--- a/timelock_proposal_test.go
+++ b/timelock_proposal_test.go
@@ -1412,7 +1412,7 @@ func Test_TimelockProposal_Merge(t *testing.T) {
 			},
 		},
 		{
-			name: "success: merge Metadata", // implemented separately as the Metadata field is not used anywhere else
+			name: "success: merge Metadata",
 			proposal1: func() *TimelockProposal {
 				proposal := mustBuild(t, baseProposalBuilder())
 				proposal.Metadata = map[string]any{"key1": 1, "key2": "two"}
@@ -1421,13 +1421,13 @@ func Test_TimelockProposal_Merge(t *testing.T) {
 			}(),
 			proposal2: func() *TimelockProposal {
 				proposal := mustBuild(t, baseProposalBuilder())
-				proposal.Metadata = map[string]any{"key1": 1, "key3": 3.0}
+				proposal.Metadata = map[string]any{"key1": "one", "key3": 3.0}
 
 				return proposal
 			}(),
 			assert: func(t *testing.T, merged *TimelockProposal) {
 				t.Helper()
-				want := map[string]any{"key1": 1, "key2": "two", "key3": 3.0}
+				want := map[string]any{"key1": "one", "key2": "two", "key3": 3.0}
 				require.Equal(t, want, merged.Metadata)
 			},
 		},
@@ -1527,22 +1527,6 @@ func Test_TimelockProposal_Merge(t *testing.T) {
 				return proposal
 			}(),
 			wantErr: "cannot merge ChainMetadata with different value for key \"key\" in AdditionalFields: value1 vs value2",
-		},
-		{
-			name: "failure: conflicting values in Metadata", // implemented separately as the Metadata field is not used anywhere else
-			proposal1: func() *TimelockProposal {
-				proposal := mustBuild(t, baseProposalBuilder())
-				proposal.Metadata = map[string]any{"key1": 1}
-
-				return proposal
-			}(),
-			proposal2: func() *TimelockProposal {
-				proposal := mustBuild(t, baseProposalBuilder())
-				proposal.Metadata = map[string]any{"key1": "one"}
-
-				return proposal
-			}(),
-			wantErr: "failed to merge proposal metadata: conflicting metadata for key key1",
 		},
 	}
 


### PR DESCRIPTION
It's more suitable for the cases when we need to merge two proposals that already have the slack attributes set in the Metadata section.