### PR TITLE
feat: update delay remaining families

### DIFF
--- a/.changeset/three-deers-grab.md
+++ b/.changeset/three-deers-grab.md
@@ -1,0 +1,5 @@
+---
+"@smartcontractkit/mcms": minor
+---
+
+Add chainwrappers timelock configurer helpers across supported chain families and add Aptos, Sui, and TON E2E coverage for timelock delay updates.

--- a/chainwrappers/timelock_configurers.go
+++ b/chainwrappers/timelock_configurers.go
@@ -1,0 +1,115 @@
+package chainwrappers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/sdk/aptos"
+	"github.com/smartcontractkit/mcms/sdk/evm"
+	"github.com/smartcontractkit/mcms/sdk/solana"
+	"github.com/smartcontractkit/mcms/sdk/sui"
+	"github.com/smartcontractkit/mcms/sdk/ton"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+// BuildTimelockConfigurers gets a map of timelock configurers for the given
+// chain metadata and chain clients.
+func BuildTimelockConfigurers(
+	chains ChainAccessor,
+	chainMetadata map[types.ChainSelector]types.ChainMetadata,
+	action types.TimelockAction,
+) (map[types.ChainSelector]sdk.TimelockConfigurer, error) {
+	configurers := map[types.ChainSelector]sdk.TimelockConfigurer{}
+	for selector, metadata := range chainMetadata {
+		configurer, err := BuildTimelockConfigurer(chains, selector, action, metadata)
+		if err != nil {
+			return nil, err
+		}
+		configurers[selector] = configurer
+	}
+
+	return configurers, nil
+}
+
+// BuildTimelockConfigurer constructs a chain-family-specific
+// [sdk.TimelockConfigurer] from a [ChainAccessor] plus chain metadata.
+func BuildTimelockConfigurer(
+	chains ChainAccessor,
+	selector types.ChainSelector,
+	action types.TimelockAction,
+	metadata types.ChainMetadata,
+) (sdk.TimelockConfigurer, error) {
+	_ = action
+
+	if chains == nil {
+		return nil, fmt.Errorf("chain access is required")
+	}
+
+	family, err := types.GetChainSelectorFamily(selector)
+	if err != nil {
+		return nil, fmt.Errorf("error getting chain family: %w", err)
+	}
+
+	rawSelector := uint64(selector)
+	switch family {
+	case chainsel.FamilyEVM:
+		client, ok := chains.EVMClient(rawSelector)
+		if !ok {
+			return nil, fmt.Errorf("missing EVM chain client for selector %d", rawSelector)
+		}
+		signer, ok := chains.EVMSigner(rawSelector)
+		if !ok {
+			return nil, fmt.Errorf("missing EVM chain signer for selector %d", rawSelector)
+		}
+
+		return evm.NewTimelockConfigurer(client, signer), nil
+
+	case chainsel.FamilySolana:
+		client, ok := chains.SolanaClient(rawSelector)
+		if !ok {
+			return nil, fmt.Errorf("missing Solana chain client for selector %d", rawSelector)
+		}
+		signer, ok := chains.SolanaSigner(rawSelector)
+		if !ok {
+			return nil, fmt.Errorf("missing Solana chain signer for selector %d", rawSelector)
+		}
+
+		return solana.NewTimelockConfigurer(client, *signer), nil
+
+	case chainsel.FamilyAptos:
+		client, ok := chains.AptosClient(rawSelector)
+		if !ok {
+			return nil, fmt.Errorf("missing Aptos chain client for selector %d", rawSelector)
+		}
+		var afm aptos.AdditionalFieldsMetadata
+		if len(metadata.AdditionalFields) > 0 {
+			if err = json.Unmarshal(metadata.AdditionalFields, &afm); err != nil {
+				return nil, fmt.Errorf("error parsing aptos metadata: %w", err)
+			}
+		}
+
+		return aptos.NewTimelockConfigurerWithMCMSType(client, afm.MCMSType), nil
+
+	case chainsel.FamilySui:
+		suiMetadata, err := sui.SuiMetadata(metadata)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing sui metadata: %w", err)
+		}
+
+		return sui.NewTimelockConfigurer(suiMetadata.McmsPackageID), nil
+
+	case chainsel.FamilyTon:
+		w, ok := chains.TonSigner(rawSelector)
+		if !ok {
+			return nil, fmt.Errorf("missing TON chain wallet for selector %d", rawSelector)
+		}
+
+		return ton.NewTimelockConfigurer(w, ton.DefaultSendAmount), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported chain family %s", family)
+	}
+}

