### PR TITLE
ci: update release workflows

### DIFF
--- a/.github/workflows/pull-request-conventional.yml
+++ b/.github/workflows/pull-request-conventional.yml
@@ -1,10 +1,13 @@
-# Ensures that the PR follows the conventional commits specification
+# Ensures that the PR title follows the conventional commits specification.
 name: pull-request-conventional
 
 on:
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, reopened, edited ]
+  merge_group:
+    types: [ checks_requested ]
+    branches: [ main ]
 
 permissions:
   contents: read
@@ -18,6 +21,14 @@ jobs:
     name: Lint PR title (Conventional Commits)
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      # Semantic PR action expects pull_request context; titles are enforced on PR events prior to merge queue.
+      - name: Semantic PR Linter
+        if: github.event_name != 'merge_group'
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auto-pass the step if it's running inside the Merge Queue
+      - name: Bypass for Merge Queue
+        if: github.event_name == 'merge_group'
+        run: echo "PR title already verified prior to entering the merge queue. Bypassing."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,9 @@
-name: release-please
+# Automated versioning and GitHub releases (Release Please).
+#
+# Runs on every push to main. Release Please reads conventional commits on main,
+# opens or updates a release PR (version bump + changelog), and when that PR is
+# merged—creates a GitHub release and a v* git tag.
+name: release
 
 on:
   push:
@@ -22,9 +27,9 @@ jobs:
         id: issue-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_MCMS_CI_CHANGESET_TOKEN_ISSUER_ROLE_ARN }}
-          aws-lambda-url: ${{ secrets.GATI_LAMBDA_DEPLOYMENT_AUTOMATION_URL }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.GATI_AWS_ROLE_MCMS }}
+          aws-lambda-url: ${{ secrets.GATI_LAMBDA_OPERATIONS_PLATFORM_URL }}
+          aws-region: ${{ secrets.GATI_AWS_REGION }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:


### PR DESCRIPTION
Updates to the release workflows to:

- Use the Operations Platform GATI secrets for the release workflows.
- Updates pull request conventional workflow to bypass on the merge queue.