### PR TITLE
ci: block chainlink-deployments-framework imports via depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - contextcheck
     - copyloopvar
     - decorder
+    - depguard
     - dogsled
     - dupword
     - durationcheck
@@ -40,6 +41,15 @@ linters:
     - wastedassign
     - whitespace
   settings:
+    depguard:
+      rules:
+        no-chainlink-deployments-framework:
+          list-mode: lax
+          files:
+            - $all
+          deny:
+            - pkg: github.com/smartcontractkit/chainlink-deployments-framework
+              desc: must not import chainlink-deployments-framework; it would introduce a circular dependency with mcms
     goconst:
       min-len: 5
     gomoddirectives:


### PR DESCRIPTION
## Summary

Enables the `depguard` linter in golangci-lint and denies imports of `github.com/smartcontractkit/chainlink-deployments-framework` (including subpackages). This keeps mcms from depending on chainlink-deployments-framework, which would introduce a circular dependency.

## Why

mcms must not import chainlink-deployments-framework because that module already depends on mcms, so adding the import would create a cycle in the dependency graph.