### PR TITLE
feat: add signature recovery helpers, QuorumMet, and clearer config docs

### DIFF
--- a/.changeset/gentle-wombats-heal.md
+++ b/.changeset/gentle-wombats-heal.md
@@ -1,0 +1,6 @@
+---
+"@smartcontractkit/mcms": patch
+---
+
+Add signature recovery helpers, `QuorumMet`, and clearer config docs
+

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ node_modules/
 /compose/
 /e2e/**-cache.toml
 *.log
+
+# OS
+.DS_Store

--- a/proposal.go
+++ b/proposal.go
@@ -113,15 +113,13 @@ func (p *BaseProposal) AppendSignature(signature types.Signature) {
 
 // ChainMetadatas returns the chain metadata for the proposal.
 func (p *BaseProposal) ChainMetadatas() map[types.ChainSelector]types.ChainMetadata {
-	cmCopy := make(map[types.ChainSelector]types.ChainMetadata, len(p.ChainMetadata))
-	for k, v := range p.ChainMetadata {
-		cmCopy[k] = v
-	}
+	cm := make(map[types.ChainSelector]types.ChainMetadata, len(p.ChainMetadata))
+	maps.Copy(cm, p.ChainMetadata)
 
-	return cmCopy
+	return cm
 }
 
-// SetChainMetadata sets the chain metadata for a given chain selector.
+// setChainMetadata sets the chain metadata for a given chain selector.
 func (p *BaseProposal) setChainMetadata(chainSelector types.ChainSelector, metadata types.ChainMetadata) {
 	p.ChainMetadata[chainSelector] = metadata
 }
@@ -406,6 +404,40 @@ func (p *Proposal) Decode(decoders map[types.ChainSelector]sdk.Decoder, contract
 	return decodedOps, nil
 }
 
+// RecoverSigningAddresses attempts to recover the signer address from every signature on the
+// proposal.
+//
+// It returns the successfully recovered addresses (in signature order) and a
+// SignatureRecoveryFailure entry for each signature whose address could not be recovered.
+//
+// An error is only returned if computing the signing hash fails.
+func (p *Proposal) RecoverSigningAddresses() ([]common.Address, []SignatureRecoveryFailure, error) {
+	signingHash, err := p.SigningHash()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	recovered, failures := RecoverSigningAddresses(signingHash, p.Signatures)
+
+	return recovered, failures, nil
+}
+
+// RecoverSigningAddressesStrict recovers the signer address from every signature on the proposal,
+// returning an error if any signature cannot be recovered.
+func (p *Proposal) RecoverSigningAddressesStrict() ([]common.Address, error) {
+	recovered, failures, err := p.RecoverSigningAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(failures) > 0 {
+		f := failures[0]
+		return nil, NewInvalidSignatureAtIndexError(f.Index, f.Sig, common.Address{}, f.Err)
+	}
+
+	return recovered, nil
+}
+
 // proposalValidateBasic basic validation for an MCMS proposal
 func proposalValidateBasic(proposalObj Proposal) error {
 	validUntil := time.Unix(int64(proposalObj.ValidUntil), 0)
@@ -436,4 +468,31 @@ func validateNoDuplicateSigners(sigs []types.Signature) error {
 	}
 
 	return nil
+}
+
+// SignatureRecoveryFailure holds the outcome of a failed attempt to recover a signer address from
+// a signature.
+type SignatureRecoveryFailure struct {
+	Index int
+	Sig   types.Signature
+	Err   error
+}
+
+// RecoverSigningAddresses attempts to recover the signer address from every signature.
+//
+// It returns the successfully recovered addresses (in signature order) and a
+// SignatureRecoveryFailure entry for each signature whose address could not be recovered.
+func RecoverSigningAddresses(
+	signingHash common.Hash, signatures []types.Signature,
+) (recovered []common.Address, failures []SignatureRecoveryFailure) {
+	for i, sig := range signatures {
+		addr, rerr := sig.Recover(signingHash)
+		if rerr != nil {
+			failures = append(failures, SignatureRecoveryFailure{Index: i, Sig: sig, Err: rerr})
+		} else {
+			recovered = append(recovered, addr)
+		}
+	}
+
+	return recovered, failures
 }

--- a/proposal_test.go
+++ b/proposal_test.go
@@ -1,6 +1,7 @@
 package mcms
 
 import (
+	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
 	"io"
@@ -64,7 +65,7 @@ func TestBaseProposal_AppendSignature(t *testing.T) {
 	assert.Equal(t, []types.Signature{signature}, proposal.Signatures)
 }
 
-func TestBaseProposal_GetChainMetadata(t *testing.T) {
+func TestBaseProposal_ChainMetadatas(t *testing.T) {
 	t.Parallel()
 
 	chainMetadata := map[types.ChainSelector]types.ChainMetadata{
@@ -1149,6 +1150,162 @@ func TestProposal_TransactionNonces(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tt.want, got)
 			}
+		})
+	}
+}
+
+// newSignedProposal is a test helper that builds a minimal valid proposal and signs it with
+// the given private keys.
+func newSignedProposal(t *testing.T, keys []*ecdsa.PrivateKey) *Proposal {
+	t.Helper()
+
+	builder := NewProposalBuilder()
+	builder.SetVersion("v1").
+		SetValidUntil(2004259681).
+		AddChainMetadata(chaintest.Chain1Selector, types.ChainMetadata{}).
+		AddOperation(types.Operation{
+			ChainSelector: chaintest.Chain1Selector,
+			Transaction: types.Transaction{
+				To:               TestAddress,
+				AdditionalFields: json.RawMessage(`{"value": 0}`),
+				Data:             common.Hex2Bytes("0x1"),
+			},
+		})
+
+	proposal, err := builder.Build()
+	require.NoError(t, err)
+
+	signable, err := NewSignable(proposal, nil)
+	require.NoError(t, err)
+
+	for _, key := range keys {
+		_, err = signable.SignAndAppend(NewPrivateKeySigner(key))
+		require.NoError(t, err)
+	}
+
+	return proposal
+}
+
+func TestProposal_EvaluateSignatures(t *testing.T) {
+	t.Parallel()
+
+	key1, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	key2, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	addr1 := crypto.PubkeyToAddress(key1.PublicKey)
+	addr2 := crypto.PubkeyToAddress(key2.PublicKey)
+
+	tests := []struct {
+		name               string
+		signerKeys         []*ecdsa.PrivateKey
+		appendBadSignature bool
+		wantRecovered      []common.Address
+		wantFailuresLen    int
+		wantFailureIndex   int // only checked when wantFailuresLen > 0
+	}{
+		{
+			name:            "success: all signatures recoverable",
+			signerKeys:      []*ecdsa.PrivateKey{key1, key2},
+			wantRecovered:   []common.Address{addr1, addr2},
+			wantFailuresLen: 0,
+		},
+		{
+			name:               "success: some signatures unrecoverable",
+			signerKeys:         []*ecdsa.PrivateKey{key1},
+			appendBadSignature: true,
+			wantRecovered:      []common.Address{addr1},
+			wantFailuresLen:    1,
+			wantFailureIndex:   1,
+		},
+		{
+			name:            "success: no signatures",
+			wantRecovered:   []common.Address{},
+			wantFailuresLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			proposal := newSignedProposal(t, tt.signerKeys)
+			if tt.appendBadSignature {
+				proposal.Signatures = append(proposal.Signatures, types.Signature{R: common.Hash{}, S: common.Hash{}, V: 0})
+			}
+
+			recovered, failures, err := proposal.RecoverSigningAddresses()
+
+			require.NoError(t, err)
+			assert.Len(t, failures, tt.wantFailuresLen)
+			if tt.wantFailuresLen > 0 {
+				assert.Equal(t, tt.wantFailureIndex, failures[0].Index)
+			}
+			assert.ElementsMatch(t, tt.wantRecovered, recovered)
+		})
+	}
+}
+
+func TestProposal_AddressesFromSignaturesStrict(t *testing.T) {
+	t.Parallel()
+
+	key1, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	key2, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	addr1 := crypto.PubkeyToAddress(key1.PublicKey)
+	addr2 := crypto.PubkeyToAddress(key2.PublicKey)
+
+	tests := []struct {
+		name               string
+		signerKeys         []*ecdsa.PrivateKey
+		appendBadSignature bool
+		wantErr            bool
+		wantSigErrIndex    int
+		want               []common.Address
+	}{
+		{
+			name:       "success: all signatures recoverable",
+			signerKeys: []*ecdsa.PrivateKey{key1, key2},
+			want:       []common.Address{addr1, addr2},
+		},
+		{
+			name:               "error: unrecoverable signature returns InvalidSignatureAtIndexError",
+			signerKeys:         []*ecdsa.PrivateKey{key1},
+			appendBadSignature: true,
+			wantErr:            true,
+			wantSigErrIndex:    1,
+		},
+		{
+			name: "success: no signatures returns empty slice",
+			want: []common.Address{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			proposal := newSignedProposal(t, tt.signerKeys)
+			if tt.appendBadSignature {
+				proposal.Signatures = append(proposal.Signatures, types.Signature{R: common.Hash{}, S: common.Hash{}, V: 0})
+			}
+
+			recovered, err := proposal.RecoverSigningAddressesStrict()
+
+			if tt.wantErr {
+				require.Nil(t, recovered)
+				var sigErr *InvalidSignatureAtIndexError
+				require.ErrorAs(t, err, &sigErr)
+				assert.Equal(t, tt.wantSigErrIndex, sigErr.Index)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, recovered)
 		})
 	}
 }

--- a/signable.go
+++ b/signable.go
@@ -7,8 +7,6 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/smartcontractkit/mcms/internal/core/merkle"
 	"github.com/smartcontractkit/mcms/sdk"
 	"github.com/smartcontractkit/mcms/types"
@@ -161,19 +159,9 @@ func (s *Signable) CheckQuorum(ctx context.Context, chain types.ChainSelector) (
 		return false, errors.New("inspector not found for chain " + strconv.FormatUint(uint64(chain), 10))
 	}
 
-	hash, err := s.proposal.SigningHash() //nolint:contextcheck //OPT-400
+	recoveredSigners, err := s.proposal.RecoverSigningAddressesStrict() //nolint:contextcheck //OPT-400
 	if err != nil {
 		return false, err
-	}
-
-	recoveredSigners := make([]common.Address, len(s.proposal.Signatures))
-	for i, sig := range s.proposal.Signatures {
-		recoveredAddr, rerr := sig.Recover(hash)
-		if rerr != nil {
-			return false, NewInvalidSignatureAtIndexError(i, sig, common.Address{}, rerr)
-		}
-
-		recoveredSigners[i] = recoveredAddr
 	}
 
 	configuration, err := inspector.GetConfig(ctx, s.proposal.ChainMetadata[chain].MCMAddress)

--- a/types/config.go
+++ b/types/config.go
@@ -25,7 +25,11 @@ type Config struct {
 	GroupSigners []Config `json:"groupSigners"`
 }
 
-// AllSigners returns a deduplicated list of all individual signers recursively.
+// AllSigners returns every distinct address that appears as a direct signer anywhere in this
+// config tree, including nested group signers. Each address appears at most once, regardless of
+// how many times it is listed across branches (use this when you need a unique roster).
+//
+// Contrast with [Config.GetAllSigners], which preserves duplicates from the nested structure.
 func (c *Config) AllSigners() []common.Address {
 	seen := make(map[common.Address]struct{})
 	var signers []common.Address
@@ -121,7 +125,14 @@ func (c *Config) Equals(other *Config) bool {
 	return true
 }
 
-// GetAllSigners returns all signers in the config and all group signers.
+// GetAllSigners returns a flat slice of this node's direct [Config.Signers] followed by the
+// recursive result for each [Config.GroupSigners] entry, in tree order. The same address may
+// appear multiple times if it occurs in more than one branch or is repeated in the JSON/config
+// data (use this when validating membership against a recovered signer list, matching how the
+// tree is laid out).
+//
+// Contrast with [Config.AllSigners], which returns the same logical set of addresses but
+// deduplicated.
 func (c *Config) GetAllSigners() []common.Address {
 	signers := make([]common.Address, 0)
 	signers = append(signers, c.Signers...)
@@ -133,7 +144,14 @@ func (c *Config) GetAllSigners() []common.Address {
 	return signers
 }
 
-// CanSetRoot checks if the recovered signers have reached consensus to set the root.
+// CanSetRoot reports whether recovered signatures satisfy quorum for this config **and**
+// whether every recovered address is a registered signer somewhere in the tree.
+//
+// It is the strict variant for root updates: [Config.GetAllSigners] defines “registered”. If
+// any recovered signer is absent from that flattened list, it returns (false, error) because the
+// on-chain contract rejects roots that include unknown signers.
+//
+// For the same consensus logic without that membership check, use [Config.QuorumMet].
 func (c *Config) CanSetRoot(recoveredSigners []common.Address) (bool, error) {
 	allSigners := c.GetAllSigners()
 	for _, recoveredSigner := range recoveredSigners {
@@ -146,15 +164,24 @@ func (c *Config) CanSetRoot(recoveredSigners []common.Address) (bool, error) {
 	return c.isGroupAtConsensus(recoveredSigners), nil
 }
 
+// QuorumMet returns true if the configured quorum is met by counting, at each level, how many
+// direct signers from [Config.Signers] appear in recoveredSigners and how many nested
+// [Config.GroupSigners] sub-configs already meet their own quorum (recursively). Extra addresses
+// in recoveredSigners that are not configured signers are ignored; they neither satisfy a slot
+// nor cause an error.
+//
+// Use [Config.CanSetRoot] when callers must enforce that every recovered address is registered;
+// use QuorumMet when you only need the threshold check (e.g. analytics or pre-checks).
+func (c *Config) QuorumMet(recoveredSigners []common.Address) bool {
+	return c.isGroupAtConsensus(recoveredSigners)
+}
+
 // isGroupAtConsensus checks if the recovered signers are at consensus for the group.
 func (c *Config) isGroupAtConsensus(recoveredSigners []common.Address) bool {
 	signerApprovalsInGroup := 0
 	for _, signer := range c.Signers {
-		for _, recoveredSigner := range recoveredSigners {
-			if signer == recoveredSigner {
-				signerApprovalsInGroup++
-				break
-			}
+		if slices.Contains(recoveredSigners, signer) {
+			signerApprovalsInGroup++
 		}
 	}
 

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -266,6 +266,110 @@ func TestConfig_CanSetRoot(t *testing.T) {
 		wantErr          string
 	}{
 		{
+			name: "success: reach consensus",
+			config: Config{
+				Quorum:  2,
+				Signers: []common.Address{signer1, signer2},
+			},
+			recoveredSigners: []common.Address{signer1, signer2},
+			want:             true,
+		},
+		{
+			name: "failure: does not reach consensus",
+			config: Config{
+				Quorum:  2,
+				Signers: []common.Address{signer1, signer2},
+			},
+			recoveredSigners: []common.Address{signer1},
+			want:             false,
+		},
+		{
+			name: "failure: invalid recovered signer",
+			config: Config{
+				Quorum:  1,
+				Signers: []common.Address{signer1},
+			},
+			recoveredSigners: []common.Address{signer4},
+			want:             false,
+			wantErr:          "recovered signer 0x0000000000000000000000000000000000000004 is not a valid signer in the MCMS proposal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.config.CanSetRoot(tt.recoveredSigners)
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestConfig_QuorumMet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		config           Config
+		recoveredSigners []common.Address
+		want             bool
+	}{
+		{
+			name: "success: reach consensus",
+			config: Config{
+				Quorum:  2,
+				Signers: []common.Address{signer1, signer2},
+			},
+			recoveredSigners: []common.Address{signer1, signer2},
+			want:             true,
+		},
+		{
+			name: "success: reach consensus with invalid recovered signers",
+			config: Config{
+				Quorum:  1,
+				Signers: []common.Address{signer1, signer2, signer4},
+			},
+			recoveredSigners: []common.Address{signer1, signer2, signer4},
+			want:             true,
+		},
+		{
+			name: "failure: does not reach consensus",
+			config: Config{
+				Quorum:  2,
+				Signers: []common.Address{signer1, signer2},
+			},
+			recoveredSigners: []common.Address{signer1},
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.config.QuorumMet(tt.recoveredSigners)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestConfig_isGroupAtConsensus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		config           Config
+		recoveredSigners []common.Address
+		want             bool
+	}{
+		{
 			name: "success: single level signers reach consensus",
 			config: Config{
 				Quorum:  2,
@@ -319,30 +423,13 @@ func TestConfig_CanSetRoot(t *testing.T) {
 			recoveredSigners: []common.Address{signer1, signer2, signer3},
 			want:             false,
 		},
-		{
-			name: "failure: invalid recovered signer",
-			config: Config{
-				Quorum:  1,
-				Signers: []common.Address{signer1},
-			},
-			recoveredSigners: []common.Address{signer4},
-			want:             false,
-			wantErr:          "recovered signer 0x0000000000000000000000000000000000000004 is not a valid signer in the MCMS proposal",
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := tt.config.CanSetRoot(tt.recoveredSigners)
-
-			if tt.wantErr != "" {
-				require.EqualError(t, err, tt.wantErr)
-			} else {
-				require.NoError(t, err)
-			}
-
+			got := tt.config.isGroupAtConsensus(tt.recoveredSigners)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
Expose RecoverSigningAddresses and RecoverSigningAddressesStrict on Proposal, plus a package-level RecoverSigningAddresses and SignatureRecoveryFailure for per-signature outcomes. Signable now uses the strict recovery path instead of duplicating the recovery loop.

Document and contrast Config.AllSigners vs GetAllSigners and CanSetRoot vs QuorumMet; simplify isGroupAtConsensus with slices.Contains. Extend config tests for CanSetRoot, QuorumMet, and isGroupAtConsensus.

Also copy chain metadata with maps.Copy, ignore .DS_Store, rename a chain-metadata test for consistency, and add a patch changeset.