--- a/chainwrappers/timelock_configurers_test.go
+++ b/chainwrappers/timelock_configurers_test.go
@@ -1,0 +1,245 @@
+package chainwrappers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/gagliardetto/solana-go"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/xssnick/tonutils-go/ton/wallet"
+
+	"github.com/smartcontractkit/mcms/chainwrappers/mocks"
+	"github.com/smartcontractkit/mcms/sdk/aptos"
+	"github.com/smartcontractkit/mcms/sdk/evm"
+	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+	"github.com/smartcontractkit/mcms/sdk/sui"
+	"github.com/smartcontractkit/mcms/sdk/ton"
+
+	mcmsTypes "github.com/smartcontractkit/mcms/types"
+)
+
+func TestBuildTimelockConfigurers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		chainMetadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata
+		setup         func(t *testing.T, access *mocks.ChainAccessor)
+		prepare       func(t *testing.T, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata)
+		expectErr     bool
+		errContains   string
+		expectTypes   map[mcmsTypes.ChainSelector]any
+	}{
+		{
+			name:          "empty input",
+			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{},
+			expectErr:     false,
+		},
+		{
+			name: "unknown chain family",
+			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{
+				1: {MCMAddress: "0xabc"},
+			},
+			expectErr:   true,
+			errContains: "error getting chain family",
+		},
+		{
+			name: "all supported families",
+			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{
+				mcmsTypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector): {MCMAddress: "0xevm"},
+				mcmsTypes.ChainSelector(chainsel.SOLANA_DEVNET.Selector):            {MCMAddress: "0xsolana"},
+				mcmsTypes.ChainSelector(chainsel.APTOS_TESTNET.Selector):            {MCMAddress: "0xaptos"},
+				mcmsTypes.ChainSelector(chainsel.TON_TESTNET.Selector):              {MCMAddress: "0xton"},
+				mcmsTypes.ChainSelector(chainsel.SUI_TESTNET.Selector): {
+					MCMAddress: "0xsui",
+					AdditionalFields: []byte(`{
+						"role":0,
+						"mcms_package_id":"0x123456789abcdef",
+						"account_obj":"0xaccount123",
+						"registry_obj":"0xregistry456",
+						"timelock_obj":"0xtimelock789",
+						"deployer_state_obj":"0xdeployer"
+					}`),
+				},
+			},
+			setup: func(t *testing.T, access *mocks.ChainAccessor) {
+				t.Helper()
+
+				access.EXPECT().EVMClient(mock.Anything).Return(nil, true)
+				access.EXPECT().EVMSigner(mock.Anything).Return(&bind.TransactOpts{}, true)
+
+				access.EXPECT().SolanaClient(mock.Anything).Return(nil, true)
+				solKey, err := solana.NewRandomPrivateKey()
+				require.NoError(t, err)
+				access.EXPECT().SolanaSigner(mock.Anything).Return(&solKey, true)
+
+				access.EXPECT().AptosClient(mock.Anything).Return(nil, true)
+
+				access.EXPECT().TonSigner(mock.Anything).Return(&wallet.Wallet{}, true)
+			},
+			expectTypes: map[mcmsTypes.ChainSelector]any{
+				mcmsTypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector): (*evm.TimelockConfigurer)(nil),
+				mcmsTypes.ChainSelector(chainsel.SOLANA_DEVNET.Selector):            (*solanasdk.TimelockConfigurer)(nil),
+				mcmsTypes.ChainSelector(chainsel.APTOS_TESTNET.Selector):            (*aptos.TimelockConfigurer)(nil),
+				mcmsTypes.ChainSelector(chainsel.SUI_TESTNET.Selector):              (*sui.TimelockConfigurer)(nil),
+				mcmsTypes.ChainSelector(chainsel.TON_TESTNET.Selector):              (*ton.TimelockConfigurer)(nil),
+			},
+		},
+		{
+			name: "aptos curse mcms from metadata",
+			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{
+				mcmsTypes.ChainSelector(chainsel.APTOS_TESTNET.Selector): {
+					MCMAddress: "0xaptos",
+				},
+			},
+			prepare: func(t *testing.T, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata) {
+				t.Helper()
+
+				b, err := json.Marshal(aptos.AdditionalFieldsMetadata{
+					Role:     aptos.TimelockRoleProposer,
+					MCMSType: aptos.MCMSTypeCurse,
+				})
+				require.NoError(t, err)
+
+				entry := metadata[mcmsTypes.ChainSelector(chainsel.APTOS_TESTNET.Selector)]
+				entry.AdditionalFields = b
+				metadata[mcmsTypes.ChainSelector(chainsel.APTOS_TESTNET.Selector)] = entry
+			},
+			setup: func(t *testing.T, access *mocks.ChainAccessor) {
+				t.Helper()
+
+				access.EXPECT().AptosClient(mock.Anything).Return(nil, true)
+			},
+			expectTypes: map[mcmsTypes.ChainSelector]any{
+				mcmsTypes.ChainSelector(chainsel.APTOS_TESTNET.Selector): (*aptos.TimelockConfigurer)(nil),
+			},
+		},
+		{
+			name: "missing evm client",
+			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{
+				mcmsTypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector): {MCMAddress: "0xevm"},
+			},
+			setup: func(t *testing.T, access *mocks.ChainAccessor) {
+				t.Helper()
+
+				access.EXPECT().EVMClient(mock.Anything).Return(nil, false)
+			},
+			expectErr:   true,
+			errContains: "missing EVM chain client",
+		},
+		{
+			name: "missing evm signer",
+			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{
+				mcmsTypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector): {MCMAddress: "0xevm"},
+			},
+			setup: func(t *testing.T, access *mocks.ChainAccessor) {
+				t.Helper()
+
+				access.EXPECT().EVMClient(mock.Anything).Return(nil, true)
+				access.EXPECT().EVMSigner(mock.Anything).Return(nil, false)
+			},
+			expectErr:   true,
+			errContains: "missing EVM chain signer",
+		},
+		{
+			name: "missing ton signer",
+			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{
+				mcmsTypes.ChainSelector(chainsel.TON_TESTNET.Selector): {MCMAddress: "0xton"},
+			},
+			setup: func(t *testing.T, access *mocks.ChainAccessor) {
+				t.Helper()
+
+				access.EXPECT().TonSigner(mock.Anything).Return(nil, false)
+			},
+			expectErr:   true,
+			errContains: "missing TON chain wallet",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			access := mocks.NewChainAccessor(t)
+			if tc.prepare != nil {
+				tc.prepare(t, tc.chainMetadata)
+			}
+			if tc.setup != nil {
+				tc.setup(t, access)
+			}
+
+			configurers, err := BuildTimelockConfigurers(access, tc.chainMetadata, mcmsTypes.TimelockActionSchedule)
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContains)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, configurers, len(tc.expectTypes))
+			for selector, expectedType := range tc.expectTypes {
+				configurer, ok := configurers[selector]
+				require.True(t, ok)
+				require.IsType(t, expectedType, configurer)
+			}
+		})
+	}
+}
+
+func TestBuildTimelockConfigurer_NilChainAccess(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildTimelockConfigurer(
+		nil,
+		mcmsTypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector),
+		mcmsTypes.TimelockActionSchedule,
+		mcmsTypes.ChainMetadata{},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chain access is required")
+}
+
+func TestBuildTimelockConfigurer_AptosCurseMetadataEncodesCursePackage(t *testing.T) {
+	t.Parallel()
+
+	access := mocks.NewChainAccessor(t)
+	access.EXPECT().AptosClient(mock.Anything).Return(nil, true)
+
+	metadata := mcmsTypes.ChainMetadata{
+		MCMAddress: "0xaptos",
+	}
+	b, err := json.Marshal(aptos.AdditionalFieldsMetadata{
+		Role:     aptos.TimelockRoleProposer,
+		MCMSType: aptos.MCMSTypeCurse,
+	})
+	require.NoError(t, err)
+	metadata.AdditionalFields = b
+
+	configurer, err := BuildTimelockConfigurer(
+		access,
+		mcmsTypes.ChainSelector(chainsel.APTOS_TESTNET.Selector),
+		mcmsTypes.TimelockActionSchedule,
+		metadata,
+	)
+	require.NoError(t, err)
+
+	result, err := configurer.UpdateDelay(
+		t.Context(),
+		"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		3600,
+	)
+	require.NoError(t, err)
+	require.Empty(t, result.Hash)
+
+	tx, ok := result.RawData.(mcmsTypes.Transaction)
+	require.True(t, ok)
+
+	var fields aptos.AdditionalFields
+	require.NoError(t, json.Unmarshal(tx.AdditionalFields, &fields))
+	require.Equal(t, "curse_mcms", fields.PackageName)
+	require.Equal(t, "curse_mcms", fields.ModuleName)
+	require.Equal(t, "timelock_update_min_delay", fields.Function)
+}

