### PR TITLE
chore: enforce conventional commits in PR titles

### DIFF
--- a/.github/workflows/pull-request-conventional.yml
+++ b/.github/workflows/pull-request-conventional.yml
@@ -1,0 +1,23 @@
+# Ensures that the PR follows the conventional commits specification
+name: pull-request-conventional
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened, edited ]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  lint-pr-title:
+    name: Lint PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 - [Contributing](#contributing)
   - [Team Overview](#team-overview)
   - [How to Contribute](#how-to-contribute)
+  - [Conventional Commits](#conventional-commits)
   - [Changesets](#changesets)
 
 <!-- TOC -->
@@ -18,9 +19,29 @@ The Operations Platform Tooling ([@smartcontractkit/op-tooling](https://github.c
 1. Open a branch from `main` and give it a descriptive name.
 2. Make changes on your branch.
 3. When you are ready to submit your changes, [create a changeset](#changesets) with `pnpm changeset` and commit the changeset file.
-4. Push your branch and open a PR against `main`.
+4. Push your branch and open a PR against `main`. You must follow the [Conventional Commits](#conventional-commits) format for the PR title.
 5. Ensure your PR passes all CI checks.
 6. Request a review from the OP Tooling team ([@smartcontractkit/op-tooling](https://github.com/orgs/smartcontractkit/teams/op-tooling)).
+
+## Conventional Commits
+
+PR titles must follow the Conventional Commits format:
+
+```text
+<type>: <description>
+```
+
+Release Please uses the merged PR titles on `main` to decide whether to create a release and which semantic version bump to apply:
+
+- `feat: add support for new deployment workflow` creates a minor release.
+- `fix: handle missing workflow artifacts` creates a patch release.
+- `perf: reduce datastore lookup latency` creates a patch release.
+- `feat!: remove deprecated workflow input` creates a major release.
+- `docs: update release instructions`, `test: add workflow deploy coverage`, `ci: update pull request checks`, `chore: update dependencies`, `build: update go version`, `style: format generated code`, and `refactor: simplify deploy input handling` are allowed but usually do not create a release by themselves.
+
+Use `!` after the type, or include `BREAKING CHANGE:` in the commit body, when the change is incompatible with existing users.
+
+For details on how Release Please uses Conventional Commits and semantic versioning, see [RELEASE.md](./RELEASE.md).
 
 ## Changesets
 


### PR DESCRIPTION
Adds a CI check top ensure that PR titles adhere to conventional commits