### PR TITLE
Add remote signing http client with pluggable response parsing

### DIFF
--- a/.changeset/true-breads-prove.md
+++ b/.changeset/true-breads-prove.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Add remote signing http client with pluggable response parsing

--- a/remote_client.go
+++ b/remote_client.go
@@ -1,0 +1,164 @@
+package mcms
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/smartcontractkit/mcms/types"
+)
+
+// ResponseParser converts backend-specific HTTP responses into an MCMS signature.
+// Implementations define success and failure semantics from status code + body.
+type ResponseParser interface {
+	ParseResponse(statusCode int, headers http.Header, body []byte) (types.Signature, error)
+}
+
+// RemoteSignRequest defines a transport-level request to a remote signer.
+// Callers are responsible for constructing the auth payload and headers.
+type RemoteSignRequest struct {
+	Method  string
+	URL     *url.URL
+	Headers http.Header
+	Body    any
+}
+
+// RemoteHTTPResponse contains the raw HTTP response from a remote signer call.
+type RemoteHTTPResponse struct {
+	StatusCode int
+	Body       []byte
+	Headers    http.Header
+}
+
+// RemoteClient executes HTTP requests and delegates response interpretation to a parser.
+type RemoteClient struct {
+	httpClient *http.Client
+	parser     ResponseParser
+}
+
+// NewRemoteClient constructs a remote client with a parser-defined response contract.
+func NewRemoteClient(httpClient *http.Client, parser ResponseParser) (*RemoteClient, error) {
+	if parser == nil {
+		return nil, errors.New("response parser is required")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &RemoteClient{
+		httpClient: httpClient,
+		parser:     parser,
+	}, nil
+}
+
+// Execute sends a remote signing request and returns the raw status/body response.
+func (c *RemoteClient) Execute(ctx context.Context, req RemoteSignRequest) (RemoteHTTPResponse, error) {
+	if req.URL == nil {
+		return RemoteHTTPResponse{}, errors.New("remote signer URL is required")
+	}
+
+	body, err := marshalHTTPBody(req.Body)
+	if err != nil {
+		return RemoteHTTPResponse{}, err
+	}
+
+	method := req.Method
+	if method == "" {
+		method = http.MethodPost
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, req.URL.String(), bytes.NewReader(body))
+	if err != nil {
+		return RemoteHTTPResponse{}, fmt.Errorf("create remote signing request: %w", err)
+	}
+
+	httpReq.Header = cloneHeaders(req.Headers)
+	if body != nil && httpReq.Header.Get("Content-Type") == "" {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+
+	httpResp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return RemoteHTTPResponse{}, fmt.Errorf("execute remote signing request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return RemoteHTTPResponse{}, fmt.Errorf("read remote signing response: %w", err)
+	}
+
+	return RemoteHTTPResponse{
+		StatusCode: httpResp.StatusCode,
+		Body:       respBody,
+		Headers:    httpResp.Header.Clone(),
+	}, nil
+}
+
+// Sign executes the request and parses the response into a signature.
+func (c *RemoteClient) Sign(ctx context.Context, req RemoteSignRequest) (types.Signature, error) {
+	resp, err := c.Execute(ctx, req)
+	if err != nil {
+		return types.Signature{}, err
+	}
+
+	return c.parser.ParseResponse(resp.StatusCode, resp.Headers, resp.Body)
+}
+
+// RequestRemoteSignatureAndAppend validates the proposal, requests a remote signature,
+// and appends that signature to the signable proposal.
+func RequestRemoteSignatureAndAppend(
+	ctx context.Context,
+	signable *Signable,
+	client *RemoteClient,
+	req RemoteSignRequest,
+) (types.Signature, error) {
+	if signable == nil {
+		return types.Signature{}, errors.New("signable is required")
+	}
+	if client == nil {
+		return types.Signature{}, errors.New("remote client is required")
+	}
+
+	if err := signable.proposal.Validate(); err != nil {
+		return types.Signature{}, fmt.Errorf("validate proposal: %w", err)
+	}
+
+	sig, err := client.Sign(ctx, req)
+	if err != nil {
+		return types.Signature{}, fmt.Errorf("request remote signature: %w", err)
+	}
+
+	signable.proposal.AppendSignature(sig)
+	return sig, nil
+}
+
+func marshalHTTPBody(body any) ([]byte, error) {
+	if body == nil {
+		return nil, nil
+	}
+
+	switch typedBody := body.(type) {
+	case []byte:
+		return typedBody, nil
+	case json.RawMessage:
+		return []byte(typedBody), nil
+	default:
+		marshaledBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal HTTP body: %w", err)
+		}
+		return marshaledBody, nil
+	}
+}
+
+func cloneHeaders(headers http.Header) http.Header {
+	if headers == nil {
+		return make(http.Header)
+	}
+	return headers.Clone()
+}

--- a/remote_client.go
+++ b/remote_client.go
@@ -49,6 +49,7 @@ func NewRemoteClient(httpClient *http.Client, parser ResponseParser) (*RemoteCli
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
+
 	return &RemoteClient{
 		httpClient: httpClient,
 		parser:     parser,
@@ -134,6 +135,7 @@ func RequestRemoteSignatureAndAppend(
 	}
 
 	signable.proposal.AppendSignature(sig)
+
 	return sig, nil
 }
 
@@ -152,6 +154,7 @@ func marshalHTTPBody(body any) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("marshal HTTP body: %w", err)
 		}
+
 		return marshaledBody, nil
 	}
 }