--- a/e2e/tests/aptos/timelock_configuration.go
+++ b/e2e/tests/aptos/timelock_configuration.go
@@ -1,0 +1,156 @@
+//go:build e2e
+
+package aptos
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/sdk"
+	aptossdk "github.com/smartcontractkit/mcms/sdk/aptos"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+func (a *TestSuite) TestUpdateDelay() {
+	ctx := a.T().Context()
+	a.deployMCMSContract()
+
+	mcmsAccountAddress := a.MCMSContract.Address()
+	mcmsAddress := mcmsAccountAddress.StringLong()
+	timelockInspector := aptossdk.NewTimelockInspector(a.AptosRPCClient)
+
+	delay, err := timelockInspector.GetMinDelay(ctx, mcmsAddress)
+	a.Require().NoError(err)
+	a.Require().EqualValues(0, delay)
+
+	proposerKey, err := crypto.GenerateKey()
+	a.Require().NoError(err)
+	proposerAddress := crypto.PubkeyToAddress(proposerKey.PublicKey)
+	proposerConfig := &types.Config{
+		Quorum:  1,
+		Signers: []common.Address{proposerAddress},
+	}
+
+	proposerConfigurer := aptossdk.NewConfigurer(a.AptosRPCClient, a.deployerAccount, aptossdk.TimelockRoleProposer)
+	configResult, err := proposerConfigurer.SetConfig(ctx, mcmsAddress, proposerConfig, false)
+	a.Require().NoError(err)
+
+	configTx, err := a.AptosRPCClient.WaitForTransaction(configResult.Hash)
+	a.Require().NoError(err)
+	a.Require().True(configTx.Success, configTx.VmStatus)
+
+	timelockConfigurer := aptossdk.NewTimelockConfigurer(a.AptosRPCClient)
+	newDelay := uint64(120)
+
+	updateDelayResult, err := timelockConfigurer.UpdateDelay(ctx, mcmsAddress, newDelay)
+	a.Require().NoError(err)
+	a.Require().Empty(updateDelayResult.Hash)
+
+	updateDelayTx, ok := updateDelayResult.RawData.(types.Transaction)
+	a.Require().True(ok, "prepared Aptos update delay operation should be an MCMS transaction")
+
+	proposerInspector := aptossdk.NewInspector(a.AptosRPCClient, aptossdk.TimelockRoleProposer)
+	startingOpCount, err := proposerInspector.GetOpCount(ctx, mcmsAddress)
+	a.Require().NoError(err)
+
+	timelockDelay := types.NewDuration(2 * time.Second)
+	timelockProposalBuilder := mcms.NewTimelockProposalBuilder().
+		SetVersion("v1").
+		SetValidUntil(uint32(time.Now().Add(24*time.Hour).Unix())).
+		SetDescription("Update timelock minimum delay via timelock configurer").
+		AddTimelockAddress(a.ChainSelector, mcmsAddress).
+		AddChainMetadata(a.ChainSelector, types.ChainMetadata{
+			StartingOpCount:  startingOpCount,
+			MCMAddress:       mcmsAddress,
+			AdditionalFields: Must(json.Marshal(aptossdk.AdditionalFieldsMetadata{Role: aptossdk.TimelockRoleProposer})),
+		}).
+		SetAction(types.TimelockActionSchedule).
+		SetDelay(timelockDelay).
+		AddOperation(types.BatchOperation{
+			ChainSelector: a.ChainSelector,
+			Transactions:  []types.Transaction{updateDelayTx},
+		})
+
+	timelockProposal, err := timelockProposalBuilder.Build()
+	a.Require().NoError(err)
+
+	converters := map[types.ChainSelector]sdk.TimelockConverter{
+		a.ChainSelector: aptossdk.NewTimelockConverter(),
+	}
+	proposal, _, err := timelockProposal.Convert(ctx, converters)
+	a.Require().NoError(err)
+
+	inspectors := map[types.ChainSelector]sdk.Inspector{
+		a.ChainSelector: proposerInspector,
+	}
+	signable, err := mcms.NewSignable(&proposal, inspectors)
+	a.Require().NoError(err)
+
+	_, err = signable.SignAndAppend(mcms.NewPrivateKeySigner(proposerKey))
+	a.Require().NoError(err)
+
+	quorumMet, err := signable.ValidateSignatures(ctx)
+	a.Require().NoError(err)
+	a.Require().True(quorumMet)
+
+	encoders, err := proposal.GetEncoders()
+	a.Require().NoError(err)
+
+	proposalExecutors := map[types.ChainSelector]sdk.Executor{
+		a.ChainSelector: aptossdk.NewExecutor(
+			a.AptosRPCClient,
+			a.deployerAccount,
+			encoders[a.ChainSelector].(*aptossdk.Encoder),
+			aptossdk.TimelockRoleProposer,
+		),
+	}
+	executable, err := mcms.NewExecutable(&proposal, proposalExecutors)
+	a.Require().NoError(err)
+
+	setRootResult, err := executable.SetRoot(ctx, a.ChainSelector)
+	a.Require().NoError(err)
+
+	setRootTx, err := a.AptosRPCClient.WaitForTransaction(setRootResult.Hash)
+	a.Require().NoError(err)
+	a.Require().True(setRootTx.Success, setRootTx.VmStatus)
+
+	scheduleResult, err := executable.Execute(ctx, 0)
+	a.Require().NoError(err)
+
+	scheduleTx, err := a.AptosRPCClient.WaitForTransaction(scheduleResult.Hash)
+	a.Require().NoError(err)
+	a.Require().True(scheduleTx.Success, scheduleTx.VmStatus)
+
+	timelockExecutors := map[types.ChainSelector]sdk.TimelockExecutor{
+		a.ChainSelector: aptossdk.NewTimelockExecutor(a.AptosRPCClient, a.deployerAccount),
+	}
+	timelockExecutable, err := mcms.NewTimelockExecutable(ctx, timelockProposal, timelockExecutors)
+	a.Require().NoError(err)
+
+	operationID, err := timelockExecutable.GetOpID(ctx, 0, timelockProposal.Operations[0], a.ChainSelector)
+	a.Require().NoError(err)
+
+	isOperation, err := timelockInspector.IsOperation(ctx, mcmsAddress, operationID)
+	a.Require().NoError(err)
+	a.Require().True(isOperation)
+
+	a.Require().EventuallyWithT(func(collect *assert.CollectT) {
+		assert.NoError(collect, timelockExecutable.IsReady(ctx))
+	}, 10*time.Second, 500*time.Millisecond)
+
+	execResult, err := timelockExecutable.Execute(ctx, 0)
+	a.Require().NoError(err)
+
+	execTx, err := a.AptosRPCClient.WaitForTransaction(execResult.Hash)
+	a.Require().NoError(err)
+	a.Require().True(execTx.Success, execTx.VmStatus)
+
+	delay, err = timelockInspector.GetMinDelay(ctx, mcmsAddress)
+	a.Require().NoError(err)
+	a.Require().Equal(newDelay, delay)
+}

