### PR TITLE
feat(sdk/stellar): add Inspector and Executor

### DIFF
--- a/sdk/stellar/executor.go
+++ b/sdk/stellar/executor.go
@@ -1,0 +1,157 @@
+package stellar
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/ethereum/go-ethereum/common"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-stellar/bindings"
+	mcmsbindings "github.com/smartcontractkit/chainlink-stellar/bindings/contracts/mcms"
+)
+
+var _ sdk.Executor = (*Executor)(nil)
+
+// Executor implements sdk.Executor for the Stellar (Soroban) MCMS contract.
+// It wraps an Encoder, Inspector, and the Soroban invoker to execute
+// operations and set Merkle roots on-chain.
+type Executor struct {
+	*Encoder
+	*Inspector
+	invoker bindings.Invoker
+}
+
+// NewExecutor creates a new Executor for Stellar chains.
+func NewExecutor(encoder *Encoder, inspector *Inspector) (*Executor, error) {
+	return &Executor{
+		Encoder:   encoder,
+		Inspector: inspector,
+		invoker:   inspector.invoker,
+	}, nil
+}
+
+// ExecuteOperation executes an MCMS operation (one transaction) on the Stellar chain.
+func (e *Executor) ExecuteOperation(
+	ctx context.Context,
+	metadata types.ChainMetadata,
+	nonce uint32,
+	proof []common.Hash,
+	op types.Operation,
+) (types.TransactionResult, error) {
+	chainNetworkID, err := chainNetworkID(e.ChainSelector)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("execute: chain network id: %w", err)
+	}
+
+	// Build the StellarOp from the SDK types.Operation.
+	_, err = parseContractID(metadata.MCMAddress)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("execute: parse mcm address: %w", err)
+	}
+	toContractID, err := parseContractID(op.Transaction.To)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("execute: parse target address: %w", err)
+	}
+	payload, err := DecodeSorobanInvokePayload(op.Transaction.Data)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("execute: decode invoke payload: %w", err)
+	}
+	stellarOp := mcmsbindings.StellarOp{
+		NetworkId:       chainNetworkID,
+		Multisig:        metadata.MCMAddress,
+		Nonce:           uint64(nonce),
+		Target:          op.Transaction.To,
+		Function:        payload.Function,
+		ArgsXdr:         payload.ArgsXDR,
+		EncodingVersion: encodingVersion,
+	}
+	_ = toContractID // validates the target is a contract address
+
+	// Convert proof hashes.
+	proofInner := make([][32]byte, len(proof))
+	for i, p := range proof {
+		proofInner[i] = p
+	}
+	merkleProof := mcmsbindings.MerkleProof{Inner: proofInner}
+
+	client := mcmsbindings.NewMcmsClient(e.invoker, metadata.MCMAddress)
+	if err := client.Execute(ctx, stellarOp, merkleProof); err != nil {
+		return types.TransactionResult{}, fmt.Errorf("stellar mcms execute: %w", err)
+	}
+
+	return types.NewTransactionResult("", nil, chainsel.FamilyStellar), nil
+}
+
+// SetRoot sets a new Merkle root in the MCMS contract on the Stellar chain.
+func (e *Executor) SetRoot(
+	ctx context.Context,
+	metadata types.ChainMetadata,
+	proof []common.Hash,
+	root [32]byte,
+	validUntil uint32,
+	sortedSignatures []types.Signature,
+) (types.TransactionResult, error) {
+	// Avoid re-submitting the same root.
+	currentRoot, currentValidUntil, err := e.Inspector.GetRoot(ctx, metadata.MCMAddress)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("set_root: get current root: %w", err)
+	}
+	if currentRoot == root && currentValidUntil == validUntil {
+		return types.TransactionResult{}, fmt.Errorf("stellar set_root: root already set (0x%x)", root)
+	}
+
+	if len(sortedSignatures) > math.MaxUint8 {
+		return types.TransactionResult{}, fmt.Errorf("too many signatures (%d > %d)", len(sortedSignatures), math.MaxUint8)
+	}
+
+	chainNetworkID, err := chainNetworkID(e.ChainSelector)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("set_root: chain network id: %w", err)
+	}
+
+	// Build StellarRootMetadata.
+	_, err = parseContractID(metadata.MCMAddress)
+	if err != nil {
+		return types.TransactionResult{}, fmt.Errorf("set_root: parse mcm address: %w", err)
+	}
+	stellarMeta := mcmsbindings.StellarRootMetadata{
+		NetworkId:            chainNetworkID,
+		Multisig:             metadata.MCMAddress,
+		PreOpCount:           metadata.StartingOpCount,
+		PostOpCount:          metadata.StartingOpCount + e.TxCount,
+		OverridePreviousRoot: e.OverridePreviousRoot,
+		ConfigVersion:        1,
+		EncodingVersion:      encodingVersion,
+	}
+
+	// Convert proof.
+	proofInner := make([][32]byte, len(proof))
+	for i, p := range proof {
+		proofInner[i] = p
+	}
+	metaProof := mcmsbindings.MerkleProof{Inner: proofInner}
+
+	// Convert signatures from mcms/types.Signature to binding Signature.
+	sigVec := mcmsbindings.SignatureVec{
+		Inner: make([]mcmsbindings.Signature, len(sortedSignatures)),
+	}
+	for i, sig := range sortedSignatures {
+		sigVec.Inner[i] = mcmsbindings.Signature{
+			R: sig.R,
+			S: sig.S,
+			V: uint32(sig.V), // uint8 → uint32 is safe
+		}
+	}
+
+	client := mcmsbindings.NewMcmsClient(e.invoker, metadata.MCMAddress)
+	if err := client.SetRoot(ctx, root, validUntil, stellarMeta, metaProof, sigVec); err != nil {
+		return types.TransactionResult{}, fmt.Errorf("stellar mcms set_root: %w", err)
+	}
+
+	return types.NewTransactionResult("", nil, chainsel.FamilyStellar), nil
+}

