### PR TITLE
feat: UpdateDelay

### DIFF
--- a/e2e/tests/evm/timelock_configuration.go
+++ b/e2e/tests/evm/timelock_configuration.go
@@ -1,0 +1,40 @@
+//go:build e2e
+
+package evme2e
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	testutils "github.com/smartcontractkit/mcms/e2e/utils"
+	"github.com/smartcontractkit/mcms/sdk/evm"
+)
+
+func (s *TimelockInspectionTestSuite) TestUpdateDelay() {
+	ctx := s.T().Context()
+
+	timelockContract := testutils.DeployTimelockContract(&s.Suite, s.ClientA, s.auth, s.publicKey.String())
+	addr := timelockContract.Address().Hex()
+
+	configurer := evm.NewTimelockConfigurer(s.ClientA, s.auth)
+
+	delay, err := configurer.GetMinDelay(ctx, addr)
+	s.Require().NoError(err, "Failed to get initial min delay")
+	s.Require().EqualValues(0, delay)
+
+	newDelay := uint64(120)
+	result, err := configurer.UpdateDelay(ctx, addr, newDelay)
+	s.Require().NoError(err, "Failed to update delay")
+	s.Require().NotEmpty(result.Hash, "Transaction hash should not be empty")
+	s.Require().Equal(chainsel.FamilyEVM, result.ChainFamily, "Chain family should be EVM")
+
+	receipt, err := testutils.WaitMinedWithTxHash(ctx, s.ClientA, common.HexToHash(result.Hash))
+	s.Require().NoError(err, "Failed to wait for transaction to be mined")
+	s.Require().Equal(types.ReceiptStatusSuccessful, receipt.Status, "Transaction was not successful")
+
+	delay, err = configurer.GetMinDelay(ctx, addr)
+	s.Require().NoError(err, "Failed to get updated min delay")
+	s.Require().Equal(newDelay, delay, "Delay should match the updated value")
+}

--- a/e2e/tests/evm/timelock_inspection.go
+++ b/e2e/tests/evm/timelock_inspection.go
@@ -323,4 +323,3 @@ func (s *TimelockInspectionTestSuite) TestGetMinDelay() {
 	s.Require().NoError(err, "Failed to get min delay")
 	s.Require().EqualValues(0, delay)
 }
-

--- a/e2e/tests/evm/timelock_inspection.go
+++ b/e2e/tests/evm/timelock_inspection.go
@@ -14,8 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/suite"
 
-	chainsel "github.com/smartcontractkit/chain-selectors"
-
 	e2e "github.com/smartcontractkit/mcms/e2e/tests"
 	testutils "github.com/smartcontractkit/mcms/e2e/utils"
 	"github.com/smartcontractkit/mcms/sdk/evm"
@@ -326,29 +324,3 @@ func (s *TimelockInspectionTestSuite) TestGetMinDelay() {
 	s.Require().EqualValues(0, delay)
 }
 
-func (s *TimelockInspectionTestSuite) TestUpdateDelay() {
-	ctx := context.Background()
-
-	timelockContract := testutils.DeployTimelockContract(&s.Suite, s.ClientA, s.auth, s.publicKey.String())
-	addr := timelockContract.Address().Hex()
-
-	configurer := evm.NewTimelockConfigurer(s.ClientA, s.auth)
-
-	delay, err := configurer.GetMinDelay(ctx, addr)
-	s.Require().NoError(err, "Failed to get initial min delay")
-	s.Require().EqualValues(0, delay)
-
-	newDelay := uint64(120)
-	result, err := configurer.UpdateDelay(ctx, addr, newDelay)
-	s.Require().NoError(err, "Failed to update delay")
-	s.Require().NotEmpty(result.Hash, "Transaction hash should not be empty")
-	s.Require().Equal(chainsel.FamilyEVM, result.ChainFamily, "Chain family should be EVM")
-
-	receipt, err := testutils.WaitMinedWithTxHash(ctx, s.ClientA, common.HexToHash(result.Hash))
-	s.Require().NoError(err, "Failed to wait for transaction to be mined")
-	s.Require().Equal(types.ReceiptStatusSuccessful, receipt.Status, "Transaction was not successful")
-
-	delay, err = configurer.GetMinDelay(ctx, addr)
-	s.Require().NoError(err, "Failed to get updated min delay")
-	s.Require().Equal(newDelay, delay, "Delay should match the updated value")
-}

