### PR TITLE
ci: update GHAs

### DIFF
--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -1,10 +1,14 @@
 name: Validate Go Mod Files
+
+on:
+  merge_group:
+  pull_request:
+
 permissions:
   contents: read
 
-on:
-  pull_request:
-  merge_group:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   go-mod-validation:
@@ -12,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate go.mod
-        uses: smartcontractkit/.github/apps/go-mod-validator@4864172d998c12cefa9c2552b36d6e9842261816 # go-mod-validator@1.3.0
+        uses: smartcontractkit/.github/apps/go-mod-validator@go-mod-validator/v1

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ci-lint:
     name: Lint
@@ -16,7 +19,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@85085f8c650468409773440bc867a7b3642ccc9b # ci-lint-go@4.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v4
         with:
           golangci-lint-version: v2.12.2
           use-go-cache: true
@@ -32,7 +35,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@85085f8c650468409773440bc867a7b3642ccc9b # ci-lint-go@4.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v4
         with:
           golangci-lint-version: v2.12.2
           golangci-lint-args: --build-tags="e2e"
@@ -47,7 +50,7 @@ jobs:
       contents: read
     steps:
       - name: Linting Misc (yaml + sh files)
-        uses: smartcontractkit/.github/actions/ci-lint-misc@9fc306ac63d8997c9ca0da283e56caaf71589f83 # ci-lint-misc@1.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-misc@ci-lint-misc/v1
 
   ci-test:
     name: Tests
@@ -58,7 +61,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test
-        uses: smartcontractkit/.github/actions/ci-test-go@2b1d964024bb001ae9fba4f840019ac86ad1d824 # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1
         with:
           go-test-cmd: go test -v -cover -coverpkg=./... -coverprofile=coverage.txt ./...
           use-go-cache: true
@@ -72,7 +75,7 @@ jobs:
       actions: read
     steps:
       - name: Install Rust
-        uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1.2.2
+        uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
 
       - name: Install Solana
         uses: metaplex-foundation/actions/install-solana@2389940047edc63a5781911f6a53fbdf784748d8 # v1.0.4
@@ -80,7 +83,7 @@ jobs:
           version: 1.18.26
 
       - name: Install Aptos CLI
-        uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
+        uses: aptos-labs/actions/install-aptos-cli@528ef7ad9427a8c0720ea3eea790a9190d6e377d # v0.1
         with:
           CLI_VERSION: 7.10.0
 
@@ -117,7 +120,7 @@ jobs:
           ./e2e/tests/solana/compile-mcm-contracts.sh
 
       - name: Run e2e tests
-        uses: smartcontractkit/.github/actions/ci-test-go@2b1d964024bb001ae9fba4f840019ac86ad1d824 # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1
         with:
           checkout-repo: false
           use-go-cache: true
@@ -161,7 +164,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Scanning with Sonarqube
-        uses: smartcontractkit/.github/actions/ci-sonarqube-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-sonarqube-go@0.3.1
+        uses: smartcontractkit/.github/actions/ci-sonarqube-go@ci-sonarqube-go/0.6.0
         with:
           # sonarqube inputs
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ci-lint:
     name: Lint
@@ -15,7 +18,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@85085f8c650468409773440bc867a7b3642ccc9b # ci-lint-go@4.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v4
         with:
           golangci-lint-version: v2.12.2
           use-go-cache: true
@@ -31,7 +34,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@85085f8c650468409773440bc867a7b3642ccc9b # ci-lint-go@4.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v4
         with:
           golangci-lint-version: v2.12.2
           golangci-lint-args: --build-tags="e2e"
@@ -46,7 +49,7 @@ jobs:
       contents: read
     steps:
       - name: Linting Misc (yaml + sh files)
-        uses: smartcontractkit/.github/actions/ci-lint-misc@9fc306ac63d8997c9ca0da283e56caaf71589f83 # ci-lint-misc@1.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-misc@ci-lint-misc/v1
 
   ci-test:
     runs-on: ubuntu-latest
@@ -56,7 +59,7 @@ jobs:
       actions: read
     steps:
       - name: ci-test
-        uses: smartcontractkit/.github/actions/ci-test-go@2b1d964024bb001ae9fba4f840019ac86ad1d824 # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1
         with:
           go-test-cmd: go test -coverprofile=coverage.txt $(go list ./...)
           use-go-cache: true
@@ -70,7 +73,7 @@ jobs:
       actions: read
     steps:
       - name: Install Rust
-        uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1.2.2
+        uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1.3.0
 
       - name: Install Solana
         uses: metaplex-foundation/actions/install-solana@2389940047edc63a5781911f6a53fbdf784748d8 # v1.0.4
@@ -78,7 +81,7 @@ jobs:
           version: 1.18.26
 
       - name: Install Aptos CLI
-        uses: aptos-labs/actions/install-aptos-cli@ce57287eb852b9819c1d74fecc3be187677559fd # v0.1
+        uses: aptos-labs/actions/install-aptos-cli@528ef7ad9427a8c0720ea3eea790a9190d6e377d # v0.1
         with:
           CLI_VERSION: 7.10.0
 
@@ -115,7 +118,7 @@ jobs:
           ./e2e/tests/solana/compile-mcm-contracts.sh
 
       - name: Run e2e tests
-        uses: smartcontractkit/.github/actions/ci-test-go@2b1d964024bb001ae9fba4f840019ac86ad1d824 # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1
         with:
           checkout-repo: false
           use-go-cache: true
@@ -177,7 +180,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Scanning with Sonarqube
-        uses: smartcontractkit/.github/actions/ci-sonarqube-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-sonarqube-go@0.3.1
+        uses: smartcontractkit/.github/actions/ci-sonarqube-go@ci-sonarqube-go/v0.6.0
         with:
           # sonarqube inputs
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/push-tag-release.yml
+++ b/.github/workflows/push-tag-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ci-lint:
     runs-on: ubuntu-latest
@@ -14,7 +17,7 @@ jobs:
       actions: read
     steps:
       - name: ci-lint
-        uses: smartcontractkit/.github/actions/ci-lint-go@85085f8c650468409773440bc867a7b3642ccc9b # ci-lint-go@4.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v4
         with:
           golangci-lint-version: v2.12.2
           golangci-lint-config: .golangci.yml
@@ -28,7 +31,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@85085f8c650468409773440bc867a7b3642ccc9b # ci-lint-go@4.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v4
         with:
           golangci-lint-version: v2.12.2
           golangci-lint-args: --build-tags="e2e"
@@ -42,7 +45,7 @@ jobs:
       actions: read
     steps:
       - name: ci-test
-        uses: smartcontractkit/.github/actions/ci-test-go@2b1d964024bb001ae9fba4f840019ac86ad1d824 # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1
   # cicd-publish-release:
   #   runs-on: ubuntu-latest
   #   permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 0 * * *" # Will be triggered every day at midnight UTC
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v10.1.1
+      - uses: actions/stale@v10.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           exempt-all-pr-assignees: true


### PR DESCRIPTION
This updates GHA to be compatible with the latest with node24, ensuring
we are using the latest version of the actions.

This omits the documentation and nix related actions for a future PR.