--- a/sdk/stellar/executor.go
+++ b/sdk/stellar/executor.go
@@ -97,7 +97,7 @@ func (e *Executor) SetRoot(
 	sortedSignatures []types.Signature,
 ) (types.TransactionResult, error) {
 	// Avoid re-submitting the same root.
-	currentRoot, currentValidUntil, err := e.Inspector.GetRoot(ctx, metadata.MCMAddress)
+	currentRoot, currentValidUntil, err := e.GetRoot(ctx, metadata.MCMAddress)
 	if err != nil {
 		return types.TransactionResult{}, fmt.Errorf("set_root: get current root: %w", err)
 	}

--- a/sdk/stellar/executor_test.go
+++ b/sdk/stellar/executor_test.go
@@ -1,0 +1,109 @@
+package stellar
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-stellar/bindings/scval"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/types"
+)
+
+func TestExecutor_ExecuteOperation(t *testing.T) {
+	t.Parallel()
+
+	const mcmAddr = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
+	const target = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
+
+	invoker := newMockInvoker()
+	inspector := NewInspectorFromInvoker(invoker)
+	encoder := NewEncoder(types.ChainSelector(4894814558906953166), 1, false)
+
+	executor, err := NewExecutor(encoder, inspector)
+	require.NoError(t, err)
+
+	op, err := NewTransaction(target, "some_func", nil, "TestContract", nil)
+	require.NoError(t, err)
+
+	metadata := types.ChainMetadata{
+		MCMAddress: mcmAddr,
+	}
+
+	res, err := executor.ExecuteOperation(context.Background(), metadata, 1, []common.Hash{}, types.Operation{Transaction: op})
+	require.NoError(t, err)
+	require.Equal(t, "stellar", res.ChainFamily)
+
+	require.Len(t, invoker.calls, 1)
+	require.Equal(t, "execute", invoker.calls[0].FunctionName)
+	require.Equal(t, mcmAddr, invoker.calls[0].ContractID)
+}
+
+func TestExecutor_SetRoot(t *testing.T) {
+	t.Parallel()
+
+	const mcmAddr = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
+
+	invoker := newMockInvoker()
+
+	// Stub get_root to return a different root so SetRoot doesn't exit early
+	var differentRoot [32]byte
+	differentRoot[0] = 1
+	rootTuple := xdr.ScVec{scval.Bytes32ToScVal(differentRoot), scval.Uint32ToScVal(0)}
+	rootTuplePtr := &rootTuple
+	rootValue := xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &rootTuplePtr}
+	invoker.stub("get_root", &rootValue, nil)
+
+	inspector := NewInspectorFromInvoker(invoker)
+	encoder := NewEncoder(types.ChainSelector(4894814558906953166), 1, false)
+
+	executor, err := NewExecutor(encoder, inspector)
+	require.NoError(t, err)
+
+	metadata := types.ChainMetadata{
+		MCMAddress: mcmAddr,
+	}
+
+	var rootToSet [32]byte
+	rootToSet[0] = 2
+
+	res, err := executor.SetRoot(context.Background(), metadata, []common.Hash{}, rootToSet, 100, []types.Signature{})
+	require.NoError(t, err)
+	require.Equal(t, "stellar", res.ChainFamily)
+
+	// Calls should include get_root simulation and set_root execution
+	require.Len(t, invoker.calls, 2)
+	require.Equal(t, "get_root", invoker.calls[0].FunctionName)
+	require.Equal(t, "set_root", invoker.calls[1].FunctionName)
+}
+
+func TestExecutor_SetRoot_AlreadySet(t *testing.T) {
+	t.Parallel()
+
+	const mcmAddr = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
+
+	invoker := newMockInvoker()
+
+	// Stub get_root to return the same root and validUntil
+	var root [32]byte
+	root[0] = 5
+	rootTuple := xdr.ScVec{scval.Bytes32ToScVal(root), scval.Uint32ToScVal(100)}
+	rootTuplePtr := &rootTuple
+	rootValue := xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &rootTuplePtr}
+	invoker.stub("get_root", &rootValue, nil)
+
+	inspector := NewInspectorFromInvoker(invoker)
+	encoder := NewEncoder(types.ChainSelector(4894814558906953166), 1, false)
+
+	executor, err := NewExecutor(encoder, inspector)
+	require.NoError(t, err)
+
+	metadata := types.ChainMetadata{
+		MCMAddress: mcmAddr,
+	}
+
+	_, err = executor.SetRoot(context.Background(), metadata, []common.Hash{}, root, 100, []types.Signature{})
+	require.ErrorContains(t, err, "root already set")
+}

