### PR TITLE
ci: update actions cache and checkout versions to latest

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -97,7 +97,7 @@ jobs:
           sui --version
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Compute Solana programs cache key
         id: solana-programs-cache-key
@@ -107,7 +107,7 @@ jobs:
           echo "key=${key}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Solana programs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-solana-programs
         with:
           path: ./e2e/artifacts/solana

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -95,7 +95,7 @@ jobs:
           sui --version
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Compute Solana programs cache key
         id: solana-programs-cache-key
@@ -105,7 +105,7 @@ jobs:
           echo "key=${key}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Solana programs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-solana-programs
         with:
           path: ./e2e/artifacts/solana


### PR DESCRIPTION
This updates `actions/cache` and `actions/checkout` to the latest versions, ensuring that they support running on node 24.