### PR TITLE
timelock configurer cleanups

### DIFF
--- a/chainwrappers/timelock_configurers_test.go
+++ b/chainwrappers/timelock_configurers_test.go
@@ -17,7 +17,6 @@ import (
 	solanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	"github.com/smartcontractkit/mcms/sdk/sui"
 	"github.com/smartcontractkit/mcms/sdk/ton"
-
 	mcmsTypes "github.com/smartcontractkit/mcms/types"
 )
 
@@ -27,8 +26,7 @@ func TestBuildTimelockConfigurers(t *testing.T) {
 	tests := []struct {
 		name          string
 		chainMetadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata
-		setup         func(t *testing.T, access *mocks.ChainAccessor)
-		prepare       func(t *testing.T, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata)
+		setup         func(t *testing.T, access *mocks.ChainAccessor, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata)
 		expectErr     bool
 		errContains   string
 		expectTypes   map[mcmsTypes.ChainSelector]any
@@ -65,7 +63,7 @@ func TestBuildTimelockConfigurers(t *testing.T) {
 					}`),
 				},
 			},
-			setup: func(t *testing.T, access *mocks.ChainAccessor) {
+			setup: func(t *testing.T, access *mocks.ChainAccessor, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata) {
 				t.Helper()
 
 				access.EXPECT().EVMClient(mock.Anything).Return(nil, true)
@@ -95,7 +93,7 @@ func TestBuildTimelockConfigurers(t *testing.T) {
 					MCMAddress: "0xaptos",
 				},
 			},
-			prepare: func(t *testing.T, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata) {
+			setup: func(t *testing.T, access *mocks.ChainAccessor, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata) {
 				t.Helper()
 
 				b, err := json.Marshal(aptos.AdditionalFieldsMetadata{
@@ -107,9 +105,6 @@ func TestBuildTimelockConfigurers(t *testing.T) {
 				entry := metadata[mcmsTypes.ChainSelector(chainsel.APTOS_TESTNET.Selector)]
 				entry.AdditionalFields = b
 				metadata[mcmsTypes.ChainSelector(chainsel.APTOS_TESTNET.Selector)] = entry
-			},
-			setup: func(t *testing.T, access *mocks.ChainAccessor) {
-				t.Helper()
 
 				access.EXPECT().AptosClient(mock.Anything).Return(nil, true)
 			},
@@ -122,7 +117,7 @@ func TestBuildTimelockConfigurers(t *testing.T) {
 			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{
 				mcmsTypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector): {MCMAddress: "0xevm"},
 			},
-			setup: func(t *testing.T, access *mocks.ChainAccessor) {
+			setup: func(t *testing.T, access *mocks.ChainAccessor, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata) {
 				t.Helper()
 
 				access.EXPECT().EVMClient(mock.Anything).Return(nil, false)
@@ -135,7 +130,7 @@ func TestBuildTimelockConfigurers(t *testing.T) {
 			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{
 				mcmsTypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector): {MCMAddress: "0xevm"},
 			},
-			setup: func(t *testing.T, access *mocks.ChainAccessor) {
+			setup: func(t *testing.T, access *mocks.ChainAccessor, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata) {
 				t.Helper()
 
 				access.EXPECT().EVMClient(mock.Anything).Return(nil, true)
@@ -149,7 +144,7 @@ func TestBuildTimelockConfigurers(t *testing.T) {
 			chainMetadata: map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata{
 				mcmsTypes.ChainSelector(chainsel.TON_TESTNET.Selector): {MCMAddress: "0xton"},
 			},
-			setup: func(t *testing.T, access *mocks.ChainAccessor) {
+			setup: func(t *testing.T, access *mocks.ChainAccessor, metadata map[mcmsTypes.ChainSelector]mcmsTypes.ChainMetadata) {
 				t.Helper()
 
 				access.EXPECT().TonSigner(mock.Anything).Return(nil, false)
@@ -163,17 +158,14 @@ func TestBuildTimelockConfigurers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			access := mocks.NewChainAccessor(t)
-			if tc.prepare != nil {
-				tc.prepare(t, tc.chainMetadata)
-			}
 			if tc.setup != nil {
-				tc.setup(t, access)
+				tc.setup(t, access, tc.chainMetadata)
 			}
 
 			configurers, err := BuildTimelockConfigurers(access, tc.chainMetadata, mcmsTypes.TimelockActionSchedule)
 			if tc.expectErr {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.errContains)
+				require.ErrorContains(t, err, tc.errContains)
 
 				return
 			}
@@ -199,7 +191,7 @@ func TestBuildTimelockConfigurer_NilChainAccess(t *testing.T) {
 		mcmsTypes.ChainMetadata{},
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "chain access is required")
+	require.ErrorContains(t, err, "chain access is required")
 }
 
 func TestBuildTimelockConfigurer_AptosCurseMetadataEncodesCursePackage(t *testing.T) {

--- a/sdk/sui/executing_callback.go
+++ b/sdk/sui/executing_callback.go
@@ -18,8 +18,6 @@ import (
 
 const (
 	UpgradeGasBudget = 500_000_000
-
-	suiMCMSSetConfigFunctionName = "set_config"
 )
 
 type EntrypointArgEncoder interface {
@@ -206,7 +204,7 @@ func (e *ExecutingCallbackParams) processMCMSMainModuleCall(ctx context.Context,
 			call.StateObj,
 			executingCallbackParams,
 		)
-	case TimelockActionCancel:
+	case suiTimelockCancelFunctionName:
 		executeDispatchCall, err = e.mcms.Encoder().McmsTimelockCancelWithArgs(
 			bind.Object{Id: call.StateObj},
 			bind.Object{Id: e.registryObj},

--- a/sdk/sui/executor.go
+++ b/sdk/sui/executor.go
@@ -148,11 +148,11 @@ func (e Executor) ExecuteOperation(
 	}
 	// Now build the timelock call using the result from the execute call
 	encoder := e.mcms.Encoder()
-	if additionalFields.Function != TimelockActionBypass && additionalFields.Function != TimelockActionSchedule && additionalFields.Function != TimelockActionCancel {
+	if additionalFields.Function != suiTimelockBypassFunctionName && additionalFields.Function != suiTimelockScheduleFunctionName && additionalFields.Function != suiTimelockCancelFunctionName {
 		return types.TransactionResult{}, fmt.Errorf("unsupported timelock action: %s", additionalFields.Function)
 	}
 
-	if additionalFields.Function == TimelockActionSchedule {
+	if additionalFields.Function == suiTimelockScheduleFunctionName {
 		timelockCall, encodeErr := encoder.DispatchTimelockScheduleBatchWithArgs(e.timelockObj, "0x6", timelockCallback)
 		if encodeErr != nil {
 			return types.TransactionResult{}, fmt.Errorf("creating timelock call: %w", encodeErr)
@@ -163,7 +163,7 @@ func (e Executor) ExecuteOperation(
 		}
 	}
 
-	if additionalFields.Function == TimelockActionCancel {
+	if additionalFields.Function == suiTimelockCancelFunctionName {
 		timelockCall, encodeErr := encoder.DispatchTimelockCancelWithArgs(e.timelockObj, timelockCallback)
 		if encodeErr != nil {
 			return types.TransactionResult{}, fmt.Errorf("creating timelock call: %w", encodeErr)
@@ -174,7 +174,7 @@ func (e Executor) ExecuteOperation(
 		}
 	}
 
-	if additionalFields.Function == TimelockActionBypass {
+	if additionalFields.Function == suiTimelockBypassFunctionName {
 		timelockCall, timelockErr := encoder.DispatchTimelockBypasserExecuteBatchWithArgs(timelockCallback)
 		if timelockErr != nil {
 			return types.TransactionResult{}, fmt.Errorf("creating timelock call: %w", timelockErr)

--- a/sdk/sui/function_names.go
+++ b/sdk/sui/function_names.go
@@ -2,6 +2,8 @@ package sui
 
 const (
 	suiMCMSSetConfigFunctionName          = "set_config"
+	suiTimelockScheduleFunctionName       = "timelock_schedule_batch"
 	suiTimelockCancelFunctionName         = "timelock_cancel"
+	suiTimelockBypassFunctionName         = "timelock_bypasser_execute_batch"
 	suiTimelockUpdateMinDelayFunctionName = "timelock_update_min_delay"
 )

--- a/sdk/sui/function_names.go
+++ b/sdk/sui/function_names.go
@@ -1,0 +1,7 @@
+package sui
+
+const (
+	suiMCMSSetConfigFunctionName          = "set_config"
+	suiTimelockCancelFunctionName         = "timelock_cancel"
+	suiTimelockUpdateMinDelayFunctionName = "timelock_update_min_delay"
+)

--- a/sdk/sui/timelock_configurer.go
+++ b/sdk/sui/timelock_configurer.go
@@ -11,11 +11,7 @@ import (
 	"github.com/smartcontractkit/mcms/types"
 )
 
-// Names used for the timelock update-min-delay call.
-const (
-	suiTimelockUpdateMinDelayModuleName   = "mcms"
-	suiTimelockUpdateMinDelayFunctionName = "timelock_update_min_delay"
-)
+const suiTimelockUpdateMinDelayModuleName = "mcms"
 
 var _ sdk.TimelockConfigurer = (*TimelockConfigurer)(nil)
 

--- a/sdk/sui/timelock_converter.go
+++ b/sdk/sui/timelock_converter.go
@@ -14,12 +14,6 @@ import (
 	"github.com/smartcontractkit/mcms/types"
 )
 
-const (
-	TimelockActionSchedule = "timelock_schedule_batch"
-	TimelockActionCancel   = "timelock_cancel"
-	TimelockActionBypass   = "timelock_bypasser_execute_batch"
-)
-
 var _ sdk.TimelockConverter = (*TimelockConverter)(nil)
 
 type TimelockConverter struct{}
@@ -85,7 +79,7 @@ func (t *TimelockConverter) ConvertBatchToChainOperations(
 	var err error
 	switch action {
 	case types.TimelockActionSchedule:
-		function = TimelockActionSchedule
+		function = suiTimelockScheduleFunctionName
 		delaySecs, castErr := safecast.Float64ToUint64(delay.Seconds())
 		if castErr != nil {
 			return nil, common.Hash{}, fmt.Errorf("failed to convert delay to uint64: %w", castErr)
@@ -95,7 +89,7 @@ func (t *TimelockConverter) ConvertBatchToChainOperations(
 			return nil, common.Hash{}, fmt.Errorf("failed to serialize timelock schedule batch: %w", err)
 		}
 	case types.TimelockActionCancel:
-		function = TimelockActionCancel
+		function = suiTimelockCancelFunctionName
 		// For cancellation, we need to serialize the operation ID
 		operationID, hashErr := HashOperationBatch(targets, moduleNames, functionNames, datas, predecessor.Bytes(), salt.Bytes())
 		if hashErr != nil {
@@ -106,7 +100,7 @@ func (t *TimelockConverter) ConvertBatchToChainOperations(
 			return nil, common.Hash{}, fmt.Errorf("failed to serialize timelock cancel: %w", err)
 		}
 	case types.TimelockActionBypass:
-		function = TimelockActionBypass
+		function = suiTimelockBypassFunctionName
 		data, err = serializeTimelockBypasserExecuteBatch(targets, moduleNames, functionNames, datas)
 		if err != nil {
 			return nil, common.Hash{}, fmt.Errorf("failed to serialize timelock bypasser execute batch: %w", err)

--- a/sdk/sui/timelock_converter_test.go
+++ b/sdk/sui/timelock_converter_test.go
@@ -383,13 +383,12 @@ func TestHashOperationBatch_Deterministic(t *testing.T) {
 	assert.NotEqual(t, hash1, hash2, "Different inputs should produce different hashes")
 }
 
-func TestTimelockConverter_ActionConstants(t *testing.T) {
+func TestTimelockConverter_FunctionNameConstants(t *testing.T) {
 	t.Parallel()
 
-	// Test that the action constants are correctly defined
-	assert.Equal(t, "timelock_schedule_batch", TimelockActionSchedule)
-	assert.Equal(t, "timelock_cancel", TimelockActionCancel)
-	assert.Equal(t, "timelock_bypasser_execute_batch", TimelockActionBypass)
+	assert.Equal(t, "timelock_schedule_batch", suiTimelockScheduleFunctionName)
+	assert.Equal(t, "timelock_cancel", suiTimelockCancelFunctionName)
+	assert.Equal(t, "timelock_bypasser_execute_batch", suiTimelockBypassFunctionName)
 }
 
 func TestOperationID(t *testing.T) {

--- a/sdk/ton/common.go
+++ b/sdk/ton/common.go
@@ -2,6 +2,8 @@ package ton
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"time"
@@ -78,4 +80,21 @@ func SendTxAfter(ctx context.Context, opts TxOpts, now uint64, validAfter uint64
 			return z, fmt.Errorf("context done while waiting to send transaction: %w", ctx.Err())
 		}
 	}
+}
+
+// Prepared TON transactions must be reproducible across identical inputs.
+func deterministicPreparedQueryID(dst *address.Address, operation string, body *cell.Cell) uint64 {
+	sum := sha256.New()
+	sum.Write([]byte(dst.String()))
+	sum.Write([]byte{0})
+	sum.Write([]byte(operation))
+	sum.Write([]byte{0})
+	sum.Write(body.Hash())
+
+	qID := binary.BigEndian.Uint64(sum.Sum(nil)[:8])
+	if qID == 0 {
+		return 1
+	}
+
+	return qID
 }

--- a/sdk/ton/configurer.go
+++ b/sdk/ton/configurer.go
@@ -89,9 +89,12 @@ func (c configurer) SetConfig(ctx context.Context, mcmsAddr string, cfg *types.C
 		return types.TransactionResult{}, fmt.Errorf("unable to create group parents dict: %w", err)
 	}
 
-	qID, err := tvm.RandomQueryID()
-	if err != nil {
-		return types.TransactionResult{}, fmt.Errorf("failed to generate random query ID: %w", err)
+	qID := uint64(0)
+	if !c.skipSend {
+		qID, err = tvm.RandomQueryID()
+		if err != nil {
+			return types.TransactionResult{}, fmt.Errorf("failed to generate random query ID: %w", err)
+		}
 	}
 
 	body, err := tlb.ToCell(mcms.SetConfig{

--- a/sdk/ton/configurer.go
+++ b/sdk/ton/configurer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/xssnick/tonutils-go/address"
 	"github.com/xssnick/tonutils-go/tlb"
 	"github.com/xssnick/tonutils-go/ton/wallet"
+	"github.com/xssnick/tonutils-go/tvm/cell"
 )
 
 var _ sdk.Configurer = &configurer{}
@@ -89,24 +90,29 @@ func (c configurer) SetConfig(ctx context.Context, mcmsAddr string, cfg *types.C
 		return types.TransactionResult{}, fmt.Errorf("unable to create group parents dict: %w", err)
 	}
 
-	qID := uint64(0)
-	if !c.skipSend {
-		qID, err = tvm.RandomQueryID()
+	msg := mcms.SetConfig{
+		SignerAddresses: signerKeys,
+		SignerGroups:    signerGroups,
+		GroupQuorums:    gqDict,
+		GroupParents:    gpDict,
+		ClearRoot:       clearRoot,
+	}
+	var body *cell.Cell
+	if c.skipSend {
+		body, err = tlb.ToCell(msg)
+		if err != nil {
+			return types.TransactionResult{}, fmt.Errorf("failed to encode SetConfig body: %w", err)
+		}
+
+		msg.QueryID = deterministicPreparedQueryID(dstAddr, "MCMS:SetConfig", body)
+	} else {
+		msg.QueryID, err = tvm.RandomQueryID()
 		if err != nil {
 			return types.TransactionResult{}, fmt.Errorf("failed to generate random query ID: %w", err)
 		}
 	}
 
-	body, err := tlb.ToCell(mcms.SetConfig{
-		QueryID: qID,
-
-		SignerAddresses: signerKeys,
-		SignerGroups:    signerGroups,
-		GroupQuorums:    gqDict,
-		GroupParents:    gpDict,
-
-		ClearRoot: clearRoot,
-	})
+	body, err = tlb.ToCell(msg)
 	if err != nil {
 		return types.TransactionResult{}, fmt.Errorf("failed to encode SetConfig body: %w", err)
 	}

--- a/sdk/ton/configurer_test.go
+++ b/sdk/ton/configurer_test.go
@@ -34,14 +34,15 @@ func TestConfigurer_SetConfig(t *testing.T) {
 	signers := testutils.MakeNewECDSASigners(16)
 
 	tests := []struct {
-		name      string
-		options   []mcmston.ConfigurerOption
-		mcmAddr   string
-		cfg       *types.Config
-		clearRoot bool
-		mockSetup func(m *ton_mocks.TonAPI)
-		want      string
-		wantErr   error
+		name         string
+		options      []mcmston.ConfigurerOption
+		mcmAddr      string
+		cfg          *types.Config
+		clearRoot    bool
+		mockSetup    func(m *ton_mocks.TonAPI)
+		want         string
+		wantErr      error
+		wantPrepared bool
 	}{
 		{
 			name:    "success",
@@ -112,8 +113,9 @@ func TestConfigurer_SetConfig(t *testing.T) {
 			mockSetup: func(m *ton_mocks.TonAPI) {
 				// No mocks needed as transaction won't be sent
 			},
-			want:    "", // Hash is empty when not sending transaction
-			wantErr: nil,
+			want:         "", // Hash is empty when not sending transaction
+			wantErr:      nil,
+			wantPrepared: true,
 		},
 		{
 			name:    "failure - SendTransaction fails",
@@ -189,6 +191,17 @@ func TestConfigurer_SetConfig(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, tx.Hash)
+				if tt.wantPrepared {
+					preparedTx, ok := tx.RawData.(types.Transaction)
+					require.True(t, ok)
+
+					tx2, err := configurer.SetConfig(ctx, tt.mcmAddr, tt.cfg, tt.clearRoot)
+					require.NoError(t, err)
+					preparedTx2, ok := tx2.RawData.(types.Transaction)
+					require.True(t, ok)
+
+					assert.Equal(t, preparedTx.Data, preparedTx2.Data)
+				}
 			}
 		})
 	}

--- a/sdk/ton/configurer_test.go
+++ b/sdk/ton/configurer_test.go
@@ -7,22 +7,20 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-
+	"github.com/smartcontractkit/chainlink-ton/pkg/bindings/mcms/mcms"
+	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/xssnick/tonutils-go/tlb"
+	"github.com/xssnick/tonutils-go/ton"
+	"github.com/xssnick/tonutils-go/tvm/cell"
 
 	"github.com/smartcontractkit/mcms/internal/testutils"
 	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
-	"github.com/smartcontractkit/mcms/types"
-
-	"github.com/xssnick/tonutils-go/tlb"
-	"github.com/xssnick/tonutils-go/ton"
-
-	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
-
 	mcmston "github.com/smartcontractkit/mcms/sdk/ton"
 	ton_mocks "github.com/smartcontractkit/mcms/sdk/ton/mocks"
+	"github.com/smartcontractkit/mcms/types"
 )
 
 // TestConfigurer_SetConfig tests the SetConfig method of the Configurer.
@@ -194,13 +192,21 @@ func TestConfigurer_SetConfig(t *testing.T) {
 				if tt.wantPrepared {
 					preparedTx, ok := tx.RawData.(types.Transaction)
 					require.True(t, ok)
+					preparedBody := must(cell.FromBOC(preparedTx.Data))
+					var preparedMsg mcms.SetConfig
+					require.NoError(t, tlb.LoadFromCell(&preparedMsg, preparedBody.BeginParse()))
 
 					tx2, err := configurer.SetConfig(ctx, tt.mcmAddr, tt.cfg, tt.clearRoot)
 					require.NoError(t, err)
 					preparedTx2, ok := tx2.RawData.(types.Transaction)
 					require.True(t, ok)
+					preparedBody2 := must(cell.FromBOC(preparedTx2.Data))
+					var preparedMsg2 mcms.SetConfig
+					require.NoError(t, tlb.LoadFromCell(&preparedMsg2, preparedBody2.BeginParse()))
 
 					assert.Equal(t, preparedTx.Data, preparedTx2.Data)
+					assert.Equal(t, preparedMsg.QueryID, preparedMsg2.QueryID)
+					assert.NotZero(t, preparedMsg.QueryID)
 				}
 			}
 		})

--- a/sdk/ton/timelock_configurer.go
+++ b/sdk/ton/timelock_configurer.go
@@ -6,12 +6,12 @@ import (
 	"math"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-ton/pkg/bindings/mcms/timelock"
 	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 	"github.com/xssnick/tonutils-go/address"
 	"github.com/xssnick/tonutils-go/tlb"
 	"github.com/xssnick/tonutils-go/ton/wallet"
-
-	"github.com/smartcontractkit/chainlink-ton/pkg/bindings/mcms/timelock"
+	"github.com/xssnick/tonutils-go/tvm/cell"
 
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/types"
@@ -60,18 +60,25 @@ func (c *TimelockConfigurer) UpdateDelay(
 		return types.TransactionResult{}, fmt.Errorf("invalid timelock address: %w", err)
 	}
 
-	qID := uint64(0)
-	if !c.skipSend {
-		qID, err = tvm.RandomQueryID()
+	msg := timelock.UpdateDelay{
+		NewDelay: uint32(newDelay),
+	}
+	var body *cell.Cell
+	if c.skipSend {
+		body, err = tlb.ToCell(msg)
+		if err != nil {
+			return types.TransactionResult{}, fmt.Errorf("failed to encode UpdateDelay body: %w", err)
+		}
+
+		msg.QueryID = deterministicPreparedQueryID(dstAddr, "RBACTimelock:UpdateDelay", body)
+	} else {
+		msg.QueryID, err = tvm.RandomQueryID()
 		if err != nil {
 			return types.TransactionResult{}, fmt.Errorf("failed to generate random query ID: %w", err)
 		}
 	}
 
-	body, err := tlb.ToCell(timelock.UpdateDelay{
-		QueryID:  qID,
-		NewDelay: uint32(newDelay),
-	})
+	body, err = tlb.ToCell(msg)
 	if err != nil {
 		return types.TransactionResult{}, fmt.Errorf("failed to encode UpdateDelay body: %w", err)
 	}

--- a/sdk/ton/timelock_configurer.go
+++ b/sdk/ton/timelock_configurer.go
@@ -6,12 +6,12 @@ import (
 	"math"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 	"github.com/xssnick/tonutils-go/address"
 	"github.com/xssnick/tonutils-go/tlb"
 	"github.com/xssnick/tonutils-go/ton/wallet"
 
 	"github.com/smartcontractkit/chainlink-ton/pkg/bindings/mcms/timelock"
-	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/types"
@@ -60,9 +60,12 @@ func (c *TimelockConfigurer) UpdateDelay(
 		return types.TransactionResult{}, fmt.Errorf("invalid timelock address: %w", err)
 	}
 
-	qID, err := tvm.RandomQueryID()
-	if err != nil {
-		return types.TransactionResult{}, fmt.Errorf("failed to generate random query ID: %w", err)
+	qID := uint64(0)
+	if !c.skipSend {
+		qID, err = tvm.RandomQueryID()
+		if err != nil {
+			return types.TransactionResult{}, fmt.Errorf("failed to generate random query ID: %w", err)
+		}
 	}
 
 	body, err := tlb.ToCell(timelock.UpdateDelay{

--- a/sdk/ton/timelock_configurer.go
+++ b/sdk/ton/timelock_configurer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/xssnick/tonutils-go/address"
 	"github.com/xssnick/tonutils-go/tlb"
 	"github.com/xssnick/tonutils-go/ton/wallet"
@@ -23,11 +24,26 @@ type TimelockConfigurer struct {
 	wallet *wallet.Wallet
 	// amount is attached to the internal message.
 	amount tlb.Coins
+
+	skipSend bool
 }
 
 // NewTimelockConfigurer creates a new TimelockConfigurer for TON chains.
-func NewTimelockConfigurer(w *wallet.Wallet, amount tlb.Coins) *TimelockConfigurer {
-	return &TimelockConfigurer{wallet: w, amount: amount}
+func NewTimelockConfigurer(w *wallet.Wallet, amount tlb.Coins, opts ...TimelockConfigurerOption) *TimelockConfigurer {
+	c := &TimelockConfigurer{wallet: w, amount: amount}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+type TimelockConfigurerOption func(*TimelockConfigurer)
+
+func WithDoNotSendTimelockInstructionsOnChain() TimelockConfigurerOption {
+	return func(c *TimelockConfigurer) {
+		c.skipSend = true
+	}
 }
 
 // UpdateDelay sends the RBACTimelock UpdateDelay message to the given timelock
@@ -55,6 +71,19 @@ func (c *TimelockConfigurer) UpdateDelay(
 	})
 	if err != nil {
 		return types.TransactionResult{}, fmt.Errorf("failed to encode UpdateDelay body: %w", err)
+	}
+
+	if c.skipSend {
+		tx, err := NewTransaction(dstAddr, body.ToBuilder().ToSlice(), c.amount.Nano(), "RBACTimelock", []string{"UpdateDelay"})
+		if err != nil {
+			return types.TransactionResult{}, fmt.Errorf("error encoding transaction: %w", err)
+		}
+
+		return types.TransactionResult{
+			Hash:        "",
+			ChainFamily: chainsel.FamilyTon,
+			RawData:     tx,
+		}, nil
 	}
 
 	return SendTx(ctx, TxOpts{

--- a/sdk/ton/timelock_configurer_test.go
+++ b/sdk/ton/timelock_configurer_test.go
@@ -130,6 +130,12 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 				require.True(t, ok)
 				assert.Equal(t, "RBACTimelock", tx.ContractType)
 				assert.Equal(t, []string{"UpdateDelay"}, tx.Tags)
+
+				result2, err := configurer.UpdateDelay(t.Context(), tt.timelockAddress, tt.newDelay)
+				require.NoError(t, err)
+				tx2, ok := result2.RawData.(types.Transaction)
+				require.True(t, ok)
+				assert.Equal(t, tx.Data, tx2.Data)
 			}
 		})
 	}

--- a/sdk/ton/timelock_configurer_test.go
+++ b/sdk/ton/timelock_configurer_test.go
@@ -6,14 +6,14 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/smartcontractkit/chainlink-ton/pkg/bindings/mcms/timelock"
+	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
 	"github.com/xssnick/tonutils-go/tlb"
 	"github.com/xssnick/tonutils-go/ton"
-
-	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
+	"github.com/xssnick/tonutils-go/tvm/cell"
 
 	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
 	mcmston "github.com/smartcontractkit/mcms/sdk/ton"
@@ -130,12 +130,20 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 				require.True(t, ok)
 				assert.Equal(t, "RBACTimelock", tx.ContractType)
 				assert.Equal(t, []string{"UpdateDelay"}, tx.Tags)
+				body := must(cell.FromBOC(tx.Data))
+				var msg timelock.UpdateDelay
+				require.NoError(t, tlb.LoadFromCell(&msg, body.BeginParse()))
 
 				result2, err := configurer.UpdateDelay(t.Context(), tt.timelockAddress, tt.newDelay)
 				require.NoError(t, err)
 				tx2, ok := result2.RawData.(types.Transaction)
 				require.True(t, ok)
+				body2 := must(cell.FromBOC(tx2.Data))
+				var msg2 timelock.UpdateDelay
+				require.NoError(t, tlb.LoadFromCell(&msg2, body2.BeginParse()))
 				assert.Equal(t, tx.Data, tx2.Data)
+				assert.Equal(t, msg.QueryID, msg2.QueryID)
+				assert.NotZero(t, msg.QueryID)
 			}
 		})
 	}

--- a/sdk/ton/timelock_configurer_test.go
+++ b/sdk/ton/timelock_configurer_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 
 	"github.com/smartcontractkit/mcms/internal/testutils/chaintest"
-
 	mcmston "github.com/smartcontractkit/mcms/sdk/ton"
 	ton_mocks "github.com/smartcontractkit/mcms/sdk/ton/mocks"
+	"github.com/smartcontractkit/mcms/types"
 )
 
 func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
@@ -30,9 +30,11 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 		name            string
 		timelockAddress string
 		newDelay        uint64
+		options         []mcmston.TimelockConfigurerOption
 		mockSetup       func(m *ton_mocks.TonAPI)
 		wantHash        string
 		wantErr         string
+		wantPrepared    bool
 	}{
 		{
 			name:            "success",
@@ -53,6 +55,16 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 					Return(&tlb.Transaction{Hash: []byte{0xde, 0xad, 0xbe, 0xef}}, &ton.BlockIDExt{}, []byte{}, nil)
 			},
 			wantHash: "deadbeef",
+		},
+		{
+			name:            "success - WithDoNotSendTimelockInstructionsOnChain option",
+			timelockAddress: validTimelockAddr,
+			newDelay:        3600,
+			options: []mcmston.TimelockConfigurerOption{
+				mcmston.WithDoNotSendTimelockInstructionsOnChain(),
+			},
+			mockSetup:    func(m *ton_mocks.TonAPI) {},
+			wantPrepared: true,
 		},
 		{
 			name:            "invalid timelock address",
@@ -100,7 +112,7 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 
 			tt.mockSetup(api)
 
-			configurer := mcmston.NewTimelockConfigurer(walletOperator, tlb.MustFromTON("0.1"))
+			configurer := mcmston.NewTimelockConfigurer(walletOperator, tlb.MustFromTON("0.1"), tt.options...)
 			result, err := configurer.UpdateDelay(t.Context(), tt.timelockAddress, tt.newDelay)
 
 			if tt.wantErr != "" {
@@ -113,6 +125,12 @@ func TestTimelockConfigurer_UpdateDelay(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantHash, result.Hash)
+			if tt.wantPrepared {
+				tx, ok := result.RawData.(types.Transaction)
+				require.True(t, ok)
+				assert.Equal(t, "RBACTimelock", tx.ContractType)
+				assert.Equal(t, []string{"UpdateDelay"}, tx.Tags)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the test and implementation code for timelock configurers, especially for TON and Sui chains. The main changes include unifying test setup logic, improving error assertion, refactoring Sui function names to a central location, and adding an optional "do not send" mode for TON timelock configurers, along with corresponding tests.