--- a/sdk/stellar/executor_test.go
+++ b/sdk/stellar/executor_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink-stellar/bindings/scval"
 	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/sdk/stellar/mocks"
 
 	"github.com/smartcontractkit/mcms/types"
 )
@@ -18,27 +21,57 @@ func TestExecutor_ExecuteOperation(t *testing.T) {
 	const mcmAddr = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
 	const target = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
 
-	invoker := newMockInvoker()
+	invoker := mocks.NewInvoker(t)
+
+	invoker.
+		On(
+			"InvokeContract",
+			mock.Anything,
+			mcmAddr,
+			"execute",
+			mock.Anything,
+		).
+		Return(nil, nil).
+		Once()
+
 	inspector := NewInspectorFromInvoker(invoker)
 	encoder := NewEncoder(types.ChainSelector(4894814558906953166), 1, false)
 
 	executor, err := NewExecutor(encoder, inspector)
 	require.NoError(t, err)
 
-	op, err := NewTransaction(target, "some_func", nil, "TestContract", nil)
+	op, err := NewTransaction(
+		target,
+		"some_func",
+		nil,
+		"TestContract",
+		nil,
+	)
 	require.NoError(t, err)
 
 	metadata := types.ChainMetadata{
 		MCMAddress: mcmAddr,
 	}
 
-	res, err := executor.ExecuteOperation(context.Background(), metadata, 1, []common.Hash{}, types.Operation{Transaction: op})
+	res, err := executor.ExecuteOperation(
+		context.Background(),
+		metadata,
+		1,
+		[]common.Hash{},
+		types.Operation{Transaction: op},
+	)
 	require.NoError(t, err)
 	require.Equal(t, "stellar", res.ChainFamily)
 
-	require.Len(t, invoker.calls, 1)
-	require.Equal(t, "execute", invoker.calls[0].FunctionName)
-	require.Equal(t, mcmAddr, invoker.calls[0].ContractID)
+	invoker.AssertNumberOfCalls(t, "InvokeContract", 1)
+	invoker.AssertCalled(
+		t,
+		"InvokeContract",
+		mock.Anything,
+		mcmAddr,
+		"execute",
+		mock.Anything,
+	)
 }
 
 func TestExecutor_SetRoot(t *testing.T) {
@@ -46,15 +79,43 @@ func TestExecutor_SetRoot(t *testing.T) {
 
 	const mcmAddr = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
 
-	invoker := newMockInvoker()
+	invoker := mocks.NewInvoker(t)
 
-	// Stub get_root to return a different root so SetRoot doesn't exit early
+	// Return a different root so SetRoot doesn't exit early.
 	var differentRoot [32]byte
 	differentRoot[0] = 1
-	rootTuple := xdr.ScVec{scval.Bytes32ToScVal(differentRoot), scval.Uint32ToScVal(0)}
+
+	rootTuple := xdr.ScVec{
+		scval.Bytes32ToScVal(differentRoot),
+		scval.Uint32ToScVal(0),
+	}
 	rootTuplePtr := &rootTuple
-	rootValue := xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &rootTuplePtr}
-	invoker.stub("get_root", &rootValue, nil)
+	rootValue := xdr.ScVal{
+		Type: xdr.ScValTypeScvVec,
+		Vec:  &rootTuplePtr,
+	}
+
+	invoker.
+		On(
+			"SimulateContract",
+			mock.Anything,
+			mcmAddr,
+			"get_root",
+			mock.Anything,
+		).
+		Return(&rootValue, nil).
+		Once()
+
+	invoker.
+		On(
+			"InvokeContract",
+			mock.Anything,
+			mcmAddr,
+			"set_root",
+			mock.Anything,
+		).
+		Return(nil, nil).
+		Once()
 
 	inspector := NewInspectorFromInvoker(invoker)
 	encoder := NewEncoder(types.ChainSelector(4894814558906953166), 1, false)
@@ -69,14 +130,37 @@ func TestExecutor_SetRoot(t *testing.T) {
 	var rootToSet [32]byte
 	rootToSet[0] = 2
 
-	res, err := executor.SetRoot(context.Background(), metadata, []common.Hash{}, rootToSet, 100, []types.Signature{})
+	res, err := executor.SetRoot(
+		context.Background(),
+		metadata,
+		[]common.Hash{},
+		rootToSet,
+		100,
+		[]types.Signature{},
+	)
 	require.NoError(t, err)
 	require.Equal(t, "stellar", res.ChainFamily)
 
-	// Calls should include get_root simulation and set_root execution
-	require.Len(t, invoker.calls, 2)
-	require.Equal(t, "get_root", invoker.calls[0].FunctionName)
-	require.Equal(t, "set_root", invoker.calls[1].FunctionName)
+	invoker.AssertNumberOfCalls(t, "SimulateContract", 1)
+	invoker.AssertNumberOfCalls(t, "InvokeContract", 1)
+
+	invoker.AssertCalled(
+		t,
+		"SimulateContract",
+		mock.Anything,
+		mcmAddr,
+		"get_root",
+		mock.Anything,
+	)
+
+	invoker.AssertCalled(
+		t,
+		"InvokeContract",
+		mock.Anything,
+		mcmAddr,
+		"set_root",
+		mock.Anything,
+	)
 }
 
 func TestExecutor_SetRoot_AlreadySet(t *testing.T) {
@@ -84,15 +168,32 @@ func TestExecutor_SetRoot_AlreadySet(t *testing.T) {
 
 	const mcmAddr = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
 
-	invoker := newMockInvoker()
+	invoker := mocks.NewInvoker(t)
 
-	// Stub get_root to return the same root and validUntil
+	// Return the same root and validUntil so SetRoot exits early.
 	var root [32]byte
 	root[0] = 5
-	rootTuple := xdr.ScVec{scval.Bytes32ToScVal(root), scval.Uint32ToScVal(100)}
+
+	rootTuple := xdr.ScVec{
+		scval.Bytes32ToScVal(root),
+		scval.Uint32ToScVal(100),
+	}
 	rootTuplePtr := &rootTuple
-	rootValue := xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &rootTuplePtr}
-	invoker.stub("get_root", &rootValue, nil)
+	rootValue := xdr.ScVal{
+		Type: xdr.ScValTypeScvVec,
+		Vec:  &rootTuplePtr,
+	}
+
+	invoker.
+		On(
+			"SimulateContract",
+			mock.Anything,
+			mcmAddr,
+			"get_root",
+			mock.Anything,
+		).
+		Return(&rootValue, nil).
+		Once()
 
 	inspector := NewInspectorFromInvoker(invoker)
 	encoder := NewEncoder(types.ChainSelector(4894814558906953166), 1, false)
@@ -104,6 +205,24 @@ func TestExecutor_SetRoot_AlreadySet(t *testing.T) {
 		MCMAddress: mcmAddr,
 	}
 
-	_, err = executor.SetRoot(context.Background(), metadata, []common.Hash{}, root, 100, []types.Signature{})
+	_, err = executor.SetRoot(
+		context.Background(),
+		metadata,
+		[]common.Hash{},
+		root,
+		100,
+		[]types.Signature{},
+	)
 	require.ErrorContains(t, err, "root already set")
+
+	// We should only read the current root. No transaction should be submitted.
+	invoker.AssertNumberOfCalls(t, "SimulateContract", 1)
+	invoker.AssertNotCalled(
+		t,
+		"InvokeContract",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	)
 }

--- a/sdk/stellar/inspector.go
+++ b/sdk/stellar/inspector.go
@@ -1,0 +1,140 @@
+package stellar
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	stellarrpc "github.com/stellar/go-stellar-sdk/clients/rpcclient"
+
+	"github.com/smartcontractkit/mcms/sdk"
+	"github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-stellar/bindings"
+	mcmsbindings "github.com/smartcontractkit/chainlink-stellar/bindings/contracts/mcms"
+)
+
+var _ sdk.Inspector = (*Inspector)(nil)
+
+// Inspector implements sdk.Inspector for the Stellar (Soroban) MCMS contract.
+// It uses a bindings.Invoker to call the generated McmsClient, which wraps
+// the Soroban RPC for simulation reads.
+type Inspector struct {
+	ConfigTransformer
+	invoker bindings.Invoker
+}
+
+// NewInspector creates a new Inspector backed by the given Soroban invoker.
+// The invoker can be a *deployment.Deployer or any other bindings.Invoker.
+func NewInspector(client *stellarrpc.Client, auth Signer, selector uint64) (*Inspector, error) {
+	invoker, err := NewInvoker(client, auth, selector)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewInspectorFromInvoker(invoker), nil
+}
+
+// NewInspectorWithNetworkPassphrase creates an inspector with an explicit
+// network passphrase supplied by the deployment framework.
+func NewInspectorWithNetworkPassphrase(client *stellarrpc.Client, auth Signer, passphrase string) (*Inspector, error) {
+	invoker, err := NewInvokerWithNetworkPassphrase(client, auth, passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewInspectorFromInvoker(invoker), nil
+}
+
+// NewInspectorFromInvoker creates an inspector for deployment code that
+// already owns a bindings.Invoker.
+func NewInspectorFromInvoker(invoker bindings.Invoker) *Inspector {
+	return &Inspector{
+		ConfigTransformer: ConfigTransformer{},
+		invoker:           invoker,
+	}
+}
+
+// GetConfig reads the current MCMS signer/group config from the chain.
+func (i *Inspector) GetConfig(ctx context.Context, mcmAddr string) (*types.Config, error) {
+	client := mcmsbindings.NewMcmsClient(i.invoker, mcmAddr)
+	cfg, err := client.GetConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("stellar mcms get_config: %w", err)
+	}
+
+	converted, err := i.ToConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("stellar mcms convert config: %w", err)
+	}
+
+	return converted, nil
+}
+
+// GetOpCount reads the current op counter from the MCMS contract.
+func (i *Inspector) GetOpCount(ctx context.Context, mcmAddr string) (uint64, error) {
+	client := mcmsbindings.NewMcmsClient(i.invoker, mcmAddr)
+	count, err := client.GetOpCount(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("stellar mcms get_op_count: %w", err)
+	}
+
+	return count, nil
+}
+
+// GetRoot reads the current Merkle root and validUntil from the MCMS contract.
+func (i *Inspector) GetRoot(ctx context.Context, mcmAddr string) (common.Hash, uint32, error) {
+	client := mcmsbindings.NewMcmsClient(i.invoker, mcmAddr)
+	root, validUntil, err := client.GetRoot(ctx)
+	if err != nil {
+		return common.Hash{}, 0, fmt.Errorf("stellar mcms get_root: %w", err)
+	}
+
+	return root, validUntil, nil
+}
+
+// GetRootMetadata reads the chain metadata from the MCMS contract's root_metadata.
+func (i *Inspector) GetRootMetadata(ctx context.Context, mcmAddr string) (types.ChainMetadata, error) {
+	client := mcmsbindings.NewMcmsClient(i.invoker, mcmAddr)
+	metadata, err := client.GetRootMetadata(ctx)
+	if err != nil {
+		return types.ChainMetadata{}, fmt.Errorf("stellar mcms get_root_metadata: %w", err)
+	}
+
+	return types.ChainMetadata{
+		StartingOpCount: metadata.PreOpCount,
+		MCMAddress:      metadata.Multisig,
+		AdditionalFields: func() json.RawMessage {
+			b, _ := json.Marshal(struct {
+				ConfigVersion   uint64 `json:"configVersion"`
+				EncodingVersion uint32 `json:"encodingVersion"`
+			}{metadata.ConfigVersion, metadata.EncodingVersion})
+
+			return b
+		}(),
+	}, nil
+}
+
+// GetOwner reads the current MCMS owner. A nil owner means the contract has
+// no owner, as defined by the common Ownable implementation.
+func (i *Inspector) GetOwner(ctx context.Context, mcmAddr string) (*string, error) {
+	client := mcmsbindings.NewMcmsClient(i.invoker, mcmAddr)
+	owner, err := client.Owner(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("stellar mcms owner: %w", err)
+	}
+
+	return owner, nil
+}
+
+// GetPendingOwner reads the address that has been proposed as the next owner.
+func (i *Inspector) GetPendingOwner(ctx context.Context, mcmAddr string) (*string, error) {
+	client := mcmsbindings.NewMcmsClient(i.invoker, mcmAddr)
+	pending, err := client.GetPendingOwner(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("stellar mcms get_pending_owner: %w", err)
+	}
+
+	return pending, nil
+}