--- a/e2e/tests/sui/timelock_configuration.go
+++ b/e2e/tests/sui/timelock_configuration.go
@@ -1,0 +1,159 @@
+//go:build e2e
+
+package sui
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/mcms"
+	"github.com/smartcontractkit/mcms/sdk"
+	suisdk "github.com/smartcontractkit/mcms/sdk/sui"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+func (s *TimelockProposalTestSuite) TestUpdateDelay() {
+	ctx := s.T().Context()
+	s.DeployMCMSContract()
+
+	timelockInspector, err := suisdk.NewTimelockInspector(s.client, s.signer, s.mcmsPackageID)
+	s.Require().NoError(err)
+
+	delay, err := timelockInspector.GetMinDelay(ctx, s.timelockObj)
+	s.Require().NoError(err)
+	s.Require().EqualValues(0, delay)
+
+	proposerConfig := CreateConfig(1, 1)
+	proposerConfigurer, err := suisdk.NewConfigurer(
+		s.client,
+		s.signer,
+		suisdk.TimelockRoleProposer,
+		s.mcmsPackageID,
+		s.ownerCapObj,
+		uint64(s.chainSelector),
+	)
+	s.Require().NoError(err)
+
+	_, err = proposerConfigurer.SetConfig(ctx, s.mcmsObj, proposerConfig.Config, true)
+	s.Require().NoError(err)
+
+	timelockConfigurer := suisdk.NewTimelockConfigurer(s.mcmsPackageID)
+	newDelay := uint64(120)
+
+	updateDelayResult, err := timelockConfigurer.UpdateDelay(ctx, s.timelockObj, newDelay)
+	s.Require().NoError(err)
+	s.Require().Empty(updateDelayResult.Hash)
+
+	updateDelayTx, ok := updateDelayResult.RawData.(types.Transaction)
+	s.Require().True(ok, "prepared Sui update delay operation should be an MCMS transaction")
+
+	proposerInspector, err := suisdk.NewInspector(s.client, s.signer, s.mcmsPackageID, suisdk.TimelockRoleProposer)
+	s.Require().NoError(err)
+
+	currentOpCount, err := proposerInspector.GetOpCount(ctx, s.mcmsObj)
+	s.Require().NoError(err)
+
+	delayDuration := types.NewDuration(2 * time.Second)
+	proposalConfig := ProposalBuilderConfig{
+		Version:            "v1",
+		Description:        "Update timelock minimum delay via timelock configurer",
+		ChainSelector:      s.chainSelector,
+		McmsObjID:          s.mcmsObj,
+		TimelockObjID:      s.timelockObj,
+		AccountObjID:       s.accountObj,
+		RegistryObjID:      s.registryObj,
+		DeployerStateObjID: s.depStateObj,
+		McmsPackageID:      s.mcmsPackageID,
+		Role:               suisdk.TimelockRoleProposer,
+		CurrentOpCount:     currentOpCount,
+		Action:             types.TimelockActionSchedule,
+		Delay:              &delayDuration,
+	}
+
+	timelockProposal, err := CreateTimelockProposalBuilder(s.T(), proposalConfig, []types.BatchOperation{{
+		ChainSelector: s.chainSelector,
+		Transactions:  []types.Transaction{updateDelayTx},
+	}}).Build()
+	s.Require().NoError(err)
+
+	timelockConverter, err := suisdk.NewTimelockConverter()
+	s.Require().NoError(err)
+
+	converters := map[types.ChainSelector]sdk.TimelockConverter{
+		s.chainSelector: timelockConverter,
+	}
+	proposal, _, err := timelockProposal.Convert(ctx, converters)
+	s.Require().NoError(err)
+
+	inspectors := map[types.ChainSelector]sdk.Inspector{
+		s.chainSelector: proposerInspector,
+	}
+	signable, err := SignProposal(&proposal, inspectors, proposerConfig.Keys, int(proposerConfig.Quorum))
+	s.Require().NoError(err)
+
+	quorumMet, err := signable.ValidateSignatures(ctx)
+	s.Require().NoError(err)
+	s.Require().True(quorumMet)
+
+	encoders, err := proposal.GetEncoders()
+	s.Require().NoError(err)
+
+	proposalExecutor, err := suisdk.NewExecutor(
+		s.client,
+		s.signer,
+		encoders[s.chainSelector].(*suisdk.Encoder),
+		s.entrypointArgEncoder,
+		s.mcmsPackageID,
+		suisdk.TimelockRoleProposer,
+		s.mcmsObj,
+		s.accountObj,
+		s.registryObj,
+		s.timelockObj,
+	)
+	s.Require().NoError(err)
+
+	executable, err := mcms.NewExecutable(&proposal, map[types.ChainSelector]sdk.Executor{
+		s.chainSelector: proposalExecutor,
+	})
+	s.Require().NoError(err)
+
+	_, err = executable.SetRoot(ctx, s.chainSelector)
+	s.Require().NoError(err)
+
+	_, err = executable.Execute(ctx, 0)
+	s.Require().NoError(err)
+
+	timelockExecutor, err := suisdk.NewTimelockExecutor(
+		s.client,
+		s.signer,
+		s.entrypointArgEncoder,
+		s.mcmsPackageID,
+		s.registryObj,
+		s.accountObj,
+	)
+	s.Require().NoError(err)
+
+	timelockExecutable, err := mcms.NewTimelockExecutable(ctx, timelockProposal, map[types.ChainSelector]sdk.TimelockExecutor{
+		s.chainSelector: timelockExecutor,
+	})
+	s.Require().NoError(err)
+
+	operationID, err := timelockExecutable.GetOpID(ctx, 0, timelockProposal.Operations[0], s.chainSelector)
+	s.Require().NoError(err)
+
+	exists, err := timelockInspector.IsOperation(ctx, s.timelockObj, operationID)
+	s.Require().NoError(err)
+	s.Require().True(exists)
+
+	s.Require().EventuallyWithT(func(collect *assert.CollectT) {
+		assert.NoError(collect, timelockExecutable.IsReady(ctx))
+	}, 20*time.Second, time.Second)
+
+	_, err = timelockExecutable.Execute(ctx, 0, mcms.WithCallProxy(s.timelockObj))
+	s.Require().NoError(err)
+
+	delay, err = timelockInspector.GetMinDelay(ctx, s.timelockObj)
+	s.Require().NoError(err)
+	s.Require().Equal(newDelay, delay)
+}

--- a/e2e/tests/ton/timelock_configuration.go
+++ b/e2e/tests/ton/timelock_configuration.go
@@ -1,0 +1,39 @@
+//go:build e2e
+
+package tone2e
+
+import (
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/xssnick/tonutils-go/tlb"
+
+	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tracetracking"
+
+	mcmston "github.com/smartcontractkit/mcms/sdk/ton"
+)
+
+func (s *TimelockInspectionTestSuite) TestUpdateDelay() {
+	ctx := s.T().Context()
+
+	inspector := mcmston.NewTimelockInspector(s.TonClient)
+	delay, err := inspector.GetMinDelay(ctx, s.timelockAddr.String())
+	s.Require().NoError(err)
+	s.Require().EqualValues(0, delay)
+
+	configurer := mcmston.NewTimelockConfigurer(s.wallet, mcmston.DefaultSendAmount)
+	newDelay := uint64(120)
+
+	result, err := configurer.UpdateDelay(ctx, s.timelockAddr.String(), newDelay)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(result.Hash)
+	s.Require().Equal(chainsel.FamilyTon, result.ChainFamily)
+
+	tx, ok := result.RawData.(*tlb.Transaction)
+	s.Require().True(ok, "TON UpdateDelay should return the sent transaction")
+
+	err = tracetracking.WaitForTrace(ctx, s.TonClient, tx)
+	s.Require().NoError(err)
+
+	delay, err = inspector.GetMinDelay(ctx, s.timelockAddr.String())
+	s.Require().NoError(err)
+	s.Require().Equal(newDelay, delay)
+}

--- a/sdk/aptos/timelock_configurer.go
+++ b/sdk/aptos/timelock_configurer.go
@@ -1,0 +1,91 @@
+package aptos
+
+import (
+	"context"
+	"fmt"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+
+	"github.com/smartcontractkit/chainlink-aptos/bindings/bind"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/curse_mcms"
+	"github.com/smartcontractkit/chainlink-aptos/bindings/mcms"
+
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+var _ sdk.TimelockConfigurer = (*TimelockConfigurer)(nil)
+
+// TimelockConfigurer configures timelock parameters on Aptos chains.
+// UpdateDelay returns a prepared MCMS transaction instead of executing on-chain.
+type TimelockConfigurer struct {
+	client    aptos.AptosRpcClient
+	mcmsType  MCMSType
+	encoderFn func(address aptos.AccountAddress, client aptos.AptosRpcClient) timelockUpdateDelayEncoder
+}
+
+type timelockUpdateDelayEncoder interface {
+	TimelockUpdateMinDelay(newMinDelay uint64) (bind.ModuleInformation, string, []aptos.TypeTag, [][]byte, error)
+}
+
+// NewTimelockConfigurer creates a new TimelockConfigurer for Aptos chains.
+func NewTimelockConfigurer(client aptos.AptosRpcClient) *TimelockConfigurer {
+	return NewTimelockConfigurerWithMCMSType(client, MCMSTypeRegular)
+}
+
+// NewTimelockConfigurerWithMCMSType creates a TimelockConfigurer that targets
+// either the standard MCMS or the CurseMCMS contract depending on mcmsType.
+func NewTimelockConfigurerWithMCMSType(client aptos.AptosRpcClient, mcmsType MCMSType) *TimelockConfigurer {
+	encoderFn := func(address aptos.AccountAddress, client aptos.AptosRpcClient) timelockUpdateDelayEncoder {
+		return mcms.Bind(address, client).MCMS().Encoder()
+	}
+	if mcmsType == MCMSTypeCurse {
+		encoderFn = func(address aptos.AccountAddress, client aptos.AptosRpcClient) timelockUpdateDelayEncoder {
+			return curse_mcms.Bind(address, client).CurseMCMS().Encoder()
+		}
+	}
+
+	return &TimelockConfigurer{
+		client:    client,
+		mcmsType:  mcmsType,
+		encoderFn: encoderFn,
+	}
+}
+
+// UpdateDelay encodes a TimelockUpdateMinDelay call on the Aptos MCMS module
+// for the given address and returns it as a prepared MCMS transaction.
+func (c *TimelockConfigurer) UpdateDelay(
+	ctx context.Context, mcmsAddr string, newDelay uint64,
+) (types.TransactionResult, error) {
+	mcmsAddress, err := hexToAddress(mcmsAddr)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("failed to parse MCMS address %q: %w", mcmsAddr, err)
+	}
+	encoder := c.encoderFn(mcmsAddress, c.client)
+
+	moduleInfo, function, _, args, err := encoder.TimelockUpdateMinDelay(newDelay)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("encoding TimelockUpdateMinDelay: %w", err)
+	}
+
+	tx, err := NewTransaction(
+		moduleInfo.PackageName,
+		moduleInfo.ModuleName,
+		function,
+		mcmsAddress,
+		ArgsToData(args),
+		"",
+		nil,
+	)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("creating mcms transaction: %w", err)
+	}
+
+	return types.TransactionResult{
+		Hash:        "",
+		ChainFamily: chainsel.FamilyAptos,
+		RawData:     tx,
+	}, nil
+}