@@ -160,5 +163,6 @@ func cloneHeaders(headers http.Header) http.Header {
 	if headers == nil {
 		return make(http.Header)
 	}
+
 	return headers.Clone()
 }

--- a/remote_client.go
+++ b/remote_client.go
@@ -125,7 +125,7 @@ func RequestRemoteSignatureAndAppend(
 		return types.Signature{}, errors.New("remote client is required")
 	}
 
-	if err := signable.proposal.Validate(); err != nil {
+	if err := signable.proposal.Validate(); err != nil { //nolint:contextcheck // Proposal.Validate has no context param; lookups use Background internally.
 		return types.Signature{}, fmt.Errorf("validate proposal: %w", err)
 	}
 

--- a/remote_client.go
+++ b/remote_client.go
@@ -121,6 +121,9 @@ func RequestRemoteSignatureAndAppend(
 	if signable == nil {
 		return types.Signature{}, errors.New("signable is required")
 	}
+	if signable.proposal == nil {
+		return types.Signature{}, errors.New("signable proposal is required")
+	}
 	if client == nil {
 		return types.Signature{}, errors.New("remote client is required")
 	}

--- a/remote_client_test.go
+++ b/remote_client_test.go
@@ -28,6 +28,58 @@ func TestNewRemoteClient_RequiresParser(t *testing.T) {
 	require.EqualError(t, err, "response parser is required")
 }
 
+func TestMarshalHTTPBody_Nil(t *testing.T) {
+	t.Parallel()
+
+	got, err := marshalHTTPBody(nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestMarshalHTTPBody_ByteSlice(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"x":1}`)
+	got, err := marshalHTTPBody(input)
+	require.NoError(t, err)
+	require.Equal(t, input, got)
+}
+
+func TestMarshalHTTPBody_ByteSliceNil(t *testing.T) {
+	t.Parallel()
+
+	var input []byte
+	got, err := marshalHTTPBody(input)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestMarshalHTTPBody_RawMessage(t *testing.T) {
+	t.Parallel()
+
+	input := json.RawMessage(`{"ok":true}`)
+	got, err := marshalHTTPBody(input)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true}`, string(got))
+}
+
+func TestMarshalHTTPBody_JSONMarshalsDefault(t *testing.T) {
+	t.Parallel()
+
+	got, err := marshalHTTPBody(map[string]int{"n": 42})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"n":42}`, string(got))
+}
+
+func TestMarshalHTTPBody_MarshalError(t *testing.T) {
+	t.Parallel()
+
+	_, err := marshalHTTPBody(make(chan int))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "marshal HTTP body")
+	require.Contains(t, err.Error(), "unsupported type")
+}
+
 func TestRemoteClient_Execute_DefaultsToPOSTAndSetsJSONContentType(t *testing.T) {
 	t.Parallel()
 
@@ -148,8 +200,7 @@ func TestRequestRemoteSignatureAndAppend(t *testing.T) {
 		_, err := w.Write([]byte(`{
 			"r":"0x1111111111111111111111111111111111111111111111111111111111111111",
 			"s":"0x2222222222222222222222222222222222222222222222222222222222222222",
-			"v":27,
-			"signer_address":"0x0000000000000000000000000000000000000000"
+			"v":27
 		}`))
 		assert.NoError(t, err)
 	}))
@@ -177,7 +228,6 @@ func TestRequestRemoteSignatureAndAppend(t *testing.T) {
 		Body: map[string]any{"request": "payload"},
 	})
 	require.NoError(t, err)
-	require.Equal(t, uint8(27), sig.V)
 	require.Len(t, signable.proposal.Signatures, 1)
 	require.Equal(t, sig, signable.proposal.Signatures[0])
 }

--- a/remote_client_test.go
+++ b/remote_client_test.go
@@ -114,7 +114,7 @@ func TestRemoteClient_Sign_DelegatesParsing(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, parser.returnedSig, sig)
 	require.Equal(t, http.StatusAccepted, parser.receivedStatusCode)
-	require.Equal(t, `{"backend":"response"}`, string(parser.receivedBody))
+	require.JSONEq(t, `{"backend":"response"}`, string(parser.receivedBody))
 }
 
 func TestRemoteClient_Sign_PropagatesParserError(t *testing.T) {
@@ -168,7 +168,7 @@ func TestRequestRemoteSignatureAndAppend(t *testing.T) {
 
 	signable, err := newTestSignableForRemoteFlow()
 	require.NoError(t, err)
-	require.Len(t, signable.proposal.Signatures, 0)
+	require.Empty(t, signable.proposal.Signatures)
 
 	sig, err := RequestRemoteSignatureAndAppend(context.Background(), signable, client, RemoteSignRequest{
 		URL:  serverURL,
@@ -231,5 +231,6 @@ func (p *capturingParser) ParseResponse(statusCode int, headers http.Header, bod
 	if p.returnedErr != nil {
 		return types.Signature{}, p.returnedErr
 	}
+
 	return p.returnedSig, nil
 }

--- a/remote_client_test.go
+++ b/remote_client_test.go
@@ -232,6 +232,16 @@ func TestRequestRemoteSignatureAndAppend(t *testing.T) {
 	require.Equal(t, sig, signable.proposal.Signatures[0])
 }
 
+func TestRequestRemoteSignatureAndAppend_RequiresProposal(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewRemoteClient(http.DefaultClient, &capturingParser{})
+	require.NoError(t, err)
+
+	_, err = RequestRemoteSignatureAndAppend(context.Background(), &Signable{}, client, RemoteSignRequest{})
+	require.EqualError(t, err, "signable proposal is required")
+}
+
 func newTestSignableForRemoteFlow() (*Signable, error) {
 	validUntil, err := safecast.Int64ToUint32(time.Now().Add(10 * time.Minute).Unix())
 	if err != nil {

--- a/remote_client_test.go
+++ b/remote_client_test.go
@@ -12,9 +12,11 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
+	"github.com/smartcontractkit/mcms/internal/utils/safecast"
 	"github.com/smartcontractkit/mcms/sdk/evm"
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -33,18 +35,18 @@ func TestRemoteClient_Execute_DefaultsToPOSTAndSetsJSONContentType(t *testing.T)
 	const testBody = `{"hello":"world"}`
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method)
-		require.Equal(t, customHeaderValue, r.Header.Get("X-Test-Header"))
-		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, customHeaderValue, r.Header.Get("X-Test-Header"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
 		var body map[string]string
 		err := json.NewDecoder(r.Body).Decode(&body)
-		require.NoError(t, err)
-		require.Equal(t, "world", body["hello"])
+		assert.NoError(t, err)
+		assert.Equal(t, "world", body["hello"])
 
 		w.WriteHeader(http.StatusOK)
 		_, err = w.Write([]byte(testBody))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(testServer.Close)
 
@@ -100,7 +102,7 @@ func TestRemoteClient_Sign_DelegatesParsing(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 		_, err := w.Write([]byte(`{"backend":"response"}`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(testServer.Close)
 
@@ -124,7 +126,7 @@ func TestRemoteClient_Sign_PropagatesParserError(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(`{"ok":true}`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(testServer.Close)
 
@@ -149,7 +151,7 @@ func TestRequestRemoteSignatureAndAppend(t *testing.T) {
 			"v":27,
 			"signer_address":"0x0000000000000000000000000000000000000000"
 		}`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(testServer.Close)
 
@@ -181,11 +183,16 @@ func TestRequestRemoteSignatureAndAppend(t *testing.T) {
 }
 
 func newTestSignableForRemoteFlow() (*Signable, error) {
+	validUntil, err := safecast.Int64ToUint32(time.Now().Add(10 * time.Minute).Unix())
+	if err != nil {
+		return nil, err
+	}
+
 	proposal := &Proposal{
 		BaseProposal: BaseProposal{
 			Version:              "v1",
 			Kind:                 types.KindProposal,
-			ValidUntil:           uint32(time.Now().Add(10 * time.Minute).Unix()),
+			ValidUntil:           validUntil,
 			Signatures:           []types.Signature{},
 			OverridePreviousRoot: false,
 			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{

--- a/remote_client_test.go
+++ b/remote_client_test.go
@@ -1,0 +1,235 @@
+package mcms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
+	"github.com/smartcontractkit/mcms/sdk/evm"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+func TestNewRemoteClient_RequiresParser(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRemoteClient(http.DefaultClient, nil)
+	require.EqualError(t, err, "response parser is required")
+}
+
+func TestRemoteClient_Execute_DefaultsToPOSTAndSetsJSONContentType(t *testing.T) {
+	t.Parallel()
+
+	const customHeaderValue = "test-token"
+	const testBody = `{"hello":"world"}`
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, customHeaderValue, r.Header.Get("X-Test-Header"))
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var body map[string]string
+		err := json.NewDecoder(r.Body).Decode(&body)
+		require.NoError(t, err)
+		require.Equal(t, "world", body["hello"])
+
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(testBody))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(testServer.Close)
+
+	serverURL, err := url.Parse(testServer.URL)
+	require.NoError(t, err)
+
+	client, err := NewRemoteClient(http.DefaultClient, &capturingParser{})
+	require.NoError(t, err)
+
+	resp, err := client.Execute(context.Background(), RemoteSignRequest{
+		URL:  serverURL,
+		Body: map[string]string{"hello": "world"},
+		Headers: http.Header{
+			"X-Test-Header": []string{customHeaderValue},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.JSONEq(t, testBody, string(resp.Body))
+}
+
+func TestRemoteClient_Execute_PropagatesNetworkErrors(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, context.DeadlineExceeded
+		}),
+	}
+
+	client, err := NewRemoteClient(httpClient, &capturingParser{})
+	require.NoError(t, err)
+
+	serverURL, err := url.Parse("https://remote-signer.test")
+	require.NoError(t, err)
+
+	_, err = client.Execute(context.Background(), RemoteSignRequest{URL: serverURL})
+	require.ErrorContains(t, err, "execute remote signing request")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRemoteClient_Sign_DelegatesParsing(t *testing.T) {
+	t.Parallel()
+
+	parser := &capturingParser{
+		returnedSig: types.Signature{
+			R: common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
+			S: common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
+			V: 27,
+		},
+	}
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		_, err := w.Write([]byte(`{"backend":"response"}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(testServer.Close)
+
+	serverURL, err := url.Parse(testServer.URL)
+	require.NoError(t, err)
+
+	client, err := NewRemoteClient(http.DefaultClient, parser)
+	require.NoError(t, err)
+
+	sig, err := client.Sign(context.Background(), RemoteSignRequest{URL: serverURL})
+	require.NoError(t, err)
+	require.Equal(t, parser.returnedSig, sig)
+	require.Equal(t, http.StatusAccepted, parser.receivedStatusCode)
+	require.Equal(t, `{"backend":"response"}`, string(parser.receivedBody))
+}
+
+func TestRemoteClient_Sign_PropagatesParserError(t *testing.T) {
+	t.Parallel()
+
+	parser := &capturingParser{returnedErr: errors.New("parse failed")}
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"ok":true}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(testServer.Close)
+
+	serverURL, err := url.Parse(testServer.URL)
+	require.NoError(t, err)
+
+	client, err := NewRemoteClient(http.DefaultClient, parser)
+	require.NoError(t, err)
+
+	_, err = client.Sign(context.Background(), RemoteSignRequest{URL: serverURL})
+	require.EqualError(t, err, "parse failed")
+}
+
+func TestRequestRemoteSignatureAndAppend(t *testing.T) {
+	t.Parallel()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+			"r":"0x1111111111111111111111111111111111111111111111111111111111111111",
+			"s":"0x2222222222222222222222222222222222222222222222222222222222222222",
+			"v":27,
+			"signer_address":"0x0000000000000000000000000000000000000000"
+		}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(testServer.Close)
+
+	serverURL, err := url.Parse(testServer.URL)
+	require.NoError(t, err)
+
+	parser := &capturingParser{
+		returnedSig: types.Signature{
+			R: common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
+			S: common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
+			V: 27,
+		},
+	}
+	client, err := NewRemoteClient(http.DefaultClient, parser)
+	require.NoError(t, err)
+
+	signable, err := newTestSignableForRemoteFlow()
+	require.NoError(t, err)
+	require.Len(t, signable.proposal.Signatures, 0)
+
+	sig, err := RequestRemoteSignatureAndAppend(context.Background(), signable, client, RemoteSignRequest{
+		URL:  serverURL,
+		Body: map[string]any{"request": "payload"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint8(27), sig.V)
+	require.Len(t, signable.proposal.Signatures, 1)
+	require.Equal(t, sig, signable.proposal.Signatures[0])
+}
+
+func newTestSignableForRemoteFlow() (*Signable, error) {
+	proposal := &Proposal{
+		BaseProposal: BaseProposal{
+			Version:              "v1",
+			Kind:                 types.KindProposal,
+			ValidUntil:           uint32(time.Now().Add(10 * time.Minute).Unix()),
+			Signatures:           []types.Signature{},
+			OverridePreviousRoot: false,
+			ChainMetadata: map[types.ChainSelector]types.ChainMetadata{
+				chaintest.Chain1Selector: {
+					StartingOpCount: 0,
+					MCMAddress:      "0x1111111111111111111111111111111111111111",
+				},
+			},
+		},
+		Operations: []types.Operation{
+			{
+				ChainSelector: chaintest.Chain1Selector,
+				Transaction: evm.NewTransaction(
+					common.HexToAddress("0x2222222222222222222222222222222222222222"),
+					[]byte{0x01},
+					big.NewInt(0),
+					"TestContract",
+					[]string{"test"},
+				),
+			},
+		},
+	}
+
+	return NewSignable(proposal, nil)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type capturingParser struct {
+	receivedStatusCode int
+	receivedBody       []byte
+	returnedSig        types.Signature
+	returnedErr        error
+}
+
+func (p *capturingParser) ParseResponse(statusCode int, headers http.Header, body []byte) (types.Signature, error) {
+	p.receivedStatusCode = statusCode
+	p.receivedBody = append([]byte(nil), body...)
+	if p.returnedErr != nil {
+		return types.Signature{}, p.returnedErr
+	}
+	return p.returnedSig, nil
+}


### PR DESCRIPTION
## Summary

Introduces an auth-agnostic HTTP layer for obtaining proposal signatures from a remote service: `RemoteClient` performs the request, and a caller-supplied `ResponseParser` turns status code, headers, and body into `types.Signature`. Also adds `RequestRemoteSignatureAndAppend` to validate a proposal, call the remote client, and append the returned signature. No backend-specific JSON or auth logic lives in this library.

## Changes

- **Remote signing transport** (`remote_client.go`):
  - `RemoteSignRequest`, `RemoteHTTPResponse`, `RemoteClient` with `Execute` and `Sign`.
  - `ResponseParser` with `ParseResponse(statusCode int, headers http.Header, body []byte) (types.Signature, error)` so callers own success/error semantics (e.g. HTTP 200 with `{ "error": ... }` vs non-2xx).
  - `RequestRemoteSignatureAndAppend` for orchestration after remote signing succeeds.
- **Tests** (`remote_client_test.go`): `httptest` coverage for request defaults, network errors, parser delegation, parser errors, and append flow.

## Rationale

The existing `signer` interface is a local crypto contract: callers pass bytes that are signed deterministically (EIP-191 handling differs by implementation but the intent is "sign this message"). Remote signing is not the same operation: the library sends an HTTP request; the server may derive the Ethereum digest from proposal context; and response handling varies widely (status codes, error bodies, vendor-specific fields).

Reusing or extending `signer` for that would muddy the API: it would imply `Sign(payload []byte)` maps directly to what gets signed on chain, force odd struct fields for HTTP/auth, and leak one deployment’s response shape into the core library. A separate transport + parser boundary keeps local signing semantics clear and keeps vendor- or deployment-specific parsing in the caller.

Alternatives considered: overload `signer` with remote implementations and documentation-only warnings (rejected: easy to misuse); hard-code one backend’s response parser in `mcms` (rejected: couples the library to internal wire formats).

## Breaking changes

None relative to `origin/main` for this diff (additive files only). Downstream code that expected a different shape should adopt `RemoteClient` + a custom `ResponseParser`.