--- a/e2e/tests/evm/timelock_inspection.go
+++ b/e2e/tests/evm/timelock_inspection.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/suite"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	e2e "github.com/smartcontractkit/mcms/e2e/tests"
 	testutils "github.com/smartcontractkit/mcms/e2e/utils"
 	"github.com/smartcontractkit/mcms/sdk/evm"
@@ -322,4 +324,31 @@ func (s *TimelockInspectionTestSuite) TestGetMinDelay() {
 	delay, err := inspector.GetMinDelay(ctx, s.timelockContract.Address().Hex())
 	s.Require().NoError(err, "Failed to get min delay")
 	s.Require().EqualValues(0, delay)
+}
+
+func (s *TimelockInspectionTestSuite) TestUpdateDelay() {
+	ctx := context.Background()
+
+	timelockContract := testutils.DeployTimelockContract(&s.Suite, s.ClientA, s.auth, s.publicKey.String())
+	addr := timelockContract.Address().Hex()
+
+	configurer := evm.NewTimelockConfigurer(s.ClientA, s.auth)
+
+	delay, err := configurer.GetMinDelay(ctx, addr)
+	s.Require().NoError(err, "Failed to get initial min delay")
+	s.Require().EqualValues(0, delay)
+
+	newDelay := uint64(120)
+	result, err := configurer.UpdateDelay(ctx, addr, newDelay)
+	s.Require().NoError(err, "Failed to update delay")
+	s.Require().NotEmpty(result.Hash, "Transaction hash should not be empty")
+	s.Require().Equal(chainsel.FamilyEVM, result.ChainFamily, "Chain family should be EVM")
+
+	receipt, err := testutils.WaitMinedWithTxHash(ctx, s.ClientA, common.HexToHash(result.Hash))
+	s.Require().NoError(err, "Failed to wait for transaction to be mined")
+	s.Require().Equal(types.ReceiptStatusSuccessful, receipt.Status, "Transaction was not successful")
+
+	delay, err = configurer.GetMinDelay(ctx, addr)
+	s.Require().NoError(err, "Failed to get updated min delay")
+	s.Require().Equal(newDelay, delay, "Delay should match the updated value")
 }

--- a/e2e/tests/solana/timelock_configuration.go
+++ b/e2e/tests/solana/timelock_configuration.go
@@ -1,0 +1,39 @@
+//go:build e2e
+
+package solanae2e
+
+import (
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+)
+
+func (s *TestSuite) TestUpdateDelay() {
+	ctx := s.T().Context()
+	initialDelay := 1 * time.Second
+	s.SetupTimelock(testPDASeedTimelockUpdateDelay, initialDelay)
+
+	admin, err := solana.PrivateKeyFromBase58(privateKey)
+	s.Require().NoError(err)
+
+	timelockAddr := solanasdk.ContractAddress(s.TimelockProgramID, testPDASeedTimelockUpdateDelay)
+	configurer := solanasdk.NewTimelockConfigurer(s.SolanaClient, admin)
+
+	delay, err := configurer.GetMinDelay(ctx, timelockAddr)
+	s.Require().NoError(err, "Failed to get initial min delay")
+	s.Require().Equal(uint64(initialDelay.Seconds()), delay, "Initial delay should match configured value")
+
+	newDelay := uint64(120)
+	result, err := configurer.UpdateDelay(ctx, timelockAddr, newDelay)
+	s.Require().NoError(err, "Failed to update delay")
+	s.Require().NotEmpty(result.Hash, "Transaction hash should not be empty")
+	s.Require().Equal(chainsel.FamilySolana, result.ChainFamily, "Chain family should be Solana")
+
+	delay, err = configurer.GetMinDelay(ctx, timelockAddr)
+	s.Require().NoError(err, "Failed to get updated min delay")
+	s.Require().Equal(newDelay, delay, "Delay should match the updated value")
+}

