### PR TITLE
feat: add proposal checks for duplicate signers [DX-1519]

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -138,3 +138,12 @@ func (e *InvalidSignatureError) Error() string {
 func NewInvalidSignatureError(recoveredAddress common.Address) *InvalidSignatureError {
 	return &InvalidSignatureError{RecoveredAddress: recoveredAddress}
 }
+
+// DuplicateSignersError is returned when proposal signatures contain the same signer more than once.
+type DuplicateSignersError struct {
+	signer string
+}
+
+func (e *DuplicateSignersError) Error() string {
+	return fmt.Sprintf("duplicate signer detected: %s", e.signer)
+}

--- a/proposal.go
+++ b/proposal.go
@@ -1,6 +1,7 @@
 package mcms
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -153,6 +154,11 @@ func (p *Proposal) Validate() error {
 	// Run tag-based validation
 	var validate = validator.New()
 	if err := validate.Struct(p); err != nil {
+		return err
+	}
+
+	// ensure there are no duplicate signers
+	if err := validateNoDuplicateSigners(p.Signatures); err != nil {
 		return err
 	}
 
@@ -408,4 +414,19 @@ func mergeMetadata(m1, m2 map[string]any) (map[string]any, error) {
 	}
 
 	return merged, nil
+}
+
+// validateNoDuplicateSigners ensures all signers are unique based on their raw bytes.
+func validateNoDuplicateSigners(sigs []types.Signature) error {
+	seen := make(map[string]struct{}, len(sigs))
+	for _, s := range sigs {
+		// Use bytes from the signature’s signer identity and encode to hex for a stable key.
+		key := hex.EncodeToString(s.ToBytes())
+		if _, ok := seen[key]; ok {
+			return &DuplicateSignersError{signer: key}
+		}
+		seen[key] = struct{}{}
+	}
+
+	return nil
 }

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -471,6 +471,16 @@ func Test_Proposal_Validate(t *testing.T) {
 				"Key: 'Proposal.Operations[0].Transaction.AdditionalFields' Error:Field validation for 'AdditionalFields' failed on the 'required' tag",
 			},
 		},
+		{
+			name: "duplicate signers",
+			giveFunc: func(p *Proposal) {
+				// Two identical signatures -> same ToBytes() -> duplicate
+				p.Signatures = []types.Signature{{}, {}}
+			},
+			wantErrs: []string{
+				"duplicate signer detected: 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/sdk/evm/timelock_converter.go
+++ b/sdk/evm/timelock_converter.go
@@ -61,6 +61,7 @@ func (t *TimelockConverter) ConvertBatchToChainOperations(
 	}
 
 	operationId, errHash := HashOperationBatch(calls, predecessor, salt)
+
 	if errHash != nil {
 		return []types.Operation{}, common.Hash{}, errHash
 	}


### PR DESCRIPTION
This pull request introduces validation to ensure that proposals do not contain duplicate signers in their signatures, improving the integrity of the proposal verification process. The main changes include implementing a new error type for duplicate signers, adding a validation function to detect duplicates, integrating this check into the proposal validation flow, and updating tests to cover this scenario.

**Signature validation improvements:**

* Added a new error type `DuplicateSignersError` in `errors.go` to clearly report when duplicate signers are detected in proposal signatures.
* Implemented the `validateNoDuplicateSigners` function in `proposal.go`, which checks for duplicate signers by comparing the raw bytes of each signature.
* Integrated the duplicate signer check into the `Proposal.Validate()` method so that proposals with duplicate signers will now fail validation.

**Testing enhancements:**

* Updated `Test_Proposal_Validate` in `proposal_test.go` to include a test case that verifies the new duplicate signer validation logic.

**Minor code improvements:**

* Added import of `encoding/hex` to support hex encoding in the new validation function.