--- a/sdk/aptos/timelock_configurer_test.go
+++ b/sdk/aptos/timelock_configurer_test.go
@@ -1,0 +1,104 @@
+package aptos
+
+import (
+	"encoding/json"
+	"testing"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/types"
+)
+
+func TestNewTimelockConfigurer(t *testing.T) {
+	t.Parallel()
+
+	configurer := NewTimelockConfigurer(nil)
+
+	require.NotNil(t, configurer)
+	require.Equal(t, MCMSTypeRegular, configurer.mcmsType)
+}
+
+func TestNewTimelockConfigurerWithMCMSType(t *testing.T) {
+	t.Parallel()
+
+	configurer := NewTimelockConfigurerWithMCMSType(nil, MCMSTypeCurse)
+
+	require.NotNil(t, configurer)
+	require.Equal(t, MCMSTypeCurse, configurer.mcmsType)
+}
+
+func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
+	t.Parallel()
+
+	validMCMSAddr := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	tests := []struct {
+		name         string
+		configurer   *TimelockConfigurer
+		mcmsAddr     string
+		newDelay     uint64
+		assertion    assert.ErrorAssertionFunc
+		wantErr      string
+		wantPackage  string
+		wantModule   string
+		wantFunction string
+	}{
+		{
+			name:         "success returns prepared tx with empty hash for regular mcms",
+			configurer:   NewTimelockConfigurer(nil),
+			mcmsAddr:     validMCMSAddr,
+			newDelay:     3600,
+			assertion:    assert.NoError,
+			wantPackage:  "mcms",
+			wantModule:   "mcms",
+			wantFunction: "timelock_update_min_delay",
+		},
+		{
+			name:         "success returns prepared tx with empty hash for curse mcms",
+			configurer:   NewTimelockConfigurerWithMCMSType(nil, MCMSTypeCurse),
+			mcmsAddr:     validMCMSAddr,
+			newDelay:     3600,
+			assertion:    assert.NoError,
+			wantPackage:  "curse_mcms",
+			wantModule:   "curse_mcms",
+			wantFunction: "timelock_update_min_delay",
+		},
+		{
+			name:       "invalid mcms address rejected",
+			configurer: NewTimelockConfigurer(nil),
+			mcmsAddr:   "not-an-address",
+			newDelay:   3600,
+			assertion:  assert.Error,
+			wantErr:    "failed to parse MCMS address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.configurer.UpdateDelay(t.Context(), tt.mcmsAddr, tt.newDelay)
+
+			tt.assertion(t, err)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			assert.Empty(t, got.Hash, "Aptos UpdateDelay must return empty Hash (prepared tx)")
+			assert.Equal(t, chainsel.FamilyAptos, got.ChainFamily)
+
+			tx, ok := got.RawData.(types.Transaction)
+			require.True(t, ok, "RawData should be mcms types.Transaction")
+
+			var fields AdditionalFields
+			require.NoError(t, json.Unmarshal(tx.AdditionalFields, &fields))
+			assert.Equal(t, tt.wantPackage, fields.PackageName)
+			assert.Equal(t, tt.wantModule, fields.ModuleName)
+			assert.Equal(t, tt.wantFunction, fields.Function)
+			assert.NotEmpty(t, tx.Data, "BCS-encoded new delay must be present")
+		})
+	}
+}

--- a/sdk/sui/executing_callback.go
+++ b/sdk/sui/executing_callback.go
@@ -206,6 +206,12 @@ func (e *ExecutingCallbackParams) processMCMSMainModuleCall(ctx context.Context,
 			call.StateObj,
 			executingCallbackParams,
 		)