--- a/e2e/tests/solana/timelock_inspection.go
+++ b/e2e/tests/solana/timelock_inspection.go
@@ -8,21 +8,26 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/timelock"
 	timelockutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/timelock"
 
 	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 )
 
-var testPDASeedTimelockGetProposers = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'p', 'r', 'o', 'p', 'o', 's', 'e', 'r'}
-var testPDASeedTimelockGetExecutors = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'e', 'x', 'e', 'c'}
-var testPDASeedTimelockGetCancellers = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'c', 'a', 'n', 'c', 'e', 'l'}
-var testPDASeedTimelockGetBypassers = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'b', 'y', 'p', 'a', 's', 's'}
-var testPDASeedTimelockIsOperations = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'o', 'p', 's'}
-var testPDASeedTimelockIsOperationsPending = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'o', 'p', 's', 'p', 'e', 'n', 'd'}
-var testPDASeedTimelockIsOperationsReady = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'o', 'p', 's', 'r', 'e', 'a', 'd', 'y'}
-var testPDASeedTimelockIsOperationsDone = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'o', 'p', 's', 'd', 'o', 'n', 'e'}
-var testPDASeedTimelockMinDelay = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'm', 'i', 'n', 'd', 'e', 'l', 'a', 'y'}
+var (
+	testPDASeedTimelockGetProposers        = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'p', 'r', 'o', 'p', 'o', 's', 'e', 'r'}
+	testPDASeedTimelockGetExecutors        = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'e', 'x', 'e', 'c'}
+	testPDASeedTimelockGetCancellers       = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'c', 'a', 'n', 'c', 'e', 'l'}
+	testPDASeedTimelockGetBypassers        = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'b', 'y', 'p', 'a', 's', 's'}
+	testPDASeedTimelockIsOperations        = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'o', 'p', 's'}
+	testPDASeedTimelockIsOperationsPending = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'o', 'p', 's', 'p', 'e', 'n', 'd'}
+	testPDASeedTimelockIsOperationsReady   = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'o', 'p', 's', 'r', 'e', 'a', 'd', 'y'}
+	testPDASeedTimelockIsOperationsDone    = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'o', 'p', 's', 'd', 'o', 'n', 'e'}
+	testPDASeedTimelockMinDelay            = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'm', 'i', 'n', 'd', 'e', 'l', 'a', 'y'}
+	testPDASeedTimelockUpdateDelay         = [32]byte{'t', 'e', 's', 't', '-', 't', 'i', 'm', 'e', 'u', 'p', 'd', 'a', 't', 'e', 'd'}
+)
 
 func (s *TestSuite) TestGetProposers() {
 	s.SetupTimelock(testPDASeedTimelockGetProposers, 1*time.Second)
@@ -33,7 +38,7 @@ func (s *TestSuite) TestGetProposers() {
 	s.Require().NoError(err, "Failed to get proposers")
 	s.Require().Len(proposers, 2, "Expected 2 proposers")
 
-	var expected = make([]string, 0, len(s.Roles[timelock.Proposer_Role].Accounts))
+	expected := make([]string, 0, len(s.Roles[timelock.Proposer_Role].Accounts))
 	for _, acc := range s.Roles[timelock.Proposer_Role].Accounts {
 		expected = append(expected, acc.PublicKey().String())
 	}
@@ -49,7 +54,7 @@ func (s *TestSuite) TestGetExecutors() {
 	s.Require().NoError(err, "Failed to get executors")
 	s.Require().Len(executors, 2, "Expected 2 executors")
 
-	var expected = make([]string, 0, len(s.Roles[timelock.Executor_Role].Accounts))
+	expected := make([]string, 0, len(s.Roles[timelock.Executor_Role].Accounts))
 	for _, acc := range s.Roles[timelock.Executor_Role].Accounts {
 		expected = append(expected, acc.PublicKey().String())
 	}
@@ -65,7 +70,7 @@ func (s *TestSuite) TestGetCancellers() {
 	s.Require().NoError(err, "Failed to get cancellers")
 	s.Require().Len(cancellers, 2, "Expected 2 cancellers")
 
-	var expected = make([]string, 0, len(s.Roles[timelock.Canceller_Role].Accounts))
+	expected := make([]string, 0, len(s.Roles[timelock.Canceller_Role].Accounts))
 	for _, acc := range s.Roles[timelock.Canceller_Role].Accounts {
 		expected = append(expected, acc.PublicKey().String())
 	}
@@ -81,7 +86,7 @@ func (s *TestSuite) TestGetBypassers() {
 	s.Require().NoError(err, "Failed to get bypassers")
 	s.Require().Len(bypassers, 2, "Expected 2 bypassers")
 
-	var expected = make([]string, 0, len(s.Roles[timelock.Bypasser_Role].Accounts))
+	expected := make([]string, 0, len(s.Roles[timelock.Bypasser_Role].Accounts))
 	for _, acc := range s.Roles[timelock.Bypasser_Role].Accounts {
 		expected = append(expected, acc.PublicKey().String())
 	}
@@ -169,6 +174,32 @@ func (s *TestSuite) TestGetMinDelay() {
 
 	s.Require().NoError(err, "Failed to query min delay")
 	s.Require().Equal(delay, uint64(minDelay.Seconds()), "Min delay should match the configured value")
+}
+
+func (s *TestSuite) TestUpdateDelay() {
+	ctx := context.Background()
+	initialDelay := 1 * time.Second
+	s.SetupTimelock(testPDASeedTimelockUpdateDelay, initialDelay)
+
+	admin, err := solana.PrivateKeyFromBase58(privateKey)
+	s.Require().NoError(err)
+
+	timelockAddr := solanasdk.ContractAddress(s.TimelockProgramID, testPDASeedTimelockUpdateDelay)
+	configurer := solanasdk.NewTimelockConfigurer(s.SolanaClient, admin)
+
+	delay, err := configurer.GetMinDelay(ctx, timelockAddr)
+	s.Require().NoError(err, "Failed to get initial min delay")
+	s.Require().Equal(uint64(initialDelay.Seconds()), delay, "Initial delay should match configured value")
+
+	newDelay := uint64(120)
+	result, err := configurer.UpdateDelay(ctx, timelockAddr, newDelay)
+	s.Require().NoError(err, "Failed to update delay")
+	s.Require().NotEmpty(result.Hash, "Transaction hash should not be empty")
+	s.Require().Equal(chainsel.FamilySolana, result.ChainFamily, "Chain family should be Solana")
+
+	delay, err = configurer.GetMinDelay(ctx, timelockAddr)
+	s.Require().NoError(err, "Failed to get updated min delay")
+	s.Require().Equal(newDelay, delay, "Delay should match the updated value")
 }
 
 func (s *TestSuite) createOperation(timelockID [32]byte) timelockutils.Operation {

--- a/e2e/tests/solana/timelock_inspection.go
+++ b/e2e/tests/solana/timelock_inspection.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 
-	chainsel "github.com/smartcontractkit/chain-selectors"
-
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/timelock"
 	timelockutils "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/timelock"
 
@@ -174,32 +172,6 @@ func (s *TestSuite) TestGetMinDelay() {
 
 	s.Require().NoError(err, "Failed to query min delay")
 	s.Require().Equal(delay, uint64(minDelay.Seconds()), "Min delay should match the configured value")
-}
-
-func (s *TestSuite) TestUpdateDelay() {
-	ctx := context.Background()
-	initialDelay := 1 * time.Second
-	s.SetupTimelock(testPDASeedTimelockUpdateDelay, initialDelay)
-
-	admin, err := solana.PrivateKeyFromBase58(privateKey)
-	s.Require().NoError(err)
-
-	timelockAddr := solanasdk.ContractAddress(s.TimelockProgramID, testPDASeedTimelockUpdateDelay)
-	configurer := solanasdk.NewTimelockConfigurer(s.SolanaClient, admin)
-
-	delay, err := configurer.GetMinDelay(ctx, timelockAddr)
-	s.Require().NoError(err, "Failed to get initial min delay")
-	s.Require().Equal(uint64(initialDelay.Seconds()), delay, "Initial delay should match configured value")
-
-	newDelay := uint64(120)
-	result, err := configurer.UpdateDelay(ctx, timelockAddr, newDelay)
-	s.Require().NoError(err, "Failed to update delay")
-	s.Require().NotEmpty(result.Hash, "Transaction hash should not be empty")
-	s.Require().Equal(chainsel.FamilySolana, result.ChainFamily, "Chain family should be Solana")
-
-	delay, err = configurer.GetMinDelay(ctx, timelockAddr)
-	s.Require().NoError(err, "Failed to get updated min delay")
-	s.Require().Equal(newDelay, delay, "Delay should match the updated value")
 }
 
 func (s *TestSuite) createOperation(timelockID [32]byte) timelockutils.Operation {

--- a/sdk/evm/timelock_configurer.go
+++ b/sdk/evm/timelock_configurer.go
@@ -1,0 +1,58 @@
+package evm
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+var _ sdk.TimelockConfigurer = (*TimelockConfigurer)(nil)
+
+// TimelockConfigurer configures timelock parameters on EVM chains.
+type TimelockConfigurer struct {
+	TimelockInspector
+	client ContractDeployBackend
+	auth   *bind.TransactOpts
+}
+
+// NewTimelockConfigurer creates a new TimelockConfigurer for EVM chains.
+func NewTimelockConfigurer(client ContractDeployBackend, auth *bind.TransactOpts) *TimelockConfigurer {
+	return &TimelockConfigurer{
+		TimelockInspector: *NewTimelockInspector(client),
+		client:            client,
+		auth:              auth,
+	}
+}
+
+// UpdateDelay calls updateDelay on the RBACTimelock contract to change the minimum delay.
+func (c *TimelockConfigurer) UpdateDelay(
+	ctx context.Context, timelockAddress string, newDelay uint64,
+) (types.TransactionResult, error) {
+	opts := *c.auth
+	opts.Context = ctx
+
+	tl, err := bindings.NewRBACTimelock(common.HexToAddress(timelockAddress), c.client)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("failed to bind RBACTimelock at %s: %w", timelockAddress, err)
+	}
+
+	tx, err := tl.UpdateDelay(&opts, new(big.Int).SetUint64(newDelay))
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("failed to update delay on %s: %w", timelockAddress, err)
+	}
+
+	return types.TransactionResult{
+		Hash:        tx.Hash().Hex(),
+		ChainFamily: chainsel.FamilyEVM,
+		RawData:     tx,
+	}, nil
+}

--- a/sdk/evm/timelock_configurer_test.go
+++ b/sdk/evm/timelock_configurer_test.go
@@ -63,7 +63,6 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 		timelockAddress string
 		newDelay        uint64
 		mockSetup       func(m *evm_mocks.ContractDeployBackend)
-		wantTxHash      string
 		wantErr         bool
 	}{
 		{
@@ -75,8 +74,7 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 					Return(nil)
 				sharedMockSetup(m)
 			},
-			wantTxHash: "",
-			wantErr:    false,
+			wantErr: false,
 		},
 		{
 			name:            "failure in tx execution",

--- a/sdk/evm/timelock_configurer_test.go
+++ b/sdk/evm/timelock_configurer_test.go
@@ -63,7 +63,7 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 		timelockAddress string
 		newDelay        uint64
 		mockSetup       func(m *evm_mocks.ContractDeployBackend)
-		wantErr         bool
+		wantErr         string
 	}{
 		{
 			name:            "success",
@@ -74,7 +74,6 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 					Return(nil)
 				sharedMockSetup(m)
 			},
-			wantErr: false,
 		},
 		{
 			name:            "failure in tx execution",
@@ -85,7 +84,7 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 					Return(errors.New("error during tx send"))
 				sharedMockSetup(m)
 			},
-			wantErr: true,
+			wantErr: "failed to update delay",
 		},
 	}
 
@@ -101,8 +100,8 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 			configurer := NewTimelockConfigurer(client, mockAuth)
 			result, err := configurer.UpdateDelay(t.Context(), test.timelockAddress, test.newDelay)
 
-			if test.wantErr {
-				require.Error(t, err)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
 			} else {
 				require.NoError(t, err)
 				assert.NotEmpty(t, result.Hash)

--- a/sdk/evm/timelock_configurer_test.go
+++ b/sdk/evm/timelock_configurer_test.go
@@ -1,0 +1,114 @@
+package evm
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	evmTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	evm_mocks "github.com/smartcontractkit/mcms/sdk/evm/mocks"
+)
+
+func TestNewTimelockConfigurer(t *testing.T) {
+	t.Parallel()
+
+	mockClient := evm_mocks.NewContractDeployBackend(t)
+	mockAuth := &bind.TransactOpts{}
+
+	configurer := NewTimelockConfigurer(mockClient, mockAuth)
+
+	assert.Equal(t, mockClient, configurer.client)
+	assert.Equal(t, mockAuth, configurer.auth)
+}
+
+func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
+	t.Parallel()
+
+	mockAuth := &bind.TransactOpts{
+		Signer: func(address common.Address, transaction *evmTypes.Transaction) (*evmTypes.Transaction, error) {
+			mockTx := evmTypes.NewTransaction(
+				1,
+				common.HexToAddress("0xMockedAddress"),
+				big.NewInt(1000000000000000000),
+				21000,
+				big.NewInt(20000000000),
+				nil,
+			)
+
+			return mockTx, nil
+		},
+	}
+
+	sharedMockSetup := func(m *evm_mocks.ContractDeployBackend) {
+		m.EXPECT().HeaderByNumber(mock.Anything, mock.Anything).
+			Return(&evmTypes.Header{}, nil)
+		m.EXPECT().SuggestGasPrice(mock.Anything).
+			Return(big.NewInt(100000000), nil)
+		m.EXPECT().PendingCodeAt(mock.Anything, mock.Anything).
+			Return([]byte("0x01"), nil)
+		m.EXPECT().EstimateGas(mock.Anything, mock.Anything).
+			Return(uint64(50000), nil)
+		m.EXPECT().PendingNonceAt(mock.Anything, mock.Anything).
+			Return(uint64(1), nil)
+	}
+
+	tests := []struct {
+		name            string
+		timelockAddress string
+		newDelay        uint64
+		mockSetup       func(m *evm_mocks.ContractDeployBackend)
+		wantTxHash      string
+		wantErr         bool
+	}{
+		{
+			name:            "success",
+			timelockAddress: "0xMockedTimelockAddress",
+			newDelay:        120,
+			mockSetup: func(m *evm_mocks.ContractDeployBackend) {
+				m.EXPECT().SendTransaction(mock.Anything, mock.Anything).
+					Return(nil)
+				sharedMockSetup(m)
+			},
+			wantTxHash: "",
+			wantErr:    false,
+		},
+		{
+			name:            "failure in tx execution",
+			timelockAddress: "0xMockedTimelockAddress",
+			newDelay:        120,
+			mockSetup: func(m *evm_mocks.ContractDeployBackend) {
+				m.EXPECT().SendTransaction(mock.Anything, mock.Anything).
+					Return(errors.New("error during tx send"))
+				sharedMockSetup(m)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := evm_mocks.NewContractDeployBackend(t)
+			if test.mockSetup != nil {
+				test.mockSetup(client)
+			}
+
+			configurer := NewTimelockConfigurer(client, mockAuth)
+			result, err := configurer.UpdateDelay(t.Context(), test.timelockAddress, test.newDelay)
+
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.NotEmpty(t, result.Hash)
+			}
+		})
+	}
+}