--- a/sdk/stellar/inspector.go
+++ b/sdk/stellar/inspector.go
@@ -27,7 +27,7 @@ type Inspector struct {
 
 // NewInspector creates a new Inspector backed by the given Soroban invoker.
 // The invoker can be a *deployment.Deployer or any other bindings.Invoker.
-func NewInspector(client *stellarrpc.Client, auth Signer, selector uint64) (*Inspector, error) {
+func NewInspector(client *stellarrpc.Client, auth bindings.Signer, selector uint64) (*Inspector, error) {
 	invoker, err := NewInvoker(client, auth, selector)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func NewInspector(client *stellarrpc.Client, auth Signer, selector uint64) (*Ins
 
 // NewInspectorWithNetworkPassphrase creates an inspector with an explicit
 // network passphrase supplied by the deployment framework.
-func NewInspectorWithNetworkPassphrase(client *stellarrpc.Client, auth Signer, passphrase string) (*Inspector, error) {
+func NewInspectorWithNetworkPassphrase(client *stellarrpc.Client, auth bindings.Signer, passphrase string) (*Inspector, error) {
 	invoker, err := NewInvokerWithNetworkPassphrase(client, auth, passphrase)
 	if err != nil {
 		return nil, err

--- a/sdk/stellar/inspector_test.go
+++ b/sdk/stellar/inspector_test.go
@@ -1,46 +1,29 @@
 package stellar
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink-stellar/bindings/contracts/mcms"
 	"github.com/smartcontractkit/chainlink-stellar/bindings/scval"
-	protocolrpc "github.com/stellar/go-stellar-sdk/protocols/rpc"
 	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/mcms/sdk/stellar/mocks"
 )
-
-type inspectorInvoker struct {
-	values map[string]xdr.ScVal
-}
-
-func (i inspectorInvoker) InvokeContract(context.Context, string, string, []xdr.ScVal) (*xdr.ScVal, error) {
-	return nil, fmt.Errorf("unexpected write")
-}
-
-func (i inspectorInvoker) SimulateContract(_ context.Context, _ string, function string, _ []xdr.ScVal) (*xdr.ScVal, error) {
-	value, ok := i.values[function]
-	if !ok {
-		return nil, fmt.Errorf("unexpected simulation %s", function)
-	}
-	return &value, nil
-}
-
-func (i inspectorInvoker) GetEvents(context.Context, string, uint32, []string) ([]protocolrpc.EventInfo, error) {
-	return nil, nil
-}
 
 func TestInspectorReadsCurrentMCMSState(t *testing.T) {
 	t.Parallel()
+
 	const contractID = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
 
 	var signer [32]byte
 	copy(signer[12:], common.HexToAddress("0x1234").Bytes())
+
 	var quorums [32]byte
 	quorums[0] = 1
+
 	configValue, err := (mcms.Config{
 		Signers:      []mcms.Signer{{Addr: signer, Group: 0, Index: 0}},
 		GroupQuorums: quorums,
@@ -49,9 +32,16 @@ func TestInspectorReadsCurrentMCMSState(t *testing.T) {
 
 	var root [32]byte
 	root[0] = 9
-	rootTuple := xdr.ScVec{scval.Bytes32ToScVal(root), scval.Uint32ToScVal(123)}
+
+	rootTuple := xdr.ScVec{
+		scval.Bytes32ToScVal(root),
+		scval.Uint32ToScVal(123),
+	}
 	rootTuplePtr := &rootTuple
-	rootValue := xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &rootTuplePtr}
+	rootValue := xdr.ScVal{
+		Type: xdr.ScValTypeScvVec,
+		Vec:  &rootTuplePtr,
+	}
 
 	metadataValue, err := (mcms.StellarRootMetadata{
 		ConfigVersion:   4,
@@ -61,21 +51,87 @@ func TestInspectorReadsCurrentMCMSState(t *testing.T) {
 		PostOpCount:     8,
 	}).ToScVal()
 	require.NoError(t, err)
+
 	owner := contractID
 
-	inspector := NewInspectorFromInvoker(inspectorInvoker{values: map[string]xdr.ScVal{
-		"get_config":        configValue,
-		"get_op_count":      scval.Uint64ToScVal(7),
-		"get_root":          rootValue,
-		"get_root_metadata": metadataValue,
-		"owner":             scval.OptionalAddressToScVal(&owner),
-		"get_pending_owner": scval.OptionalAddressToScVal(nil),
-	}})
+	invoker := mocks.NewInvoker(t)
+
+	invoker.
+		On(
+			"SimulateContract",
+			mock.Anything,
+			contractID,
+			"get_config",
+			mock.Anything,
+		).
+		Return(&configValue, nil).
+		Once()
+
+	invoker.
+		On(
+			"SimulateContract",
+			mock.Anything,
+			contractID,
+			"get_op_count",
+			mock.Anything,
+		).
+		Return(new(scval.Uint64ToScVal(7)), nil).
+		Once()
+
+	invoker.
+		On(
+			"SimulateContract",
+			mock.Anything,
+			contractID,
+			"get_root",
+			mock.Anything,
+		).
+		Return(&rootValue, nil).
+		Once()
+
+	invoker.
+		On(
+			"SimulateContract",
+			mock.Anything,
+			contractID,
+			"get_root_metadata",
+			mock.Anything,
+		).
+		Return(&metadataValue, nil).
+		Once()
+
+	invoker.
+		On(
+			"SimulateContract",
+			mock.Anything,
+			contractID,
+			"owner",
+			mock.Anything,
+		).
+		Return(new(scval.OptionalAddressToScVal(&owner)), nil).
+		Once()
+
+	invoker.
+		On(
+			"SimulateContract",
+			mock.Anything,
+			contractID,
+			"get_pending_owner",
+			mock.Anything,
+		).
+		Return(new(scval.OptionalAddressToScVal(nil)), nil).
+		Once()
+
+	inspector := NewInspectorFromInvoker(invoker)
 
 	config, err := inspector.GetConfig(t.Context(), contractID)
 	require.NoError(t, err)
 	require.Equal(t, uint8(1), config.Quorum)
-	require.Equal(t, []common.Address{common.HexToAddress("0x1234")}, config.Signers)
+	require.Equal(
+		t,
+		[]common.Address{common.HexToAddress("0x1234")},
+		config.Signers,
+	)
 
 	opCount, err := inspector.GetOpCount(t.Context(), contractID)
 	require.NoError(t, err)
@@ -90,11 +146,16 @@ func TestInspectorReadsCurrentMCMSState(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(7), metadata.StartingOpCount)
 	require.Equal(t, contractID, metadata.MCMAddress)
-	require.JSONEq(t, `{"configVersion":4,"encodingVersion":1}`, string(metadata.AdditionalFields))
+	require.JSONEq(
+		t,
+		`{"configVersion":4,"encodingVersion":1}`,
+		string(metadata.AdditionalFields),
+	)
 
 	actualOwner, err := inspector.GetOwner(t.Context(), contractID)
 	require.NoError(t, err)
 	require.Equal(t, &owner, actualOwner)
+
 	pendingOwner, err := inspector.GetPendingOwner(t.Context(), contractID)
 	require.NoError(t, err)
 	require.Nil(t, pendingOwner)
@@ -102,19 +163,28 @@ func TestInspectorReadsCurrentMCMSState(t *testing.T) {
 
 func TestToSDKConfigReturnsConversionErrors(t *testing.T) {
 	t.Parallel()
+
 	_, err := toSDKConfig(nil)
 	require.Error(t, err)
 
 	var quorums [32]byte
 	quorums[0] = 1
-	_, err = toSDKConfig(&mcms.Config{GroupQuorums: quorums})
+
+	_, err = toSDKConfig(&mcms.Config{
+		GroupQuorums: quorums,
+	})
 	require.ErrorContains(t, err, "no signers")
 
 	var malformed [32]byte
 	malformed[0] = 1
 	_, err = toSDKConfig(&mcms.Config{
 		GroupQuorums: quorums,
-		Signers:      []mcms.Signer{{Addr: malformed, Group: 0}},
+		Signers: []mcms.Signer{
+			{
+				Addr:  malformed,
+				Group: 0,
+			},
+		},
 	})
 	require.ErrorContains(t, err, "not a padded EVM address")
 }

--- a/sdk/stellar/inspector_test.go
+++ b/sdk/stellar/inspector_test.go
@@ -1,0 +1,120 @@
+package stellar
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-stellar/bindings/contracts/mcms"
+	"github.com/smartcontractkit/chainlink-stellar/bindings/scval"
+	protocolrpc "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/require"
+)
+
+type inspectorInvoker struct {
+	values map[string]xdr.ScVal
+}
+
+func (i inspectorInvoker) InvokeContract(context.Context, string, string, []xdr.ScVal) (*xdr.ScVal, error) {
+	return nil, fmt.Errorf("unexpected write")
+}
+
+func (i inspectorInvoker) SimulateContract(_ context.Context, _ string, function string, _ []xdr.ScVal) (*xdr.ScVal, error) {
+	value, ok := i.values[function]
+	if !ok {
+		return nil, fmt.Errorf("unexpected simulation %s", function)
+	}
+	return &value, nil
+}
+
+func (i inspectorInvoker) GetEvents(context.Context, string, uint32, []string) ([]protocolrpc.EventInfo, error) {
+	return nil, nil
+}
+
+func TestInspectorReadsCurrentMCMSState(t *testing.T) {
+	t.Parallel()
+	const contractID = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
+
+	var signer [32]byte
+	copy(signer[12:], common.HexToAddress("0x1234").Bytes())
+	var quorums [32]byte
+	quorums[0] = 1
+	configValue, err := (mcms.Config{
+		Signers:      []mcms.Signer{{Addr: signer, Group: 0, Index: 0}},
+		GroupQuorums: quorums,
+	}).ToScVal()
+	require.NoError(t, err)
+
+	var root [32]byte
+	root[0] = 9
+	rootTuple := xdr.ScVec{scval.Bytes32ToScVal(root), scval.Uint32ToScVal(123)}
+	rootTuplePtr := &rootTuple
+	rootValue := xdr.ScVal{Type: xdr.ScValTypeScvVec, Vec: &rootTuplePtr}
+
+	metadataValue, err := (mcms.StellarRootMetadata{
+		ConfigVersion:   4,
+		EncodingVersion: 1,
+		Multisig:        contractID,
+		PreOpCount:      7,
+		PostOpCount:     8,
+	}).ToScVal()
+	require.NoError(t, err)
+	owner := contractID
+
+	inspector := NewInspectorFromInvoker(inspectorInvoker{values: map[string]xdr.ScVal{
+		"get_config":        configValue,
+		"get_op_count":      scval.Uint64ToScVal(7),
+		"get_root":          rootValue,
+		"get_root_metadata": metadataValue,
+		"owner":             scval.OptionalAddressToScVal(&owner),
+		"get_pending_owner": scval.OptionalAddressToScVal(nil),
+	}})
+
+	config, err := inspector.GetConfig(t.Context(), contractID)
+	require.NoError(t, err)
+	require.Equal(t, uint8(1), config.Quorum)
+	require.Equal(t, []common.Address{common.HexToAddress("0x1234")}, config.Signers)
+
+	opCount, err := inspector.GetOpCount(t.Context(), contractID)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), opCount)
+
+	actualRoot, validUntil, err := inspector.GetRoot(t.Context(), contractID)
+	require.NoError(t, err)
+	require.Equal(t, common.Hash(root), actualRoot)
+	require.Equal(t, uint32(123), validUntil)
+
+	metadata, err := inspector.GetRootMetadata(t.Context(), contractID)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), metadata.StartingOpCount)
+	require.Equal(t, contractID, metadata.MCMAddress)
+	require.JSONEq(t, `{"configVersion":4,"encodingVersion":1}`, string(metadata.AdditionalFields))
+
+	actualOwner, err := inspector.GetOwner(t.Context(), contractID)
+	require.NoError(t, err)
+	require.Equal(t, &owner, actualOwner)
+	pendingOwner, err := inspector.GetPendingOwner(t.Context(), contractID)
+	require.NoError(t, err)
+	require.Nil(t, pendingOwner)
+}
+
+func TestToSDKConfigReturnsConversionErrors(t *testing.T) {
+	t.Parallel()
+	_, err := toSDKConfig(nil)
+	require.Error(t, err)
+
+	var quorums [32]byte
+	quorums[0] = 1
+	_, err = toSDKConfig(&mcms.Config{GroupQuorums: quorums})
+	require.ErrorContains(t, err, "no signers")
+
+	var malformed [32]byte
+	malformed[0] = 1
+	_, err = toSDKConfig(&mcms.Config{
+		GroupQuorums: quorums,
+		Signers:      []mcms.Signer{{Addr: malformed, Group: 0}},
+	})
+	require.ErrorContains(t, err, "not a padded EVM address")
+}


### PR DESCRIPTION
Inspector implements sdk.Inspector for Stellar MCMS. Uses the invoker to read config, op count, root, owner, and pending owner from the chain. Provides NewInspectorFromInvoker for deployment code that already owns a bindings.Invoker.

Executor implements sdk.Executor for Stellar MCMS. Calls execute and set_root through the generated McmsClient binding.