+	case TimelockActionCancel:
+		executeDispatchCall, err = e.mcms.Encoder().McmsTimelockCancelWithArgs(
+			bind.Object{Id: call.StateObj},
+			bind.Object{Id: e.registryObj},
+			executingCallbackParams,
+		)
 	case suiTimelockUpdateMinDelayFunctionName:
 		executeDispatchCall, err = e.mcms.Encoder().McmsTimelockUpdateMinDelayWithArgs(
 			bind.Object{Id: call.StateObj},

--- a/sdk/sui/executing_callback.go
+++ b/sdk/sui/executing_callback.go
@@ -18,6 +18,8 @@ import (
 
 const (
 	UpgradeGasBudget = 500_000_000
+
+	suiMCMSSetConfigFunctionName = "set_config"
 )
 
 type EntrypointArgEncoder interface {
@@ -190,21 +192,36 @@ func (e *ExecutingCallbackParams) processMCMSAccountCall(ctx context.Context, pt
 }
 
 func (e *ExecutingCallbackParams) processMCMSMainModuleCall(ctx context.Context, ptb *transaction.Transaction, opts *bind.CallOpts, executingCallbackParams *transaction.Argument, call Call, index int) error {
-	executeDispatchCall, err := e.mcms.Encoder().McmsSetConfigWithArgs(
-		e.registryObj,
-		call.StateObj,
-		executingCallbackParams,
+	var (
+		executeDispatchCall *bind.EncodedCall
+		err                 error
 	)
-	if err != nil {
-		return fmt.Errorf("creating ExecuteDispatchToAccount call %d: %w", index, err)
-	}
 
-	// Adjust function name to match mcms_ prefix
-	executeDispatchCall.Function = "mcms_" + strings.TrimPrefix(call.FunctionName, "mcms_")
+	normalizedFunctionName := strings.TrimPrefix(call.FunctionName, "mcms_")
+
+	switch normalizedFunctionName {
+	case suiMCMSSetConfigFunctionName:
+		executeDispatchCall, err = e.mcms.Encoder().McmsSetConfigWithArgs(
+			e.registryObj,
+			call.StateObj,
+			executingCallbackParams,
+		)
+	case suiTimelockUpdateMinDelayFunctionName:
+		executeDispatchCall, err = e.mcms.Encoder().McmsTimelockUpdateMinDelayWithArgs(
+			bind.Object{Id: call.StateObj},
+			bind.Object{Id: e.registryObj},
+			executingCallbackParams,
+		)
+	default:
+		return fmt.Errorf("unsupported MCMS main module function %q", call.FunctionName)
+	}
+	if err != nil {
+		return fmt.Errorf("creating MCMS main module call %d: %w", index, err)
+	}
 
 	_, err = e.mcms.Bound().AppendPTB(ctx, opts, ptb, executeDispatchCall)
 	if err != nil {
-		return fmt.Errorf("adding ExecuteDispatchToAccount call %d to PTB: %w", index, err)
+		return fmt.Errorf("adding MCMS main module call %d to PTB: %w", index, err)
 	}
 
 	return nil

--- a/sdk/sui/executing_callback_test.go
+++ b/sdk/sui/executing_callback_test.go
@@ -74,7 +74,7 @@ func TestNewExecutingCallbackParams(t *testing.T) {
 	assert.Equal(t, entrypointEncoder, params.entryPointEncoder)
 }
 
-func TestExecutingCallbackParams_AppendPTB_WithMCMSPackageTarget(t *testing.T) {
+func TestExecutingCallbackParams_AppendPTB_WithMCMSSetConfig(t *testing.T) {
 	t.Parallel()
 
 	// Create mock objects
@@ -88,14 +88,14 @@ func TestExecutingCallbackParams_AppendPTB_WithMCMSPackageTarget(t *testing.T) {
 	mockMcms.EXPECT().Encoder().Return(mockMcmsEncoder)
 	mockMcms.EXPECT().Bound().Return(mockBound)
 
-	// Mock the McmsSetConfigWithArgs call (default case for non-mcms_deployer/mcms_account modules)
+	// Mock the McmsSetConfigWithArgs call.
 	expectedCall := &bind.EncodedCall{
 		Module: bind.ModuleInformation{
 			PackageID:   "0x123456789abcdef",
 			PackageName: "mcms",
-			ModuleName:  "test_module",
+			ModuleName:  "mcms",
 		},
-		Function: "test_function",
+		Function: "mcms_set_config",
 	}
 	mockMcmsEncoder.EXPECT().McmsSetConfigWithArgs(
 		"0xregistry",
@@ -141,19 +141,122 @@ func TestExecutingCallbackParams_AppendPTB_WithMCMSPackageTarget(t *testing.T) {
 	ptb := &transaction.Transaction{}
 	executeCallback := &transaction.Argument{}
 
-	// Create a call that targets the MCMS package (should trigger ExecuteDispatchToAccount)
+	// Create a call that targets the MCMS package and uses set_config.
 	calls := []Call{
 		{
 			Target:       mcmsPackageIDBytes,
 			StateObj:     "0x742d35cc6b8d4c8c8e1b9b3b2d2a8b9c8d7e6f1234567890abcdef0123456789",
-			ModuleName:   "test_module",
-			FunctionName: "test_function",
+			ModuleName:   "mcms",
+			FunctionName: suiMCMSSetConfigFunctionName,
 		},
 	}
 
 	// Execute the method
 	err = params.AppendPTB(ctx, ptb, executeCallback, calls)
 	assert.NoError(t, err)
+}
+
+func TestExecutingCallbackParams_AppendPTB_WithMCMSTimelockUpdateMinDelay(t *testing.T) {
+	t.Parallel()
+
+	mockClient := mocksui.NewISuiAPI(t)
+	mockMcms := mockmcms.NewIMcms(t)
+	entrypointEncoder := &MockEntrypointArgEncoder{t: t, registryObj: "0xregistry"}
+	mockMcmsEncoder := mockmcms.NewMcmsEncoder(t)
+	mockBound := mockbindutils.NewIBoundContract(t)
+
+	mockMcms.EXPECT().Encoder().Return(mockMcmsEncoder)
+	mockMcms.EXPECT().Bound().Return(mockBound)
+
+	expectedCall := &bind.EncodedCall{
+		Module: bind.ModuleInformation{
+			PackageID:   "0x123456789abcdef",
+			PackageName: "mcms",
+			ModuleName:  "mcms",
+		},
+		Function: "mcms_timelock_update_min_delay",
+	}
+	mockMcmsEncoder.EXPECT().McmsTimelockUpdateMinDelayWithArgs(
+		bind.Object{Id: "0xtimelock"},
+		bind.Object{Id: "0xregistry"},
+		mock.AnythingOfType("*transaction.Argument"),
+	).Return(expectedCall, nil)
+
+	mockBound.EXPECT().AppendPTB(
+		mock.Anything,
+		mock.AnythingOfType("*bind.CallOpts"),
+		mock.AnythingOfType("*transaction.Transaction"),
+		expectedCall,
+	).Return(nil, nil)
+
+	mcmsPackageIDHex := "123456789abcdef0" + strings.Repeat("0", 48)
+	mcmsPackageIDBytes, err := hex.DecodeString(mcmsPackageIDHex)
+	require.NoError(t, err)
+	mcmsPackageID := "0x" + mcmsPackageIDHex
+
+	params := NewExecutingCallbackParams(
+		mockClient,
+		mockMcms,
+		mcmsPackageID,
+		entrypointEncoder,
+		"0xregistry",
+		"0xaccount",
+	)
+	params.extractExecutingCallbackParams = func(mcmsPackageID string, ptb *transaction.Transaction, vectorExecutingCallback *transaction.Argument) (*transaction.Argument, error) {
+		return &transaction.Argument{}, nil
+	}
+	params.closeExecutingCallbackParams = func(mcmsPackageID string, ptb *transaction.Transaction, vectorExecutingCallback *transaction.Argument) error {
+		return nil
+	}
+
+	err = params.AppendPTB(context.Background(), &transaction.Transaction{}, &transaction.Argument{}, []Call{
+		{
+			Target:       mcmsPackageIDBytes,
+			StateObj:     "0xtimelock",
+			ModuleName:   "mcms",
+			FunctionName: suiTimelockUpdateMinDelayFunctionName,
+		},
+	})
+	assert.NoError(t, err)
+}
+
+func TestExecutingCallbackParams_AppendPTB_WithUnsupportedMCMSMainModuleCall(t *testing.T) {
+	t.Parallel()
+
+	mockClient := mocksui.NewISuiAPI(t)
+	mockMcms := mockmcms.NewIMcms(t)
+	entrypointEncoder := &MockEntrypointArgEncoder{t: t, registryObj: "0xregistry"}
+
+	mcmsPackageIDHex := "123456789abcdef0" + strings.Repeat("0", 48)
+	mcmsPackageIDBytes, err := hex.DecodeString(mcmsPackageIDHex)
+	require.NoError(t, err)
+	mcmsPackageID := "0x" + mcmsPackageIDHex
+
+	params := NewExecutingCallbackParams(
+		mockClient,
+		mockMcms,
+		mcmsPackageID,
+		entrypointEncoder,
+		"0xregistry",
+		"0xaccount",
+	)
+	params.extractExecutingCallbackParams = func(mcmsPackageID string, ptb *transaction.Transaction, vectorExecutingCallback *transaction.Argument) (*transaction.Argument, error) {
+		return &transaction.Argument{}, nil
+	}
+	params.closeExecutingCallbackParams = func(mcmsPackageID string, ptb *transaction.Transaction, vectorExecutingCallback *transaction.Argument) error {
+		return nil
+	}
+
+	err = params.AppendPTB(context.Background(), &transaction.Transaction{}, &transaction.Argument{}, []Call{
+		{
+			Target:       mcmsPackageIDBytes,
+			StateObj:     "0xstate",
+			ModuleName:   "mcms",
+			FunctionName: "unknown_function",
+		},
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `unsupported MCMS main module function "unknown_function"`)
 }
 
 func TestExecutingCallbackParams_AppendPTB_WithMCMSAccountModule(t *testing.T) {

--- a/sdk/sui/timelock_configurer.go
+++ b/sdk/sui/timelock_configurer.go
@@ -1,0 +1,74 @@
+package sui
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aptos-labs/aptos-go-sdk/bcs"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+// Names used for the timelock update-min-delay call.
+const (
+	suiTimelockUpdateMinDelayModuleName   = "mcms"
+	suiTimelockUpdateMinDelayFunctionName = "timelock_update_min_delay"
+)
+
+var _ sdk.TimelockConfigurer = (*TimelockConfigurer)(nil)
+
+// TimelockConfigurer configures timelock parameters on Sui chains.
+// UpdateDelay returns a prepared MCMS transaction instead of executing on-chain.
+type TimelockConfigurer struct {
+	mcmsPackageID string
+}
+
+// NewTimelockConfigurer creates a new TimelockConfigurer for Sui chains.
+func NewTimelockConfigurer(mcmsPackageID string) *TimelockConfigurer {
+	return &TimelockConfigurer{mcmsPackageID: mcmsPackageID}
+}
+
+// UpdateDelay prepares the Sui MCMS transaction for a timelock min-delay
+// update and returns it as a prepared MCMS transaction.
+func (c *TimelockConfigurer) UpdateDelay(
+	ctx context.Context, timelockAddress string, newDelay uint64,
+) (types.TransactionResult, error) {
+	if timelockAddress == "" {
+		return types.TransactionResult{}, fmt.Errorf("timelock address is required")
+	}
+
+	data, err := serializeTimelockUpdateMinDelay(newDelay)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("encoding timelock_update_min_delay: %w", err)
+	}
+
+	// chainlink-sui does not generate the plain timelock_update_min_delay.
+	tx, err := NewTransactionWithStateObj(
+		suiTimelockUpdateMinDelayModuleName,
+		suiTimelockUpdateMinDelayFunctionName,
+		c.mcmsPackageID,
+		data,
+		"",
+		nil,
+		timelockAddress,
+		nil,
+	)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("creating mcms transaction: %w", err)
+	}
+
+	return types.TransactionResult{
+		Hash:        "",
+		ChainFamily: chainsel.FamilySui,
+		RawData:     tx,
+	}, nil
+}
+
+// serializeTimelockUpdateMinDelay BCS-encodes the new delay.
+func serializeTimelockUpdateMinDelay(newMinDelay uint64) ([]byte, error) {
+	return bcs.SerializeSingle(func(ser *bcs.Serializer) {
+		ser.U64(newMinDelay)
+	})
+}

--- a/sdk/sui/timelock_configurer.go
+++ b/sdk/sui/timelock_configurer.go
@@ -39,7 +39,7 @@ func (c *TimelockConfigurer) UpdateDelay(
 		return types.TransactionResult{}, fmt.Errorf("timelock address is required")
 	}
 
-	data, err := serializeTimelockUpdateMinDelay(newDelay)
+	data, err := serializeTimelockUpdateMinDelay(timelockAddress, newDelay)
 	if err != nil {
 		return types.TransactionResult{}, fmt.Errorf("encoding timelock_update_min_delay: %w", err)
 	}
@@ -66,9 +66,15 @@ func (c *TimelockConfigurer) UpdateDelay(
 	}, nil
 }
 
-// serializeTimelockUpdateMinDelay BCS-encodes the new delay.
-func serializeTimelockUpdateMinDelay(newMinDelay uint64) ([]byte, error) {
+// serializeTimelockUpdateMinDelay BCS-encodes the timelock object address and new delay.
+func serializeTimelockUpdateMinDelay(timelockAddress string, newMinDelay uint64) ([]byte, error) {
+	timelockAddr, err := AddressFromHex(timelockAddress)
+	if err != nil {
+		return nil, fmt.Errorf("decoding timelock address: %w", err)
+	}
+
 	return bcs.SerializeSingle(func(ser *bcs.Serializer) {
+		ser.FixedBytes(timelockAddr.Bytes())
 		ser.U64(newMinDelay)
 	})
 }

--- a/sdk/sui/timelock_configurer_test.go
+++ b/sdk/sui/timelock_configurer_test.go
@@ -26,6 +26,7 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 	t.Parallel()
 
 	mcmsPackageID := "0x1"
+	validTimelockAddress := "0x1234"
 
 	configurer := NewTimelockConfigurer(mcmsPackageID)
 
@@ -38,7 +39,7 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 	}{
 		{
 			name:            "success returns prepared tx with empty hash",
-			timelockAddress: "0xtimelock",
+			timelockAddress: validTimelockAddress,
 			newDelay:        3600,
 			assertion:       assert.NoError,
 		},
@@ -48,6 +49,13 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 			newDelay:        3600,
 			assertion:       assert.Error,
 			wantErr:         "timelock address is required",
+		},
+		{
+			name:            "invalid timelock address rejected",
+			timelockAddress: "0xtimelock",
+			newDelay:        3600,
+			assertion:       assert.Error,
+			wantErr:         "decoding timelock address",
 		},
 	}
 
@@ -83,8 +91,13 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 func TestSerializeTimelockUpdateMinDelay(t *testing.T) {
 	t.Parallel()
 
-	data, err := serializeTimelockUpdateMinDelay(3600)
+	timelockAddress := "0x1234"
+	data, err := serializeTimelockUpdateMinDelay(timelockAddress, 3600)
 	require.NoError(t, err)
-	require.Len(t, data, 8)
-	assert.Equal(t, uint64(3600), binary.LittleEndian.Uint64(data))
+	require.Len(t, data, AddressLen+8)
+
+	addr, err := AddressFromHex(timelockAddress)
+	require.NoError(t, err)
+	assert.Equal(t, addr.Bytes(), data[:AddressLen])
+	assert.Equal(t, uint64(3600), binary.LittleEndian.Uint64(data[AddressLen:]))
 }

--- a/sdk/sui/timelock_configurer_test.go
+++ b/sdk/sui/timelock_configurer_test.go
@@ -1,0 +1,90 @@
+package sui
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"testing"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/types"
+)
+
+func TestNewTimelockConfigurer(t *testing.T) {
+	t.Parallel()
+
+	mcmsPackageID := "0x1"
+
+	configurer := NewTimelockConfigurer(mcmsPackageID)
+	require.NotNil(t, configurer)
+	assert.Equal(t, mcmsPackageID, configurer.mcmsPackageID)
+}
+
+func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
+	t.Parallel()
+
+	mcmsPackageID := "0x1"
+
+	configurer := NewTimelockConfigurer(mcmsPackageID)
+
+	tests := []struct {
+		name            string
+		timelockAddress string
+		newDelay        uint64
+		assertion       assert.ErrorAssertionFunc
+		wantErr         string
+	}{
+		{
+			name:            "success returns prepared tx with empty hash",
+			timelockAddress: "0xtimelock",
+			newDelay:        3600,
+			assertion:       assert.NoError,
+		},
+		{
+			name:            "empty timelock address rejected",
+			timelockAddress: "",
+			newDelay:        3600,
+			assertion:       assert.Error,
+			wantErr:         "timelock address is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := configurer.UpdateDelay(t.Context(), tt.timelockAddress, tt.newDelay)
+
+			tt.assertion(t, err)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			assert.Empty(t, got.Hash, "Sui UpdateDelay must return empty Hash (prepared tx)")
+			assert.Equal(t, chainsel.FamilySui, got.ChainFamily)
+
+			tx, ok := got.RawData.(types.Transaction)
+			require.True(t, ok, "RawData should be mcms types.Transaction")
+			assert.Equal(t, mcmsPackageID, tx.To)
+
+			var fields AdditionalFields
+			require.NoError(t, json.Unmarshal(tx.AdditionalFields, &fields))
+			assert.Equal(t, suiTimelockUpdateMinDelayModuleName, fields.ModuleName)
+			assert.Equal(t, suiTimelockUpdateMinDelayFunctionName, fields.Function)
+			assert.Equal(t, tt.timelockAddress, fields.StateObj)
+			assert.NotEmpty(t, tx.Data, "BCS-encoded new delay must be present")
+		})
+	}
+}
+
+func TestSerializeTimelockUpdateMinDelay(t *testing.T) {
+	t.Parallel()
+
+	data, err := serializeTimelockUpdateMinDelay(3600)
+	require.NoError(t, err)
+	require.Len(t, data, 8)
+	assert.Equal(t, uint64(3600), binary.LittleEndian.Uint64(data))
+}

--- a/sdk/ton/timelock_configurer.go
+++ b/sdk/ton/timelock_configurer.go
@@ -1,0 +1,66 @@
+package ton
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/xssnick/tonutils-go/address"
+	"github.com/xssnick/tonutils-go/tlb"
+	"github.com/xssnick/tonutils-go/ton/wallet"
+
+	"github.com/smartcontractkit/chainlink-ton/pkg/bindings/mcms/timelock"
+	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
+
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/types"
+)
+
+var _ sdk.TimelockConfigurer = (*TimelockConfigurer)(nil)
+
+// TimelockConfigurer configures timelock parameters on TON chains.
+type TimelockConfigurer struct {
+	wallet *wallet.Wallet
+	// amount is attached to the internal message.
+	amount tlb.Coins
+}
+
+// NewTimelockConfigurer creates a new TimelockConfigurer for TON chains.
+func NewTimelockConfigurer(w *wallet.Wallet, amount tlb.Coins) *TimelockConfigurer {
+	return &TimelockConfigurer{wallet: w, amount: amount}
+}
+
+// UpdateDelay sends the RBACTimelock UpdateDelay message to the given timelock
+// address. TON's timelock accepts a uint32 delay.
+func (c *TimelockConfigurer) UpdateDelay(
+	ctx context.Context, timelockAddress string, newDelay uint64,
+) (types.TransactionResult, error) {
+	if newDelay > math.MaxUint32 {
+		return types.TransactionResult{}, fmt.Errorf("newDelay %d exceeds uint32 range supported by TON timelock", newDelay)
+	}
+
+	dstAddr, err := address.ParseAddr(timelockAddress)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("invalid timelock address: %w", err)
+	}
+
+	qID, err := tvm.RandomQueryID()
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("failed to generate random query ID: %w", err)
+	}
+
+	body, err := tlb.ToCell(timelock.UpdateDelay{
+		QueryID:  qID,
+		NewDelay: uint32(newDelay),
+	})
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("failed to encode UpdateDelay body: %w", err)
+	}
+
+	return SendTx(ctx, TxOpts{
+		Wallet:  c.wallet,
+		DstAddr: dstAddr,
+		Amount:  c.amount,
+		Body:    body,
+	})
+}