--- a/sdk/solana/timelock_configurer.go
+++ b/sdk/solana/timelock_configurer.go
@@ -1,0 +1,69 @@
+package solana
+
+import (
+	"context"
+	"fmt"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/types"
+
+	bindings "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/timelock"
+)
+
+var _ sdk.TimelockConfigurer = (*TimelockConfigurer)(nil)
+
+// TimelockConfigurer configures timelock parameters on Solana chains.
+type TimelockConfigurer struct {
+	*TimelockInspector
+	client *rpc.Client
+	auth   solana.PrivateKey
+}
+
+// NewTimelockConfigurer creates a new TimelockConfigurer for Solana chains.
+func NewTimelockConfigurer(client *rpc.Client, auth solana.PrivateKey) *TimelockConfigurer {
+	return &TimelockConfigurer{
+		TimelockInspector: NewTimelockInspector(client),
+		client:            client,
+		auth:              auth,
+	}
+}
+
+// UpdateDelay calls the UpdateDelay instruction on the Solana RBACTimelock program.
+func (c *TimelockConfigurer) UpdateDelay(
+	ctx context.Context, timelockAddress string, newDelay uint64,
+) (types.TransactionResult, error) {
+	programID, timelockID, err := ParseContractAddress(timelockAddress)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("unable to parse contract address: %w", err)
+	}
+
+	bindings.SetProgramID(programID)
+
+	configPDA, err := FindTimelockConfigPDA(programID, timelockID)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("unable to find timelock config pda: %w", err)
+	}
+
+	instruction := bindings.NewUpdateDelayInstruction(
+		timelockID,
+		newDelay,
+		configPDA,
+		c.auth.PublicKey(),
+	)
+
+	signature, tx, err := sendAndConfirm(ctx, c.client, c.auth, instruction, rpc.CommitmentConfirmed)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("unable to update delay: %w", err)
+	}
+
+	return types.TransactionResult{
+		Hash:        signature,
+		ChainFamily: chainsel.FamilySolana,
+		RawData:     tx,
+	}, nil
+}

--- a/sdk/solana/timelock_configurer_test.go
+++ b/sdk/solana/timelock_configurer_test.go
@@ -64,7 +64,7 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) { //nolint:paralleltest
 			},
 		},
 		{
-			name:     "error: send tx fails",
+			name:     "error: get latest blockhash fails",
 			address:  timelockAddress,
 			newDelay: 120,
 			setup: func(t *testing.T, _ *TimelockConfigurer, m *mocks.JSONRPCClient) {

--- a/sdk/solana/timelock_configurer_test.go
+++ b/sdk/solana/timelock_configurer_test.go
@@ -1,0 +1,97 @@
+package solana
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+
+	"github.com/smartcontractkit/mcms/sdk/solana/mocks"
+)
+
+func TestNewTimelockConfigurer(t *testing.T) {
+	t.Parallel()
+
+	client := &rpc.Client{}
+	auth, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+
+	configurer := NewTimelockConfigurer(client, auth)
+
+	require.NotNil(t, configurer)
+	require.Equal(t, auth, configurer.auth)
+}
+
+func TestTimelockConfigurer_UpdateDelay(t *testing.T) { //nolint:paralleltest
+	auth, err := solana.PrivateKeyFromBase58(dummyPrivateKey)
+	require.NoError(t, err)
+
+	timelockAddress := fmt.Sprintf("%s.%s", testTimelockProgramID.String(), testTimelockSeed)
+
+	tests := []struct {
+		name      string
+		address   string
+		newDelay  uint64
+		setup     func(*testing.T, *TimelockConfigurer, *mocks.JSONRPCClient)
+		want      string
+		assertion assert.ErrorAssertionFunc
+	}{
+		{
+			name:     "success",
+			address:  timelockAddress,
+			newDelay: 120,
+			setup: func(t *testing.T, _ *TimelockConfigurer, m *mocks.JSONRPCClient) {
+				t.Helper()
+				mockSolanaTransaction(t, m, 20, 5,
+					"2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6",
+					nil, nil)
+			},
+			want:      "2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6",
+			assertion: assert.NoError,
+		},
+		{
+			name:     "error: invalid address",
+			address:  "bad ...format",
+			newDelay: 120,
+			setup:    func(t *testing.T, _ *TimelockConfigurer, _ *mocks.JSONRPCClient) { t.Helper() },
+			assertion: func(t assert.TestingT, err error, _ ...any) bool {
+				return assert.ErrorIs(t, err, ErrInvalidContractAddressFormat)
+			},
+		},
+		{
+			name:     "error: send tx fails",
+			address:  timelockAddress,
+			newDelay: 120,
+			setup: func(t *testing.T, _ *TimelockConfigurer, m *mocks.JSONRPCClient) {
+				t.Helper()
+				t.Setenv("MCMS_SOLANA_MAX_RETRIES", "1")
+
+				mockSolanaTransaction(t, m, 20, 5,
+					"2QUBE2GqS8PxnGP1EBrWpLw3La4XkEUz5NKXJTdTHoA43ANkf5fqKwZ8YPJVAi3ApefbbbCYJipMVzUa7kg3a7v6",
+					nil, errors.New("send failed"))
+			},
+			assertion: func(t assert.TestingT, err error, _ ...any) bool {
+				return assert.ErrorContains(t, err, "unable to update delay")
+			},
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest
+		t.Run(tt.name, func(t *testing.T) {
+			jsonRPCClient := mocks.NewJSONRPCClient(t)
+			client := rpc.NewWithCustomRPCClient(jsonRPCClient)
+			configurer := NewTimelockConfigurer(client, auth)
+			tt.setup(t, configurer, jsonRPCClient)
+
+			got, err := configurer.UpdateDelay(t.Context(), tt.address, tt.newDelay)
+
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got.Hash)
+		})
+	}
+}

--- a/sdk/timelock_configurer.go
+++ b/sdk/timelock_configurer.go
@@ -8,6 +8,5 @@ import (
 
 // TimelockConfigurer is an interface for configuring timelock contract parameters.
 type TimelockConfigurer interface {
-	TimelockInspector
 	UpdateDelay(ctx context.Context, timelockAddress string, newDelay uint64) (types.TransactionResult, error)
 }

--- a/sdk/timelock_configurer.go
+++ b/sdk/timelock_configurer.go
@@ -1,0 +1,13 @@
+package sdk
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/mcms/types"
+)
+
+// TimelockConfigurer is an interface for configuring timelock contract parameters.
+type TimelockConfigurer interface {
+	TimelockInspector
+	UpdateDelay(ctx context.Context, timelockAddress string, newDelay uint64) (types.TransactionResult, error)
+}


### PR DESCRIPTION
This pull request introduces a new abstraction for configuring timelock contract parameters on both EVM and Solana chains, along with corresponding implementations and tests. The main focus is to enable updating the minimum delay of timelock contracts in a chain-agnostic way, and to provide robust test coverage for these new features. Additionally, the end-to-end (E2E) test suites are extended to verify the new functionality.