--- a/sdk/ton/timelock_configurer_test.go
+++ b/sdk/ton/timelock_configurer_test.go
@@ -1,0 +1,118 @@
+package ton_test
+
+import (
+	"errors"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/xssnick/tonutils-go/tlb"
+	"github.com/xssnick/tonutils-go/ton"
+
+	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
+
+	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
+
+	mcmston "github.com/smartcontractkit/mcms/sdk/ton"
+	ton_mocks "github.com/smartcontractkit/mcms/sdk/ton/mocks"
+)
+
+func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
+	t.Parallel()
+
+	const validTimelockAddr = "EQADa3W6G0nSiTV4a6euRA42fU9QxSEnb-WeDpcrtWzA2jM8"
+
+	tests := []struct {
+		name            string
+		timelockAddress string
+		newDelay        uint64
+		mockSetup       func(m *ton_mocks.TonAPI)
+		wantHash        string
+		wantErr         string
+	}{
+		{
+			name:            "success",
+			timelockAddress: validTimelockAddr,
+			newDelay:        3600,
+			mockSetup: func(m *ton_mocks.TonAPI) {
+				m.EXPECT().CurrentMasterchainInfo(mock.Anything).
+					Return(&ton.BlockIDExt{}, nil)
+
+				apiw := ton_mocks.NewAPIClientWrapped(t)
+				apiw.EXPECT().GetAccount(mock.Anything, mock.Anything, mock.Anything).
+					Return(&tlb.Account{}, nil)
+				apiw.EXPECT().RunGetMethod(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(ton.NewExecutionResult([]any{big.NewInt(5)}), nil)
+
+				m.EXPECT().WaitForBlock(mock.Anything).Return(apiw)
+				m.EXPECT().SendExternalMessageWaitTransaction(mock.Anything, mock.Anything).
+					Return(&tlb.Transaction{Hash: []byte{0xde, 0xad, 0xbe, 0xef}}, &ton.BlockIDExt{}, []byte{}, nil)
+			},
+			wantHash: "deadbeef",
+		},
+		{
+			name:            "invalid timelock address",
+			timelockAddress: "not-a-valid-ton-address",
+			newDelay:        3600,
+			mockSetup:       func(m *ton_mocks.TonAPI) {},
+			wantErr:         "invalid timelock address",
+		},
+		{
+			name:            "newDelay exceeds uint32 rejected",
+			timelockAddress: validTimelockAddr,
+			newDelay:        math.MaxUint32 + 1,
+			mockSetup:       func(m *ton_mocks.TonAPI) {},
+			wantErr:         "exceeds uint32 range",
+		},
+		{
+			name:            "send transaction fails",
+			timelockAddress: validTimelockAddr,
+			newDelay:        3600,
+			mockSetup: func(m *ton_mocks.TonAPI) {
+				m.EXPECT().CurrentMasterchainInfo(mock.Anything).
+					Return(&ton.BlockIDExt{}, nil)
+
+				apiw := ton_mocks.NewAPIClientWrapped(t)
+				apiw.EXPECT().GetAccount(mock.Anything, mock.Anything, mock.Anything).
+					Return(&tlb.Account{}, nil)
+				apiw.EXPECT().RunGetMethod(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(ton.NewExecutionResult([]any{big.NewInt(5)}), nil)
+
+				m.EXPECT().WaitForBlock(mock.Anything).Return(apiw)
+				m.EXPECT().SendExternalMessageWaitTransaction(mock.Anything, mock.Anything).
+					Return(nil, nil, nil, errors.New("boom"))
+			},
+			wantErr: "failed to send transaction",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			api := ton_mocks.NewTonAPI(t)
+			chainID := chaintest.Chain7TONID
+			walletOperator := must(tvm.NewRandomV5R1TestWallet(api, chainID))
+
+			tt.mockSetup(api)
+
+			configurer := mcmston.NewTimelockConfigurer(walletOperator, tlb.MustFromTON("0.1"))
+			result, err := configurer.UpdateDelay(t.Context(), tt.timelockAddress, tt.newDelay)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.Empty(t, result.Hash)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHash, result.Hash)
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces new helpers for timelock configuration across multiple supported chain families in the `chainwrappers` package, and expands end-to-end (E2E) test coverage for timelock delay updates on Aptos, Sui, and TON blockchains. 